### PR TITLE
Valid `ECDSAsecp256k1PrivateKey`s are throwing `BadKeyException`

### DIFF
--- a/sdk/main/src/ED25519PrivateKey.cc
+++ b/sdk/main/src/ED25519PrivateKey.cc
@@ -64,6 +64,7 @@ const std::vector<std::byte> SLIP10_SEED = { std::byte('e'), std::byte('d'), std
 
   return key;
 }
+
 } // namespace
 
 //-----
@@ -92,47 +93,42 @@ std::unique_ptr<ED25519PrivateKey> ED25519PrivateKey::generatePrivateKey()
 //-----
 std::unique_ptr<ED25519PrivateKey> ED25519PrivateKey::fromString(std::string_view key)
 {
-  if (key.size() == KEY_SIZE * 2 + DER_ENCODED_PREFIX_HEX.size() || key.size() == KEY_SIZE * 2)
-  {
-    try
-    {
-      return std::make_unique<ED25519PrivateKey>(
-        ED25519PrivateKey(bytesToPKEY(internal::HexConverter::hexToBytes(key))));
-    }
-    catch (const OpenSSLException& openSSLException)
-    {
-      throw BadKeyException(std::string("ED25519PrivateKey cannot be realized from input string: ") +
-                            openSSLException.what());
-    }
-  }
-  else
+  if (key.size() != KEY_SIZE * 2 + DER_ENCODED_PREFIX_HEX.size() && key.size() != KEY_SIZE * 2)
   {
     throw BadKeyException("ED25519PrivateKey cannot be realized from input string: input string size should be " +
                           std::to_string(KEY_SIZE * 2 + DER_ENCODED_PREFIX_HEX.size()) + " or " +
                           std::to_string(KEY_SIZE * 2));
+  }
+
+  try
+  {
+    return std::make_unique<ED25519PrivateKey>(ED25519PrivateKey(bytesToPKEY(internal::HexConverter::hexToBytes(key))));
+  }
+  catch (const OpenSSLException& openSSLException)
+  {
+    throw BadKeyException(std::string("ED25519PrivateKey cannot be realized from input string: ") +
+                          openSSLException.what());
   }
 }
 
 //-----
 std::unique_ptr<ED25519PrivateKey> ED25519PrivateKey::fromBytes(const std::vector<std::byte>& bytes)
 {
-  if (bytes.size() == KEY_SIZE + DER_ENCODED_PREFIX_BYTES.size() || bytes.size() == KEY_SIZE)
-  {
-    try
-    {
-      return std::make_unique<ED25519PrivateKey>(ED25519PrivateKey(bytesToPKEY(bytes)));
-    }
-    catch (const OpenSSLException& openSSLException)
-    {
-      throw BadKeyException(std::string("ED25519PrivateKey cannot be realized from input bytes: ") +
-                            openSSLException.what());
-    }
-  }
-  else
+  if (bytes.size() != KEY_SIZE + DER_ENCODED_PREFIX_BYTES.size() && bytes.size() != KEY_SIZE)
   {
     throw BadKeyException("ED25519PrivateKey cannot be realized from input bytes: input byte array size should be " +
                           std::to_string(KEY_SIZE + DER_ENCODED_PREFIX_BYTES.size()) + " or " +
                           std::to_string(KEY_SIZE));
+  }
+
+  try
+  {
+    return std::make_unique<ED25519PrivateKey>(ED25519PrivateKey(bytesToPKEY(bytes)));
+  }
+  catch (const OpenSSLException& openSSLException)
+  {
+    throw BadKeyException(std::string("ED25519PrivateKey cannot be realized from input bytes: ") +
+                          openSSLException.what());
   }
 }
 

--- a/sdk/tests/ECDSAsecp256k1PrivateKeyTest.cc
+++ b/sdk/tests/ECDSAsecp256k1PrivateKeyTest.cc
@@ -24,9 +24,11 @@
 #include "exceptions/UninitializedException.h"
 #include "impl/Utilities.h"
 
+#include <algorithm>
 #include <gtest/gtest.h>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 using namespace Hedera;
@@ -35,6 +37,13 @@ using namespace Hedera::internal::Utilities;
 class ECDSAsecp256k1PrivateKeyTest : public ::testing::Test
 {
 protected:
+  [[nodiscard]] static std::string toLowercase(std::string_view str)
+  {
+    std::string lowercaseStr;
+    std::transform(str.cbegin(), str.cend(), std::back_inserter(lowercaseStr), [](char c) { return tolower(c); });
+    return lowercaseStr;
+  }
+
   [[nodiscard]] inline const std::string& getTestPrivateKeyHexString() const { return mPrivateKeyHexString; }
   [[nodiscard]] inline const std::vector<std::byte>& getTestPrivateKeyBytes() const { return mPrivateKeyBytes; }
 
@@ -109,6 +118,8 @@ TEST_F(ECDSAsecp256k1PrivateKeyTest, FromString)
     const std::unique_ptr<ECDSAsecp256k1PrivateKey> key = ECDSAsecp256k1PrivateKey::fromString(
       std::string(ECDSAsecp256k1PrivateKey::DER_ENCODED_PREFIX_HEX.size(), 'A') + getTestPrivateKeyHexString()),
     BadKeyException);
+  EXPECT_NO_THROW(const std::unique_ptr<ECDSAsecp256k1PrivateKey> key =
+                    ECDSAsecp256k1PrivateKey::fromString(toLowercase(getTestPrivateKeyHexString())));
 }
 
 //-----

--- a/sdk/tests/ECDSAsecp256k1PublicKeyTest.cc
+++ b/sdk/tests/ECDSAsecp256k1PublicKeyTest.cc
@@ -22,9 +22,12 @@
 #include "exceptions/BadKeyException.h"
 #include "impl/Utilities.h"
 
+#include <algorithm>
 #include <gtest/gtest.h>
 #include <memory>
 #include <proto/basic_types.pb.h>
+#include <string>
+#include <string_view>
 #include <vector>
 
 using namespace Hedera;
@@ -33,6 +36,13 @@ using namespace Hedera::internal::Utilities;
 class ECDSAsecp256k1PublicKeyTest : public ::testing::Test
 {
 protected:
+  [[nodiscard]] static std::string toLowercase(std::string_view str)
+  {
+    std::string lowercaseStr;
+    std::transform(str.cbegin(), str.cend(), std::back_inserter(lowercaseStr), [](char c) { return tolower(c); });
+    return lowercaseStr;
+  }
+
   [[nodiscard]] inline const std::string& getTestUncompressedPublicKeyHex() const { return mUncompressedPublicKeyHex; }
   [[nodiscard]] inline const std::string& getTestCompressedPublicKeyHex() const { return mCompressedPublicKeyHex; }
   [[nodiscard]] inline const std::vector<std::byte>& getTestUncompressedPublicKeyBytes() const
@@ -122,6 +132,8 @@ TEST_F(ECDSAsecp256k1PublicKeyTest, FromString)
                  std::string(ECDSAsecp256k1PublicKey::DER_ENCODED_COMPRESSED_PREFIX_HEX.size(), 'A') +
                  getTestCompressedPublicKeyHex()),
                BadKeyException);
+  EXPECT_NO_THROW(const std::shared_ptr<ECDSAsecp256k1PublicKey> key =
+                    ECDSAsecp256k1PublicKey::fromString(toLowercase(getTestCompressedPublicKeyHex())));
 }
 
 //-----

--- a/sdk/tests/ED25519PrivateKeyTest.cc
+++ b/sdk/tests/ED25519PrivateKeyTest.cc
@@ -24,8 +24,11 @@
 #include "exceptions/UninitializedException.h"
 #include "impl/Utilities.h"
 
+#include <algorithm>
 #include <gtest/gtest.h>
 #include <memory>
+#include <string>
+#include <string_view>
 #include <vector>
 
 using namespace Hedera;
@@ -34,6 +37,13 @@ using namespace Hedera::internal::Utilities;
 class ED25519PrivateKeyTest : public ::testing::Test
 {
 protected:
+  [[nodiscard]] static std::string toLowercase(std::string_view str)
+  {
+    std::string lowercaseStr;
+    std::transform(str.cbegin(), str.cend(), std::back_inserter(lowercaseStr), [](char c) { return tolower(c); });
+    return lowercaseStr;
+  }
+
   [[nodiscard]] inline const std::string& getTestPrivateKeyHexString() const { return mPrivateKeyHexString; }
   [[nodiscard]] inline const std::vector<std::byte>& getTestPrivateKeyBytes() const { return mPrivateKeyBytes; }
 
@@ -106,6 +116,8 @@ TEST_F(ED25519PrivateKeyTest, FromString)
   EXPECT_THROW(const std::unique_ptr<ED25519PrivateKey> key = ED25519PrivateKey::fromString(
                  std::string(ED25519PrivateKey::DER_ENCODED_PREFIX_HEX.size(), 'A') + getTestPrivateKeyHexString()),
                BadKeyException);
+  EXPECT_NO_THROW(const std::unique_ptr<ED25519PrivateKey> key =
+                    ED25519PrivateKey::fromString(toLowercase(getTestPrivateKeyHexString())));
 }
 
 //-----

--- a/sdk/tests/ED25519PublicKeyTest.cc
+++ b/sdk/tests/ED25519PublicKeyTest.cc
@@ -24,9 +24,12 @@
 #include "impl/HexConverter.h"
 #include "impl/Utilities.h"
 
+#include <algorithm>
 #include <gtest/gtest.h>
 #include <memory>
 #include <proto/basic_types.pb.h>
+#include <string>
+#include <string_view>
 #include <vector>
 
 using namespace Hedera;
@@ -35,6 +38,13 @@ using namespace Hedera::internal::Utilities;
 class ED25519PublicKeyTest : public ::testing::Test
 {
 protected:
+  [[nodiscard]] static std::string toLowercase(std::string_view str)
+  {
+    std::string lowercaseStr;
+    std::transform(str.cbegin(), str.cend(), std::back_inserter(lowercaseStr), [](char c) { return tolower(c); });
+    return lowercaseStr;
+  }
+
   [[nodiscard]] inline const std::string& getTestPublicKeyHex() const { return mPublicKeyHexString; }
   [[nodiscard]] inline const std::vector<std::byte>& getTestPublicKeyBytes() const { return mPublicKeyBytes; }
 
@@ -86,6 +96,8 @@ TEST_F(ED25519PublicKeyTest, FromString)
   EXPECT_THROW(const std::shared_ptr<ED25519PublicKey> key = ED25519PublicKey::fromString(
                  std::string(ED25519PublicKey::DER_ENCODED_PREFIX_HEX.size(), 'A') + getTestPublicKeyHex()),
                BadKeyException);
+  EXPECT_NO_THROW(const std::shared_ptr<ED25519PublicKey> key =
+                    ED25519PublicKey::fromString(toLowercase(getTestPublicKeyHex())));
 }
 
 //-----


### PR DESCRIPTION
**Description**:
This PR fixes an issue with creating `ECDSAsecp256k1PrivateKey`s where inputting lowercase hex into `fromString` would cause `BadKeyException`s to be thrown. To fix this, the comparison is made after a conversion to bytes, where lowercase and uppercase hex will convert to the same byte value. Tests were added to catch this case.

**Related issue(s)**:

Fixes #253 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
