### PR TITLE
Add `CustomFee` base class

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(${PROJECT_NAME} STATIC
         src/ContractInfoQuery.cc
         src/ContractLogInfo.cc
         src/ContractUpdateTransaction.cc
+        src/CustomFee.cc
         src/DelegateContractId.cc
         src/ECDSAsecp256k1PrivateKey.cc
         src/ECDSAsecp256k1PublicKey.cc

--- a/sdk/main/include/CustomFee.h
+++ b/sdk/main/include/CustomFee.h
@@ -1,0 +1,114 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_CUSTOM_FEE_H_
+#define HEDERA_SDK_CPP_CUSTOM_FEE_H_
+
+#include "AccountId.h"
+
+#include <memory>
+
+namespace proto
+{
+class CustomFee;
+}
+
+namespace Hedera
+{
+/**
+ * Base class for custom fees. This is assessed during a CryptoTransfer that transfers units of the token to which the
+ * fee is attached. A custom fee may be either fixed, fractional, or a royalty, and must specify a fee collector account
+ * to receive the assessed fees. Only positive fees may be assessed.
+ */
+template<typename FeeType>
+class CustomFee
+{
+public:
+  virtual ~CustomFee() = default;
+
+  /**
+   * Create a CustomFee object from a CustomFee protobuf object.
+   *
+   * @param proto The CustomFee protobuf object from which to create an CustomFee object.
+   * @return A pointer to the constructed CustomFee object.
+   */
+  [[nodiscard]] static std::unique_ptr<CustomFee<FeeType>> fromProtobuf(const proto::CustomFee& proto);
+
+  /**
+   * Create a clone of this CustomFee object.
+   *
+   * @return A pointer to the created clone of this CustomFee.
+   */
+  [[nodiscard]] virtual std::unique_ptr<CustomFee> clone() const = 0;
+
+  /**
+   * Set the ID of the desired fee collector account.
+   *
+   * @param accountId The ID of the desired fee collector account.
+   * @return A reference to this derived CustomFee object, with the newly-set fee collector account ID.
+   */
+  FeeType& setFeeCollectorAccountId(const AccountId& accountId);
+
+  /**
+   * Set the fee collector exemption policy.
+   *
+   * @param exempt \c TRUE if fee collectors should be exempt from this CustomFee, otherwise \c FALSE.
+   * @return A reference ot this derived CustomFee object, with the newly-set fee collector exemption policy.
+   */
+  FeeType& setAllCollectorsAreExempt(bool exempt);
+
+  /**
+   * Get the ID of the desired fee collector account.
+   *
+   * @return The ID of the desired fee collector account.
+   */
+  [[nodiscard]] inline AccountId getFeeCollectorAccountId() const { return mFeeCollectorAccountId; }
+
+  /**
+   * Get the fee collector exemption policy.
+   *
+   * @return \c TRUE if fee collectors are currently configured to be exempt from this CustomFee, otherwise \c FALSE.
+   */
+  [[nodiscard]] inline bool getAllCollectorsAreExempt() const { return mAllCollectorsAreExempt; }
+
+protected:
+  /**
+   * Prevent public copying and moving to prevent slicing. Use the 'clone()' virtual method instead.
+   */
+  CustomFee() = default;
+  CustomFee(const CustomFee&) = default;
+  CustomFee& operator=(const CustomFee&) = default;
+  CustomFee(CustomFee&&) noexcept = default;
+  CustomFee& operator=(CustomFee&&) noexcept = default;
+
+private:
+  /**
+   * The ID of the account that should receive the fee.
+   */
+  AccountId mFeeCollectorAccountId;
+
+  /**
+   * Should all token fee collection accounts be exempt from this fee?
+   */
+  bool mAllCollectorsAreExempt = false;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_CUSTOM_FEE_H_

--- a/sdk/main/src/CustomFee.cc
+++ b/sdk/main/src/CustomFee.cc
@@ -1,0 +1,50 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "CustomFee.h"
+
+#include <proto/custom_fees.pb.h>
+
+namespace Hedera
+{
+//-----
+template<typename FeeType>
+std::unique_ptr<CustomFee<FeeType>> CustomFee<FeeType>::fromProtobuf(const proto::CustomFee& proto)
+{
+  // TODO
+  return std::unique_ptr<CustomFee<FeeType>>();
+}
+
+//-----
+template<typename FeeType>
+FeeType& CustomFee<FeeType>::setFeeCollectorAccountId(const AccountId& accountId)
+{
+  mFeeCollectorAccountId = accountId;
+  return static_cast<FeeType&>(*this);
+}
+
+//-----
+template<typename FeeType>
+FeeType& CustomFee<FeeType>::setAllCollectorsAreExempt(bool exempt)
+{
+  mAllCollectorsAreExempt = exempt;
+  return static_cast<FeeType&>(*this);
+}
+
+} // namespace Hedera


### PR DESCRIPTION
**Description**:
This PR adds the `CustomFee` base class, from which actual custom fee implementations can be derived.

**Related issue(s)**:

Fixes #354 

**Notes for reviewer**:
`CustomFee::fromProtobuf` functionality requires derived class functionality to be implemented, so this is left blank for now but will be gradually filled in when more derived `CustomFee` classes are implemented. In addition to this, unit tests require a derived implementation, so these will also be added at a later time.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
