### PR TITLE
chore(HIP-1021): Reenable

### DIFF
--- a/src/sdk/main/src/TopicCreateTransaction.cc
+++ b/src/sdk/main/src/TopicCreateTransaction.cc
@@ -126,8 +126,7 @@ void TopicCreateTransaction::addToBody(proto::TransactionBody& body) const
 {
   body.set_allocated_consensuscreatetopic(build());
 
-  if (body.has_transactionid() && !body.consensuscreatetopic().has_autorenewaccount() &&
-      body.consensuscreatetopic().has_adminkey())
+  if (body.has_transactionid() && !body.consensuscreatetopic().has_autorenewaccount())
   {
     std::unique_ptr<proto::AccountID> accountId = std::make_unique<proto::AccountID>(body.transactionid().accountid());
     body.mutable_consensuscreatetopic()->set_allocated_autorenewaccount(accountId.release());


### PR DESCRIPTION
**Description**:

Due to `mainnet` being on `>=0.60` the feature previously introduced must be reenabled.

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-sdk-cpp/issues/948

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
