### PR TITLE
feat: Add optional Tests/TCK builds

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -121,7 +121,7 @@ jobs:
           VCPKG_BINARY_SOURCES: clear
         run: |
           echo "::group::Configure Project"
-          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-debug
+          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-debug -DBUILD_TCK=ON -DBUILD_TESTS=ON
           echo "::endgroup::"
 
           echo "::group::Build Project"
@@ -143,7 +143,7 @@ jobs:
           VCPKG_BINARY_SOURCES: clear
         run: |
           echo "::group::Configure Project"
-          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-release
+          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-release -DBUILD_TCK=ON -DBUILD_TESTS=ON
           echo "::endgroup::"
 
           echo "::group::Build Project"

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -121,7 +121,7 @@ jobs:
           VCPKG_BINARY_SOURCES: clear
         run: |
           echo "::group::Configure Project"
-          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-debug -DBUILD_TCK=ON -DBUILD_TESTS=ON
+          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-debug -DBUILD_TESTS=ON
           echo "::endgroup::"
 
           echo "::group::Build Project"
@@ -143,7 +143,7 @@ jobs:
           VCPKG_BINARY_SOURCES: clear
         run: |
           echo "::group::Configure Project"
-          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-release -DBUILD_TCK=ON -DBUILD_TESTS=ON
+          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-release -DBUILD_TESTS=ON
           echo "::endgroup::"
 
           echo "::group::Build Project"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ Default: OFF
 Enable: Add -DBUILD_TESTS=ON during configuration.
 ```
 
+`BUILD_EXAMPLES`
+
+```
+Description: Controls whether the user examples are included in the build.
+Default: OFF
+Enable: Add -DBUILD_EXAMPLES=ON during configuration.
+```
+
 ## Testing
 
 To run all SDK tests (for Release or Debug builds):

--- a/README.md
+++ b/README.md
@@ -46,27 +46,46 @@ git clone https://github.com/hiero-ledger/hiero-sdk-cpp.git
 cd hiero-sdk-cpp
 ```
 
-3. Complete the following tasks within your project directory for the build you want
+3. You can configure and build the project for various platforms using CMake presets. Additionally, optional components like TCK and Tests can be included in the build using flags.
 
 ```sh
 # Ensure the VCPkg Submodule is initialized
 git submodule update --init
 
 # Windows (x64) Build
-cmake --preset windows-x64-release
+cmake --preset windows-x64-release -DBUILD_TCK=ON -DBUILD_TESTS=ON
 cmake --build --preset windows-x64-release
 
 # Linux (x64) Build
-cmake --preset linux-x64-release
+cmake --preset linux-x64-release -DBUILD_TCK=ON -DBUILD_TESTS=ON
 cmake --build --preset linux-x64-release
 
 # MacOS (Intel x64) Build
-cmake --preset macos-x64-release
+cmake --preset macos-x64-release -DBUILD_TCK=ON -DBUILD_TESTS=ON
 cmake --build --preset macos-x64-release
 
 # MacOS (Aarch64) Build
-cmake --preset macos-arm64-release
+cmake --preset macos-arm64-release -DBUILD_TCK=ON -DBUILD_TESTS=ON
 cmake --build --preset macos-arm64-release
+```
+
+Optional Build Flags
+The project supports the following optional flags to include or exclude specific components:
+
+`BUILD_TCK`
+
+```
+Description: Controls whether the TCK tests are included in the build.
+Default: OFF
+Enable: Add -DBUILD_TCK=ON during configuration.
+```
+
+`BUILD_TESTS`
+
+```
+Description: Controls whether the test suite is included in the build.
+Default: OFF
+Enable: Add -DBUILD_TESTS=ON during configuration.
 ```
 
 ## Testing
@@ -177,7 +196,7 @@ More instructions for contribution can be found in the
 
 ## Code of Conduct
 
-Hiero uses the Linux Foundation Decentralised Trust [Code of Conduct]([https://github.com/hashgraph/.github/blob/main/CODE_OF_CONDUCT.md](https://www.lfdecentralizedtrust.org/code-of-conduct)).
+Hiero uses the Linux Foundation Decentralised Trust [Code of Conduct](<[https://github.com/hashgraph/.github/blob/main/CODE_OF_CONDUCT.md](https://www.lfdecentralizedtrust.org/code-of-conduct)>).
 
 ## License
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_subdirectory(sdk)
-# Add optional TCK subdirectory build
+# Optional TCK build
 option(BUILD_TCK "Build the TCK tests" OFF)
 
 if(BUILD_TCK)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,10 @@
 add_subdirectory(sdk)
-add_subdirectory(tck)
+# Add optional TCK subdirectory build
+option(BUILD_TCK "Build the TCK tests" OFF)
+
+if(BUILD_TCK)
+    message(STATUS "Including TCK tests in the build.")
+    add_subdirectory(tck)
+else()
+    message(STATUS "TCK tests are not included in the build.")
+endif()

--- a/src/sdk/CMakeLists.txt
+++ b/src/sdk/CMakeLists.txt
@@ -1,3 +1,11 @@
 add_subdirectory(examples)
 add_subdirectory(main)
-add_subdirectory(tests)
+# Optional Tests build
+option(BUILD_TESTS "Build the test suite" OFF)
+
+if(BUILD_TESTS)
+    message(STATUS "Including tests in the build.")
+    add_subdirectory(tests)
+else()
+    message(STATUS "Tests are not included in the build.")
+endif()

--- a/src/sdk/CMakeLists.txt
+++ b/src/sdk/CMakeLists.txt
@@ -1,4 +1,12 @@
-add_subdirectory(examples)
+# Optional Examples build
+option(BUILD_EXAMPLES "Build the example builds" OFF)
+
+if(BUILD_EXAMPLES)
+    message(STATUS "Including examples in the build.")
+    add_subdirectory(tests)
+else()
+    message(STATUS "Examples are not included in the build.")
+endif()
 add_subdirectory(main)
 # Optional Tests build
 option(BUILD_TESTS "Build the test suite" OFF)


### PR DESCRIPTION
**Description**:
Introduces flags for optional builds:
* BUILD_TCK - building the TCK project
* BUILD_TESTS - building the unit/integration test suites
* BUILD_EXAMPLES - building the user examples

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-sdk-cpp/issues/816

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
