### PR TITLE
feat: Introduce CustomFeeLimits for ScheduledTransactions

### DIFF
--- a/src/sdk/main/include/TopicMessageSubmitTransaction.h
+++ b/src/sdk/main/include/TopicMessageSubmitTransaction.h
@@ -115,7 +115,7 @@ public:
    *
    * @return A vector containing the current custom fee limits.
    */
-  [[nodiscard]] std::vector<CustomFeeLimit> getCustomFeeLimits() const;
+  [[nodiscard]] inline std::vector<CustomFeeLimit> getCustomFeeLimits() const { return mCustomFeeLimits; }
 
 private:
   friend class WrappedTransaction;

--- a/src/sdk/main/src/TopicMessageSubmitTransaction.cc
+++ b/src/sdk/main/src/TopicMessageSubmitTransaction.cc
@@ -96,6 +96,12 @@ void TopicMessageSubmitTransaction::validateChecksums(const Client& client) cons
 void TopicMessageSubmitTransaction::addToBody(proto::TransactionBody& body) const
 {
   body.set_allocated_consensussubmitmessage(build());
+
+  // Add custom fee limits to the transaction body
+  for (const auto& fee : mCustomFeeLimits)
+  {
+    body.mutable_max_custom_fees()->AddAllocated(fee.toProtobuf().release());
+  }
 }
 
 //-----
@@ -126,6 +132,13 @@ void TopicMessageSubmitTransaction::initFromSourceTransactionBody()
       body.has_topicid())
   {
     mTopicId = TopicId::fromProtobuf(body.topicid());
+  }
+
+  // Read custom fee limits from the transaction body
+  mCustomFeeLimits.clear();
+  for (const auto& protoFeeLimit : transactionBody.max_custom_fees())
+  {
+    mCustomFeeLimits.push_back(CustomFeeLimit::fromProtobuf(protoFeeLimit));
   }
 
   // Construct the data from the various Transaction protobuf objects.

--- a/src/sdk/main/src/WrappedTransaction.cc
+++ b/src/sdk/main/src/WrappedTransaction.cc
@@ -213,6 +213,12 @@ WrappedTransaction WrappedTransaction::fromProtobuf(const proto::SchedulableTran
   txBody.set_memo(proto.memo());
   txBody.set_transactionfee(proto.transactionfee());
 
+  // Copy custom fee limits from the schedulable transaction body
+  if (proto.max_custom_fees_size() > 0)
+  {
+    *txBody.mutable_max_custom_fees() = proto.max_custom_fees();
+  }
+
   if (proto.has_cryptoapproveallowance())
   {
     *txBody.mutable_cryptoapproveallowance() = proto.cryptoapproveallowance();
@@ -1027,6 +1033,12 @@ std::unique_ptr<proto::SchedulableTransactionBody> WrappedTransaction::toSchedul
   auto schedulableTxBody = std::make_unique<proto::SchedulableTransactionBody>();
   schedulableTxBody->set_transactionfee(txBody.transactionfee());
   schedulableTxBody->set_memo(txBody.memo());
+
+  // Copy custom fee limits from the transaction body
+  if (txBody.max_custom_fees_size() > 0)
+  {
+    *schedulableTxBody->mutable_max_custom_fees() = txBody.max_custom_fees();
+  }
 
   if (txBody.has_cryptoapproveallowance())
   {


### PR DESCRIPTION
**Description**:

Adds support for CustomFeeLimits for ScheduledTransactions

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-sdk-cpp/issues/990

**Notes for reviewer**:

!! This PR can not be e2e tested at this point as there are no available images with the enabled functionality in solo/local-node. We need to add tests at a later point so keeping in draft.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
