### PR TITLE
feat: Add cancelAirdrop TCK functionality

### DIFF
--- a/src/tck/include/token/TokenService.h
+++ b/src/tck/include/token/TokenService.h
@@ -12,6 +12,7 @@ namespace Hiero::TCK::TokenService
 struct AirdropTokenParams;
 struct AssociateTokenParams;
 struct BurnTokenParams;
+struct CancelAirdropParams;
 struct CreateTokenParams;
 struct DeleteTokenParams;
 struct DissociateTokenParams;
@@ -49,6 +50,14 @@ nlohmann::json associateToken(const AssociateTokenParams& params);
  * @return A JSON response containing the status of the token burn and the new total supply of the token.
  */
 nlohmann::json burnToken(const BurnTokenParams& params);
+
+/**
+ * Cancel an airdrop.
+ *
+ * @param params The parameters to use to cancel an airdrop.
+ * @return A JSON response containing the status of the airdrop cancel.
+ */
+nlohmann::json cancelAirdrop(const CancelAirdropParams& params);
 
 /**
  * Create a token.

--- a/src/tck/include/token/params/CancelAirdropParams.h
+++ b/src/tck/include/token/params/CancelAirdropParams.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef HIERO_TCK_CPP_CANCEL_AIRDROP_PARAMS_H_
+#define HIERO_TCK_CPP_CANCEL_AIRDROP_PARAMS_H_
+
+#include "common/CommonTransactionParams.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace Hiero::TCK::TokenService
+{
+/**
+ * Struct to hold the arguments for a `cancelAirdrop` JSON-RPC method call.
+ */
+struct CancelAirdropParams
+{
+  /**
+   * The ID of the sender of the airdrop.
+   */
+  std::string mSenderAccountId;
+
+  /**
+   * The ID of the sender receiver of the airdrop.
+   */
+  std::string mReceiverAccountId;
+
+  /**
+   * The ID of the token being airdropped.
+   */
+  std::string mTokenId;
+
+  /**
+   * The serial numbers of the NFTs being airdropped.
+   */
+  std::optional<std::vector<std::string>> mSerialNumbers;
+
+  /**
+   * Any parameters common to all transaction types.
+   */
+  std::optional<CommonTransactionParams> mCommonTxParams;
+};
+
+} // namespace Hiero::TCK::TokenService
+
+namespace nlohmann
+{
+/**
+ * JSON serializer template specialization required to convert CancelAirdropParams arguments properly.
+ */
+template<>
+struct [[maybe_unused]] adl_serializer<Hiero::TCK::TokenService::CancelAirdropParams>
+{
+  /**
+   * Convert a JSON object to a CancelAirdropParams.
+   *
+   * @param jsonFrom The JSON object with which to fill the CancelAirdropParams.
+   * @param params   The CancelAirdropParams to fill with the JSON object.
+   */
+  static void from_json(const json& jsonFrom, Hiero::TCK::TokenService::CancelAirdropParams& params)
+  {
+    params.mSenderAccountId = Hiero::TCK::getRequiredJsonParameter<std::string>(jsonFrom, "senderAccountId");
+    params.mReceiverAccountId = Hiero::TCK::getRequiredJsonParameter<std::string>(jsonFrom, "receiverAccountId");
+    params.mTokenId = Hiero::TCK::getRequiredJsonParameter<std::string>(jsonFrom, "tokenId");
+    params.mSerialNumbers = Hiero::TCK::getOptionalJsonParameter<std::vector<std::string>>(jsonFrom, "serialNumbers");
+    params.mCommonTxParams =
+      Hiero::TCK::getOptionalJsonParameter<Hiero::TCK::CommonTransactionParams>(jsonFrom, "commonTransactionParams");
+  }
+};
+
+} // namespace nlohmann
+
+#endif // HIERO_TCK_CPP_AIRDROP_TOKEN_PARAMS_H_

--- a/src/tck/src/TckServer.cc
+++ b/src/tck/src/TckServer.cc
@@ -15,6 +15,7 @@
 #include "token/params/AirdropTokenParams.h"
 #include "token/params/AssociateTokenParams.h"
 #include "token/params/BurnTokenParams.h"
+#include "token/params/CancelAirdropParams.h"
 #include "token/params/CreateTokenParams.h"
 #include "token/params/DeleteTokenParams.h"
 #include "token/params/DissociateTokenParams.h"
@@ -377,6 +378,8 @@ template TckServer::MethodHandle TckServer::getHandle<TokenService::AssociateTok
   nlohmann::json (*method)(const TokenService::AssociateTokenParams&));
 template TckServer::MethodHandle TckServer::getHandle<TokenService::BurnTokenParams>(
   nlohmann::json (*method)(const TokenService::BurnTokenParams&));
+template TckServer::MethodHandle TckServer::getHandle<TokenService::CancelAirdropParams>(
+  nlohmann::json (*method)(const TokenService::CancelAirdropParams&));
 template TckServer::MethodHandle TckServer::getHandle<TokenService::CreateTokenParams>(
   nlohmann::json (*method)(const TokenService::CreateTokenParams&));
 template TckServer::MethodHandle TckServer::getHandle<TokenService::DeleteTokenParams>(

--- a/src/tck/src/main.cc
+++ b/src/tck/src/main.cc
@@ -34,6 +34,7 @@ int main(int argc, char** argv)
   tckServer.add("airdropToken", tckServer.getHandle(&TokenService::airdropToken));
   tckServer.add("associateToken", tckServer.getHandle(&TokenService::associateToken));
   tckServer.add("burnToken", tckServer.getHandle(&TokenService::burnToken));
+  tckServer.add("cancelAirdrop", tckServer.getHandle(&TokenService::cancelAirdrop));
   tckServer.add("createToken", tckServer.getHandle(&TokenService::createToken));
   tckServer.add("deleteToken", tckServer.getHandle(&TokenService::deleteToken));
   tckServer.add("dissociateToken", tckServer.getHandle(&TokenService::dissociateToken));

--- a/src/tck/src/token/TokenService.cc
+++ b/src/tck/src/token/TokenService.cc
@@ -5,6 +5,7 @@
 #include "token/params/AirdropTokenParams.h"
 #include "token/params/AssociateTokenParams.h"
 #include "token/params/BurnTokenParams.h"
+#include "token/params/CancelAirdropParams.h"
 #include "token/params/CreateTokenParams.h"
 #include "token/params/DeleteTokenParams.h"
 #include "token/params/DissociateTokenParams.h"
@@ -26,6 +27,7 @@
 #include <TokenAirdropTransaction.h>
 #include <TokenAssociateTransaction.h>
 #include <TokenBurnTransaction.h>
+#include <TokenCancelAirdropTransaction.h>
 #include <TokenCreateTransaction.h>
 #include <TokenDeleteTransaction.h>
 #include <TokenDissociateTransaction.h>
@@ -201,6 +203,40 @@ nlohmann::json burnToken(const BurnTokenParams& params)
   return {
     {"status",          gStatusToString.at(txReceipt.mStatus)            },
     { "newTotalSupply", std::to_string(txReceipt.mNewTotalSupply.value())}
+  };
+}
+
+//-----
+nlohmann::json cancelAirdrop(const CancelAirdropParams& params)
+{
+  TokenCancelAirdropTransaction tokenCancelAirdropTransaction;
+  tokenCancelAirdropTransaction.setGrpcDeadline(SdkClient::DEFAULT_TCK_REQUEST_TIMEOUT);
+
+  PendingAirdropId pendingAirdropId;
+  pendingAirdropId.mSender = AccountId::fromString(params.mSenderAccountId);
+  pendingAirdropId.mReceiver = AccountId::fromString(params.mReceiverAccountId);
+
+  const TokenId tokenId = TokenId::fromString(params.mTokenId);
+
+  if (params.mSerialNumbers.has_value())
+  {
+    std::vector<PendingAirdropId> nftAirdrops;
+    for (const auto& serialNumber : params.mSerialNumbers.value())
+    {
+      nftAirdrops.push_back(pendingAirdropId);
+      nftAirdrops.back().mNft = NftId(tokenId, Hiero::internal::EntityIdHelper::getNum(serialNumber));
+    }
+  }
+  else
+  {
+    pendingAirdropId.mFt = tokenId;
+    tokenCancelAirdropTransaction.setPendingAirdrops({ pendingAirdropId });
+  }
+
+  return {
+    {"status",
+     gStatusToString.at(
+        tokenCancelAirdropTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient()).mStatus)}
   };
 }
 


### PR DESCRIPTION
**Description**:
This PR adds the `cancelAirdrop` JSON-RPC endpoint for the TCK.

WAIT TO REVIEW UNTIL MULTIPLE AIRDROPS CAN BE CANCELLED.

**Related issue(s)**:

Fixes #964 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
