### PR TITLE
ci: Bump Solo-Action version

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Prepare Hiero Solo
         id: solo
-        uses: hiero-ledger/hiero-solo-action@71219540ac7f578e6ea4fc3c17575c0295e56163 # v0.9
+        uses: hiero-ledger/hiero-solo-action@10ec96a107b8d2f5cd26b3e7ab47e65407b5c462 # v0.11.0
         with:
           installMirrorNode: true
           hieroVersion: v0.61.4


### PR DESCRIPTION
**Description**:

Bumps solo-action to newest release v0.11.0 in order to access Solo features in v0.41.0.

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-sdk-cpp/issues/998

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
