### PR TITLE
feat: Add transaction size API

### DIFF
--- a/src/sdk/main/include/Transaction.h
+++ b/src/sdk/main/include/Transaction.h
@@ -316,6 +316,20 @@ public:
    */
   [[nodiscard]] std::optional<bool> getRegenerateTransactionIdPolicy() const;
 
+  /**
+   * Get the size of the Transaction protobuf object for this Transaction.
+   *
+   * @return The byte size of the Transaction protobuf object for this Transaction.
+   */
+  [[nodiscard]] size_t getTransactionSize() const;
+
+  /**
+   * Get the size of the TransactionBody protobuf object for this Transaction.
+   *
+   * @return The byte size of the TransactionBody protobuf object for this Transaction.
+   */
+  [[nodiscard]] size_t getTransactionBodySize() const;
+
 protected:
   /**
    * Dummy transaction and account IDs used to assist in deserializing incomplete Transactions.

--- a/src/sdk/main/src/Transaction.cc
+++ b/src/sdk/main/src/Transaction.cc
@@ -755,6 +755,28 @@ std::optional<bool> Transaction<SdkRequestType>::getRegenerateTransactionIdPolic
 
 //-----
 template<typename SdkRequestType>
+size_t Transaction<SdkRequestType>::getTransactionSize() const
+{
+  if (!isFrozen())
+  {
+    throw IllegalStateException("Transaction must be frozen in order to calculate its size.");
+  }
+  return makeRequest(0).ByteSizeLong();
+}
+
+//-----
+template<typename SdkRequestType>
+size_t Transaction<SdkRequestType>::getTransactionBodySize() const
+{
+  if (!isFrozen())
+  {
+    throw IllegalStateException("Transaction must be frozen in order to calculate its body size.");
+  }
+  return mImpl->mSourceTransactionBody.ByteSizeLong();
+}
+
+//-----
+template<typename SdkRequestType>
 Transaction<SdkRequestType>::Transaction()
   : Executable<SdkRequestType, proto::Transaction, proto::TransactionResponse, TransactionResponse>()
   , mImpl(std::make_unique<TransactionImpl>())

--- a/src/sdk/tests/integration/BaseIntegrationTest.h
+++ b/src/sdk/tests/integration/BaseIntegrationTest.h
@@ -16,13 +16,47 @@ namespace Hiero
 class BaseIntegrationTest : public testing::Test
 {
 protected:
+  /** Get the test Client used in integration tests.
+   *
+   * @return The test Client.
+   */
   [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
+
+  /** Get the test file content used in integration tests.
+   *
+   * @return The test file content.
+   */
   [[nodiscard]] inline const std::vector<std::byte>& getTestFileContent() const { return mFileContent; }
+
+  /** Get tge test smart contract bytecode used in integration tests.
+   *
+   * @return The test smart contract bytecode in hex format.
+   */
   [[nodiscard]] inline const std::string& getTestSmartContractBytecode() const { return mTestContractBytecodeHex; }
+
+  /** Get the test big contents used in integration tests.
+   *
+   * @return The test big contents.
+   */
   [[nodiscard]] inline const std::string& getTestBigContents() const { return mBigContents; }
 
+  /** Set the test Client operator with the given account ID and private key.
+   *
+   * @param accountId The account ID of the operator.
+   * @param privateKey The private key of the operator.
+   */
   void setTestClientOperator(const AccountId& accountId, const std::shared_ptr<PrivateKey>& privateKey);
+
+  /** Set the test Client operator with the default test account ID and private key.
+   *
+   * This method is used to set the operator for integration tests.
+   */
   void setDefaultTestClientOperator();
+
+  /** Set up the test environment.
+   *
+   * This method is called before each test case to initialize the test Client and file content.
+   */
   void SetUp() override;
 
 private:

--- a/src/sdk/tests/unit/BaseUnitTest.cc
+++ b/src/sdk/tests/unit/BaseUnitTest.cc
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "BaseUnitTest.h"
+
+namespace Hiero
+{
+//-----
+void BaseUnitTest::SetUp()
+{
+  // Set up the test Client mock with a default operator account ID and private key.
+  mClientMock = Client::forNetwork({
+    { "0.client.mock.com:50211", AccountId(3ULL) },
+    { "1.client.mock.com:50211", AccountId(4ULL) }
+  });
+  mClientMock.setMirrorNetwork({ { "0.mirror.mock.com:5551" } });
+  mClientMock.setOperator(mOperatorMockAccountId, mOperatorMockPrivateKey);
+
+  // Set up a mock TransactionId with a valid start time.
+  mTransactionIdMock = TransactionId::withValidStart(mOperatorMockAccountId, std::chrono::system_clock::now());
+}
+
+} // namespace Hiero

--- a/src/sdk/tests/unit/BaseUnitTest.h
+++ b/src/sdk/tests/unit/BaseUnitTest.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef HIERO_SDK_CPP_BASE_UNIT_TEST_H_
+#define HIERO_SDK_CPP_BASE_UNIT_TEST_H_
+
+#include "AccountId.h"
+#include "Client.h"
+#include "ED25519PrivateKey.h"
+#include "PrivateKey.h"
+#include "TransactionId.h"
+
+#include <gtest/gtest.h>
+#include <string>
+
+namespace Hiero
+{
+
+class BaseUnitTest : public testing::Test
+{
+protected:
+  /**  Get the test Client mock used in unit tests.
+   *
+   * @return The test Client mock.
+   */
+  [[nodiscard]] inline const Client& getTestClientMock() const { return mClientMock; }
+
+  /**  Get a transaction ID with a valid start time.
+   *
+   * @return A TransactionId with a valid start time.
+   */
+  [[nodiscard]] inline const TransactionId& getTestTransactionIdMock() const { return mTransactionIdMock; }
+
+  /** Set up the test environment.
+   *
+   * This method is called before each test case to initialize the test Client and file content.
+   */
+  void SetUp() override;
+
+private:
+  Client mClientMock;
+  TransactionId mTransactionIdMock;
+  const AccountId mOperatorMockAccountId = AccountId::fromString("0.0.2");
+  const std::shared_ptr<PrivateKey> mOperatorMockPrivateKey = ED25519PrivateKey::fromString(
+    "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137");
+};
+
+} // namespace Hiero
+
+#endif // HIERO_SDK_CPP_BASE_UNIT_TEST_H_

--- a/src/sdk/tests/unit/CMakeLists.txt
+++ b/src/sdk/tests/unit/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(${TEST_PROJECT_NAME}
         AccountUpdateTransactionUnitTests.cc
         AddressBookQueryUnitTests.cc
         AssessedCustomFeesUnitTests.cc
+        BaseUnitTest.cc
         ChunkedTransactionUnitTests.cc
         ClientUnitTests.cc
         ContractByteCodeQueryUnitTests.cc

--- a/src/sdk/tests/unit/TransactionUnitTests.cc
+++ b/src/sdk/tests/unit/TransactionUnitTests.cc
@@ -4,6 +4,7 @@
 #include "AccountCreateTransaction.h"
 #include "AccountDeleteTransaction.h"
 #include "AccountUpdateTransaction.h"
+#include "BaseUnitTest.h"
 #include "ContractCreateTransaction.h"
 #include "ContractDeleteTransaction.h"
 #include "ContractExecuteTransaction.h"
@@ -42,6 +43,7 @@
 #include "TransactionType.h"
 #include "TransferTransaction.h"
 #include "WrappedTransaction.h"
+#include "exceptions/IllegalStateException.h"
 #include "impl/Utilities.h"
 
 #include <gtest/gtest.h>
@@ -52,7 +54,7 @@
 
 using namespace Hiero;
 
-class TransactionUnitTests : public ::testing::Test
+class TransactionUnitTests : public BaseUnitTest
 {
 };
 
@@ -2718,4 +2720,103 @@ TEST_F(TransactionUnitTests, TransferTransactionFromTransactionListBytes)
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TRANSFER_TRANSACTION);
   EXPECT_NE(wrappedTx.getTransaction<TransferTransaction>(), nullptr);
+}
+
+//-----
+TEST_F(TransactionUnitTests, GetTransactionAndTransactionBodySize)
+{
+  // Given
+  AccountCreateTransaction accountCreateTransaction;
+  ASSERT_NO_THROW(accountCreateTransaction = AccountCreateTransaction()
+                                               .setTransactionMemo("Test Memo")
+                                               .setNodeAccountIds({ AccountId(3) })
+                                               .setTransactionId(getTestTransactionIdMock())
+                                               .freezeWith(&getTestClientMock()));
+
+  // When
+  size_t transactionBodySize;
+  ASSERT_NO_THROW(transactionBodySize = accountCreateTransaction.getTransactionBodySize());
+
+  size_t transactionSize;
+  ASSERT_NO_THROW(transactionSize = accountCreateTransaction.getTransactionSize());
+
+  // Then
+  ASSERT_GT(transactionSize, transactionBodySize);
+}
+
+//-----
+TEST_F(TransactionUnitTests, CannotGetTransactionAndTransactionBodySizeWhenNotFrozen)
+{
+  // Given / When
+  AccountCreateTransaction accountCreateTransaction;
+  ASSERT_NO_THROW(accountCreateTransaction = AccountCreateTransaction()
+                                               .setTransactionMemo("Test Memo")
+                                               .setNodeAccountIds({ AccountId(3) })
+                                               .setTransactionId(getTestTransactionIdMock()));
+
+  // Then
+  size_t transactionBodySize;
+  EXPECT_THROW(transactionBodySize = accountCreateTransaction.getTransactionBodySize(), IllegalStateException);
+
+  size_t transactionSize;
+  EXPECT_THROW(transactionSize = accountCreateTransaction.getTransactionSize(), IllegalStateException);
+}
+
+//-----
+TEST_F(TransactionUnitTests, GetTransactionSizeWithSignatures)
+{
+  // Given
+  const std::shared_ptr<ED25519PrivateKey> privateKey = ED25519PrivateKey::generatePrivateKey();
+
+  AccountCreateTransaction accountCreateTransaction;
+  ASSERT_NO_THROW(accountCreateTransaction = AccountCreateTransaction()
+                                               .setTransactionMemo("Test Memo")
+                                               .setNodeAccountIds({ AccountId(3) })
+                                               .setTransactionId(getTestTransactionIdMock())
+                                               .setKey(privateKey->getPublicKey())
+                                               .freezeWith(&getTestClientMock()));
+
+  // When
+  size_t transactionSizeBeforeSign;
+  ASSERT_NO_THROW(transactionSizeBeforeSign = accountCreateTransaction.getTransactionSize());
+
+  ASSERT_NO_THROW(accountCreateTransaction.sign(privateKey));
+
+  size_t transactionSizeAfterSign;
+  ASSERT_NO_THROW(transactionSizeAfterSign = accountCreateTransaction.getTransactionSize());
+
+  // Then
+  ASSERT_GT(transactionSizeAfterSign, transactionSizeBeforeSign);
+}
+
+//-----
+TEST_F(TransactionUnitTests, GetTransactionBodySizeForBigAndSmallData)
+{
+  // Given
+  AccountCreateTransaction bigBodyTransaction;
+  ASSERT_NO_THROW(
+    bigBodyTransaction =
+      AccountCreateTransaction()
+        .setTransactionMemo("This is a very long memo that exceeds the typical size limit for a transaction memo. "
+                            "It is designed to test the handling of larger transaction bodies.")
+        .setNodeAccountIds({ AccountId(3) })
+        .setTransactionId(getTestTransactionIdMock())
+        .freezeWith(&getTestClientMock()));
+
+  AccountCreateTransaction smallBodyTransaction;
+  ASSERT_NO_THROW(smallBodyTransaction = AccountCreateTransaction()
+                                           .setTransactionMemo("memo")
+                                           .setNodeAccountIds({ AccountId(3) })
+                                           .setTransactionId(getTestTransactionIdMock())
+                                           .freezeWith(&getTestClientMock()));
+
+  // When
+  size_t transactionBigBodySize;
+  ASSERT_NO_THROW(transactionBigBodySize = bigBodyTransaction.getTransactionBodySize());
+
+  size_t transactionSmallBodySize;
+  ASSERT_NO_THROW(transactionSmallBodySize = smallBodyTransaction.getTransactionBodySize());
+
+  // Then
+  ASSERT_GT(transactionBigBodySize, transactionSmallBodySize);
 }


### PR DESCRIPTION
**Description**:

Introduces:
*  `transactionSize` and `transactionBodySize` selectors
*  `BaseUnitTest` class with mocked `Client`
*  Transaction size unit tests.
*  Added some missing docs for `BaseIntegrationTest`

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-sdk-cpp/issues/951

**Notes for reviewer**:

I saw that we already have functions for getting `ChunkedTransaction` size so I left out implementing those. 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
