### PR TITLE
chore: Update runs-on stanza to use the appropriate latitude label

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build:
     name: Build
-    runs-on: client-sdk-linux-large
+    runs-on: hiero-client-sdk-linux-large
 
     env:
       HEDERA_NETWORK: localhost


### PR DESCRIPTION
**Description**:

Updates the runs-on stanza to use the hiero label for the latitude runners

**Related Issue(s)**:

Fixes: #807