### PR TITLE
feat: Added solo mirror node exposed port 5600 and enabled tests

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -180,6 +180,7 @@ jobs:
           solo mirror-node deploy -n "${SOLO_NAMESPACE}" --pinger true
           kubectl port-forward $(cut -d' ' -f1 <<<$(kubectl get pods -n solo-e2e | grep mirror-rest-)) 5551:5551 -n solo-e2e &
           kubectl port-forward $(cut -d' ' -f1 <<<$(kubectl get pods -n solo-e2e | grep mirror-web)) 8545:8545 -n solo-e2e &
+          kubectl port-forward $(cut -d' ' -f1 <<<$(kubectl get pods -n solo-e2e | grep mirror-grpc)) 5600:5600 -n solo-e2e &
 
       - name: Start CTest suite (Debug)
         run: ${{ steps.cgroup.outputs.exec }} ctest -j 6 -C Debug --test-dir build/${{ matrix.preset }}-debug --output-on-failure

--- a/src/sdk/tests/integration/AddressBookQueryIntegrationTests.cc
+++ b/src/sdk/tests/integration/AddressBookQueryIntegrationTests.cc
@@ -13,7 +13,7 @@ class AddressBookQueryIntegrationTests : public BaseIntegrationTest
 };
 
 //-----
-TEST_F(AddressBookQueryIntegrationTests, DISABLED_ExecuteAddressBookQuery)
+TEST_F(AddressBookQueryIntegrationTests, ExecuteAddressBookQuery)
 {
   // Given / When / Then
   EXPECT_NO_THROW(const NodeAddressBook nodeAddressBook =

--- a/src/sdk/tests/integration/TopicMessageQueryIntegrationTests.cc
+++ b/src/sdk/tests/integration/TopicMessageQueryIntegrationTests.cc
@@ -22,8 +22,7 @@ class TopicMessageQueryIntegrationTests : public BaseIntegrationTest
 };
 
 //-----
-// Disabled until Solo triage
-TEST_F(TopicMessageQueryIntegrationTests, DISABLED_ExecuteTopicMessageQuery)
+TEST_F(TopicMessageQueryIntegrationTests, ExecuteTopicMessageQuery)
 {
   // Given
   const std::string topicMessage = "Hello from HCS!";
@@ -80,8 +79,7 @@ TEST_F(TopicMessageQueryIntegrationTests, DISABLED_ExecuteTopicMessageQuery)
 }
 
 //-----
-// Disabled until Solo triage
-TEST_F(TopicMessageQueryIntegrationTests, DISABLED_CanReceiveLargeTopicMessage)
+TEST_F(TopicMessageQueryIntegrationTests, CanReceiveLargeTopicMessage)
 {
   // Given
   const std::string topicMessage =


### PR DESCRIPTION
**Description**:

* Enables `AddressBookQueryIntegrationTests` as now supported after exposing mirror-node grpc port `5600`.
* Enables `TopicMessageQueryIntegrationTests` as now working against 0.59.0.
* HIP-423 Features will still be disabled as they seem not enabled at this point.

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-sdk-cpp/issues/891

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
