### PR TITLE
chore: Update protobuf definitions link

### DIFF
--- a/HieroApi.cmake
+++ b/HieroApi.cmake
@@ -7,7 +7,7 @@ endif ()
 # Fetch the protobuf definitions
 FetchContent_Declare(
         HProto
-        GIT_REPOSITORY https://github.com/hashgraph/hedera-services.git
+        GIT_REPOSITORY https://github.com/hiero-ledger/hiero-consensus-node.git
         GIT_TAG ${HAPI_VERSION_TAG}
 )
 set(FETCHCONTENT_QUIET OFF)


### PR DESCRIPTION
**Description**:

`HieroApi.cmake` now refers to the Hiero consensus-node repo.

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-sdk-cpp/issues/896

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
