### PR TITLE
fix: update `Account` types to `string` from `int64_t`

### DIFF
--- a/src/tck/include/account/params/CreateAccountParams.h
+++ b/src/tck/include/account/params/CreateAccountParams.h
@@ -25,7 +25,7 @@ struct CreateAccountParams
   /**
    * The desired initial balance for the account.
    */
-  std::optional<int64_t> mInitialBalance;
+  std::optional<std::string> mInitialBalance;
 
   /**
    * Should the new account require a receiver signature?
@@ -35,7 +35,7 @@ struct CreateAccountParams
   /**
    * The desired amount of time in seconds to renew the new account.
    */
-  std::optional<int64_t> mAutoRenewPeriod;
+  std::optional<std::string> mAutoRenewPeriod;
 
   /**
    * The desired memo for the new account.
@@ -55,7 +55,7 @@ struct CreateAccountParams
   /**
    * The ID of the desired node to which the new account should stake.
    */
-  std::optional<int64_t> mStakedNodeId;
+  std::optional<std::string> mStakedNodeId;
 
   /**
    * Should the new account decline staking rewards?
@@ -92,15 +92,15 @@ struct [[maybe_unused]] adl_serializer<Hiero::TCK::AccountService::CreateAccount
   static void from_json(const json& jsonFrom, Hiero::TCK::AccountService::CreateAccountParams& params)
   {
     params.mKey = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "key");
-    params.mInitialBalance = Hiero::TCK::getOptionalJsonParameter<int64_t>(jsonFrom, "initialBalance");
+    params.mInitialBalance = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "initialBalance");
     params.mReceiverSignatureRequired =
       Hiero::TCK::getOptionalJsonParameter<bool>(jsonFrom, "receiverSignatureRequired");
-    params.mAutoRenewPeriod = Hiero::TCK::getOptionalJsonParameter<int64_t>(jsonFrom, "autoRenewPeriod");
+    params.mAutoRenewPeriod = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "autoRenewPeriod");
     params.mMemo = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "memo");
     params.mMaxAutoTokenAssociations =
       Hiero::TCK::getOptionalJsonParameter<int32_t>(jsonFrom, "maxAutoTokenAssociations");
     params.mStakedAccountId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "stakedAccountId");
-    params.mStakedNodeId = Hiero::TCK::getOptionalJsonParameter<int64_t>(jsonFrom, "stakedNodeId");
+    params.mStakedNodeId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "stakedNodeId");
     params.mDeclineStakingReward = Hiero::TCK::getOptionalJsonParameter<bool>(jsonFrom, "declineStakingReward");
     params.mAlias = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "alias");
     params.mCommonTxParams =

--- a/src/tck/include/account/params/UpdateAccountParams.h
+++ b/src/tck/include/account/params/UpdateAccountParams.h
@@ -30,12 +30,12 @@ struct UpdateAccountParams
   /**
    * The desired new amount of time in seconds to renew the account.
    */
-  std::optional<int64_t> mAutoRenewPeriod;
+  std::optional<std::string> mAutoRenewPeriod;
 
   /**
    * The new expiration time to which to extend this account.
    */
-  std::optional<int64_t> mExpirationTime;
+  std::optional<std::string> mExpirationTime;
 
   /**
    * Should the account now require a receiver signature?
@@ -60,7 +60,7 @@ struct UpdateAccountParams
   /**
    * The ID of the new desired node to which the account should stake.
    */
-  std::optional<int64_t> mStakedNodeId;
+  std::optional<std::string> mStakedNodeId;
 
   /**
    * Should the account now decline staking rewards?
@@ -93,15 +93,15 @@ struct [[maybe_unused]] adl_serializer<Hiero::TCK::AccountService::UpdateAccount
   {
     params.mAccountId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "accountId");
     params.mKey = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "key");
-    params.mAutoRenewPeriod = Hiero::TCK::getOptionalJsonParameter<int64_t>(jsonFrom, "autoRenewPeriod");
-    params.mExpirationTime = Hiero::TCK::getOptionalJsonParameter<int64_t>(jsonFrom, "expirationTime");
+    params.mAutoRenewPeriod = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "autoRenewPeriod");
+    params.mExpirationTime = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "expirationTime");
     params.mReceiverSignatureRequired =
       Hiero::TCK::getOptionalJsonParameter<bool>(jsonFrom, "receiverSignatureRequired");
     params.mMemo = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "memo");
     params.mMaxAutoTokenAssociations =
       Hiero::TCK::getOptionalJsonParameter<int32_t>(jsonFrom, "maxAutoTokenAssociations");
     params.mStakedAccountId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "stakedAccountId");
-    params.mStakedNodeId = Hiero::TCK::getOptionalJsonParameter<int64_t>(jsonFrom, "stakedNodeId");
+    params.mStakedNodeId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "stakedNodeId");
     params.mDeclineStakingReward = Hiero::TCK::getOptionalJsonParameter<bool>(jsonFrom, "declineStakingReward");
     params.mCommonTxParams =
       Hiero::TCK::getOptionalJsonParameter<Hiero::TCK::CommonTransactionParams>(jsonFrom, "commonTransactionParams");

--- a/src/tck/src/account/AccountService.cc
+++ b/src/tck/src/account/AccountService.cc
@@ -16,8 +16,10 @@
 #include <Status.h>
 #include <TransactionReceipt.h>
 #include <TransactionResponse.h>
+#include <impl/EntityIdHelper.h>
 
 #include <chrono>
+#include <cstdint>
 #include <nlohmann/json.hpp>
 #include <string>
 
@@ -36,7 +38,8 @@ nlohmann::json createAccount(const CreateAccountParams& params)
 
   if (params.mInitialBalance.has_value())
   {
-    accountCreateTransaction.setInitialBalance(Hbar(params.mInitialBalance.value(), HbarUnit::TINYBAR()));
+    accountCreateTransaction.setInitialBalance(
+      Hbar(Hiero::internal::EntityIdHelper::getNum<int64_t>(params.mInitialBalance.value()), HbarUnit::TINYBAR()));
   }
 
   if (params.mReceiverSignatureRequired.has_value())
@@ -46,7 +49,8 @@ nlohmann::json createAccount(const CreateAccountParams& params)
 
   if (params.mAutoRenewPeriod.has_value())
   {
-    accountCreateTransaction.setAutoRenewPeriod(std::chrono::seconds(params.mAutoRenewPeriod.value()));
+    accountCreateTransaction.setAutoRenewPeriod(
+      std::chrono::seconds(Hiero::internal::EntityIdHelper::getNum<int64_t>(params.mAutoRenewPeriod.value())));
   }
 
   if (params.mMemo.has_value())
@@ -66,7 +70,8 @@ nlohmann::json createAccount(const CreateAccountParams& params)
 
   if (params.mStakedNodeId.has_value())
   {
-    accountCreateTransaction.setStakedNodeId(params.mStakedNodeId.value());
+    accountCreateTransaction.setStakedNodeId(
+      Hiero::internal::EntityIdHelper::getNum<int64_t>(params.mStakedNodeId.value()));
   }
 
   if (params.mDeclineStakingReward.has_value())
@@ -138,13 +143,15 @@ nlohmann::json updateAccount(const UpdateAccountParams& params)
 
   if (params.mAutoRenewPeriod.has_value())
   {
-    accountUpdateTransaction.setAutoRenewPeriod(std::chrono::seconds(params.mAutoRenewPeriod.value()));
+    accountUpdateTransaction.setAutoRenewPeriod(
+      std::chrono::seconds(Hiero::internal::EntityIdHelper::getNum<int64_t>(params.mAutoRenewPeriod.value())));
   }
 
   if (params.mExpirationTime.has_value())
   {
-    accountUpdateTransaction.setExpirationTime(std::chrono::system_clock::from_time_t(0) +
-                                               std::chrono::seconds(params.mExpirationTime.value()));
+    accountUpdateTransaction.setExpirationTime(
+      std::chrono::system_clock::from_time_t(0) +
+      std::chrono::seconds(Hiero::internal::EntityIdHelper::getNum<int64_t>(params.mExpirationTime.value())));
   }
 
   if (params.mReceiverSignatureRequired.has_value())
@@ -169,7 +176,8 @@ nlohmann::json updateAccount(const UpdateAccountParams& params)
 
   if (params.mStakedNodeId.has_value())
   {
-    accountUpdateTransaction.setStakedNodeId(params.mStakedNodeId.value());
+    accountUpdateTransaction.setStakedNodeId(
+      Hiero::internal::EntityIdHelper::getNum<int64_t>(params.mStakedNodeId.value()));
   }
 
   if (params.mDeclineStakingReward.has_value())


### PR DESCRIPTION
**Description**:
This PR changes the `int64_t` types in `createAccount` and `updateAccount` to `std::string`s as a part of
https://github.com/hiero-ledger/hiero-sdk-tck/issues/284.

**Related issue(s)**:

Fixes #855 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
