### PR TITLE
Implement `KeyList`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(${PROJECT_NAME} STATIC
         src/FileInfoQuery.cc
         src/HbarAllowance.cc
         src/HbarTransfer.cc
+        src/KeyList.cc
         src/LedgerId.cc
         src/Mnemonic.cc
         src/MnemonicBIP39.cc

--- a/sdk/main/include/KeyList.h
+++ b/sdk/main/include/KeyList.h
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -17,19 +17,116 @@
  * limitations under the License.
  *
  */
-#ifndef KEY_LIST_H_
-#define KEY_LIST_H_
+#ifndef HEDERA_SDK_CPP_KEYLIST_H_
+#define HEDERA_SDK_CPP_KEYLIST_H_
 
-#include <proto/basic_types.pb.h>
+#include "PublicKey.h"
+
+#include <memory>
+#include <vector>
+
+namespace proto
+{
+class Key;
+class KeyList;
+}
 
 namespace Hedera
 {
+/**
+ * A key list key structure where all the keys in the list are required to sign transactions that modify accounts,
+ * topics, tokens, smart contracts, or files. A key list can contain a ED25519 or ECDSAsecp256k1 key type.
+ *
+ * If all the keys in the key list key structure do not sign, the transaction will fail and return an
+ * "INVALID_SIGNATURE" error. A key list can have repeated keys. A signature for the repeated key will count as many
+ * times as the key is listed in the key list. For example, a key list has three keys. Two of the three public keys in
+ * the list are the same. When a user signs a transaction with the repeated key it will account for two out of the three
+ * keys required signature.
+ */
 class KeyList
 {
 public:
-  static KeyList fromProtobuf(const proto::KeyList& proto) { return KeyList(); }
-  proto::KeyList* toProtobuf() const { return new proto::KeyList; }
+  /**
+   * Construct a KeyList object from a KeyList protobuf object.
+   *
+   * @param proto The KeyList protobuf object from which to create a KeyList object.
+   * @return The created KeyList object.
+   * @throws BadKeyException If a key in the KeyList protobuf is unable to be created.
+   */
+  [[nodiscard]] static KeyList fromProtobuf(const proto::KeyList& proto);
+
+  /**
+   * Construct a KeyList object from a list of PublicKeys.
+   *
+   * @param keys The list of PublicKeys to add to this KeyList.
+   * @return The created KeyList object.
+   */
+  [[nodiscard]] static KeyList of(const std::vector<std::shared_ptr<PublicKey>>& keys);
+
+  /**
+   * Construct a Key protobuf object from this KeyList object.
+   *
+   * @return A pointer to a created Key protobuf object filled with this KeyList object's data.
+   * @throws OpenSSLException If OpenSSL is unable to serialize any key in this KeyList.
+   */
+  [[nodiscard]] std::unique_ptr<proto::Key> toProtobufKey() const;
+
+  /**
+   * Construct a KeyList protobuf object from this KeyList object.
+   *
+   * @return A pointer to a created KeyList protobuf object filled with this KeyList object's data.
+   * @throws OpenSSLException If OpenSSL is unable to serialize any key in this KeyList.
+   */
+  [[nodiscard]] std::unique_ptr<proto::KeyList> toProtobuf() const;
+
+  /**
+   * Get the number of keys in this KeyList.
+   *
+   * @return The number of keys in this KeyList.
+   */
+  [[nodiscard]] size_t size() const;
+
+  /**
+   * Determine if this KeyList contains any keys.
+   *
+   * @return \c TRUE if this KeyList is empty, otherwise \c FALSE.
+   */
+  [[nodiscard]] bool empty() const;
+
+  /**
+   * Determine if this KeyList contains a certain key.
+   *
+   * @param key The key to determine if this KeyList contains.
+   * @return \c TRUE if this KeyList contains the input key, otherwise \c FALSE.
+   */
+  [[nodiscard]] bool contains(const std::shared_ptr<PublicKey>& key) const;
+
+  /**
+   * Add a key to this KeyList.
+   *
+   * @param key The key to add to this KeyList.
+   */
+  void push_back(const std::shared_ptr<PublicKey>& key);
+
+  /**
+   * Remove a key from this KeyList. Does nothing if the input key is not a part of this KeyList.
+   *
+   * @param key The key to remove from this KeyList.
+   */
+  void remove(const std::shared_ptr<PublicKey>& key);
+
+  /**
+   * Remove all keys from this KeyList.
+   */
+  void clear();
+
+private:
+  /**
+   * The list of PublicKeys that all must sign transactions.
+   */
+  std::vector<std::shared_ptr<PublicKey>> mKeys;
 };
+
 } // namespace Hedera
 
-#endif // KEY_LIST_H_
+#endif // HEDERA_SDK_CPP_KEYLIST_H_

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(${TEST_PROJECT_NAME}
         HbarAllowanceTest.cc
         HbarTest.cc
         HbarTransferTest.cc
+        KeyListTest.cc
         LedgerIdTest.cc
         NftIdTest.cc
         NodeAddressTest.cc

--- a/sdk/tests/unit/KeyListTest.cc
+++ b/sdk/tests/unit/KeyListTest.cc
@@ -1,0 +1,207 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "KeyList.h"
+#include "ED25519PrivateKey.h"
+#include "PublicKey.h"
+#include "impl/Utilities.h"
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <proto/basic_types.pb.h>
+
+using namespace Hedera;
+
+class KeyListTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestPublicKey1() const { return mTestPublicKey1; }
+  [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestPublicKey2() const { return mTestPublicKey2; }
+  [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestPublicKey3() const { return mTestPublicKey3; }
+
+private:
+  const std::shared_ptr<PublicKey> mTestPublicKey1 =
+    ED25519PrivateKey::fromString(
+      "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10")
+      ->getPublicKey();
+  const std::shared_ptr<PublicKey> mTestPublicKey2 =
+    ED25519PrivateKey::fromString(
+      "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e11")
+      ->getPublicKey();
+  const std::shared_ptr<PublicKey> mTestPublicKey3 =
+    ED25519PrivateKey::fromString(
+      "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e12")
+      ->getPublicKey();
+};
+
+//-----
+TEST_F(KeyListTest, FromProtobuf)
+{
+  // Given
+  proto::KeyList protoKeyList;
+  protoKeyList.add_keys()->set_ed25519(internal::Utilities::byteVectorToString(getTestPublicKey1()->toBytesDer()));
+  protoKeyList.add_keys()->set_ed25519(internal::Utilities::byteVectorToString(getTestPublicKey2()->toBytesDer()));
+  protoKeyList.add_keys()->set_ed25519(internal::Utilities::byteVectorToString(getTestPublicKey3()->toBytesDer()));
+
+  // When
+  KeyList keyList;
+  EXPECT_NO_THROW(keyList = KeyList::fromProtobuf(protoKeyList));
+
+  // Then
+  EXPECT_TRUE(keyList.contains(getTestPublicKey1()));
+  EXPECT_TRUE(keyList.contains(getTestPublicKey2()));
+  EXPECT_TRUE(keyList.contains(getTestPublicKey3()));
+}
+
+//-----
+TEST_F(KeyListTest, Of)
+{
+  // Given / When
+  const KeyList keyList = KeyList::of({ getTestPublicKey1(), getTestPublicKey2(), getTestPublicKey3() });
+
+  // Then
+  EXPECT_TRUE(keyList.contains(getTestPublicKey1()));
+  EXPECT_TRUE(keyList.contains(getTestPublicKey2()));
+  EXPECT_TRUE(keyList.contains(getTestPublicKey3()));
+}
+
+//-----
+TEST_F(KeyListTest, ToProtobufKey)
+{
+  // Given
+  const KeyList keyList = KeyList::of({ getTestPublicKey1(), getTestPublicKey2(), getTestPublicKey3() });
+
+  // When
+  std::unique_ptr<proto::Key> protoKey;
+  EXPECT_NO_THROW(protoKey = keyList.toProtobufKey());
+
+  // Then
+  ASSERT_TRUE(protoKey->has_keylist());
+  ASSERT_EQ(protoKey->keylist().keys_size(), 3);
+  EXPECT_EQ(protoKey->keylist().keys(0).ed25519(),
+            internal::Utilities::byteVectorToString(getTestPublicKey1()->toBytesRaw()));
+  EXPECT_EQ(protoKey->keylist().keys(1).ed25519(),
+            internal::Utilities::byteVectorToString(getTestPublicKey2()->toBytesRaw()));
+  EXPECT_EQ(protoKey->keylist().keys(2).ed25519(),
+            internal::Utilities::byteVectorToString(getTestPublicKey3()->toBytesRaw()));
+}
+
+//-----
+TEST_F(KeyListTest, ToProtobuf)
+{
+  // Given
+  const KeyList keyList = KeyList::of({ getTestPublicKey1(), getTestPublicKey2(), getTestPublicKey3() });
+
+  // When
+  std::unique_ptr<proto::KeyList> protoKeyList;
+  EXPECT_NO_THROW(protoKeyList = keyList.toProtobuf());
+
+  // Then
+  ASSERT_EQ(protoKeyList->keys_size(), 3);
+  EXPECT_EQ(protoKeyList->keys(0).ed25519(),
+            internal::Utilities::byteVectorToString(getTestPublicKey1()->toBytesRaw()));
+  EXPECT_EQ(protoKeyList->keys(1).ed25519(),
+            internal::Utilities::byteVectorToString(getTestPublicKey2()->toBytesRaw()));
+  EXPECT_EQ(protoKeyList->keys(2).ed25519(),
+            internal::Utilities::byteVectorToString(getTestPublicKey3()->toBytesRaw()));
+}
+
+//-----
+TEST_F(KeyListTest, Size)
+{
+  // Given / When
+  const KeyList keyList = KeyList::of({ getTestPublicKey1(), getTestPublicKey2(), getTestPublicKey3() });
+  const KeyList emptyKeyList;
+
+  // Then
+  EXPECT_EQ(keyList.size(), 3);
+  EXPECT_EQ(emptyKeyList.size(), 0);
+}
+
+//-----
+TEST_F(KeyListTest, Empty)
+{
+  // Given / When
+  const KeyList keyList = KeyList::of({ getTestPublicKey1(), getTestPublicKey2(), getTestPublicKey3() });
+  const KeyList emptyKeyList;
+
+  // Then
+  EXPECT_FALSE(keyList.empty());
+  EXPECT_TRUE(emptyKeyList.empty());
+}
+
+//-----
+TEST_F(KeyListTest, Contains)
+{
+  // Given / When
+  const KeyList keyList = KeyList::of({ getTestPublicKey1(), getTestPublicKey2(), getTestPublicKey3() });
+  const KeyList emptyKeyList;
+
+  // Then
+  EXPECT_TRUE(keyList.contains(getTestPublicKey1()));
+  EXPECT_TRUE(keyList.contains(getTestPublicKey2()));
+  EXPECT_TRUE(keyList.contains(getTestPublicKey3()));
+
+  EXPECT_FALSE(emptyKeyList.contains(getTestPublicKey1()));
+  EXPECT_FALSE(emptyKeyList.contains(getTestPublicKey2()));
+  EXPECT_FALSE(emptyKeyList.contains(getTestPublicKey3()));
+}
+
+//-----
+TEST_F(KeyListTest, PushBack)
+{
+  // Given
+  KeyList keyList = KeyList::of({ getTestPublicKey1(), getTestPublicKey2() });
+
+  // When
+  keyList.push_back(getTestPublicKey3());
+
+  // Then
+  EXPECT_EQ(keyList.size(), 3);
+  EXPECT_TRUE(keyList.contains(getTestPublicKey3()));
+}
+
+//-----
+TEST_F(KeyListTest, Remove)
+{
+  // Given
+  KeyList keyList = KeyList::of({ getTestPublicKey1(), getTestPublicKey2(), getTestPublicKey3() });
+
+  // When
+  keyList.remove(getTestPublicKey1());
+
+  // Then
+  EXPECT_EQ(keyList.size(), 2);
+  EXPECT_FALSE(keyList.contains(getTestPublicKey1()));
+  EXPECT_TRUE(keyList.contains(getTestPublicKey2()));
+  EXPECT_TRUE(keyList.contains(getTestPublicKey3()));
+}
+
+//-----
+TEST_F(KeyListTest, Clear)
+{
+  // Given
+  KeyList keyList = KeyList::of({ getTestPublicKey1(), getTestPublicKey2(), getTestPublicKey3() });
+
+  // When
+  keyList.clear();
+
+  // Then
+  EXPECT_TRUE(keyList.empty());
+}


### PR DESCRIPTION
**Description**:
This PR implements `KeyList`, a structure that allows multiple keys to sign a transaction.

**Related issue(s)**:

Fixes #310 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
