### PR TITLE
chore: Update CODEOWNERS for CMake and root files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,21 +15,21 @@
 /.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
 
 # Cmake project files and inline plugins
-**/.clang*                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
-**/.clang-format                                @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
-**/.clang-tidy                                  @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
-**/CMakeLists.txt                               @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
-**/CMakePresets.json                            @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
+**/.clang*                                      @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
+**/.clang-format                                @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
+**/.clang-tidy                                  @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
+**/CMakeLists.txt                               @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
+**/CMakePresets.json                            @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
 
 # Codacy Tool Configurations
 /config/                                        @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
 .remarkrc                                       @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
-/CODEOWNERS                                     @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
+/CODEOWNERS                                     @hiero-ledger/github-maintainers
 
 # Protect the repository root files
-/README.md                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
+/README.md                                      @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
 **/LICENSE                                      @hiero-ledger/github-maintainers @hiero-ledger/tsc
 
 # CodeCov configuration


### PR DESCRIPTION
**Description**:

This pull request updates the `.github/CODEOWNERS` file to revise team ownership assignments for several key project files. The main changes focus on reducing the scope of ownership for C++-related files and the repository root files, ensuring that only the most relevant teams are listed as code owners.

Ownership assignment updates:

* C++ project files (`.clang*`, `.clang-format`, `.clang-tidy`, `CMakeLists.txt`, `CMakePresets.json`): Removed `@hiero-ledger/github-maintainers` from ownership, leaving only `@hiero-ledger/hiero-sdk-cpp-maintainers` and `@hiero-ledger/hiero-sdk-cpp-committers` as owners.

* Repository root files:
  * [`CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L18-R32): Now only requires approval from `@hiero-ledger/github-maintainers`, removing other teams.
  * [`README.md`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L18-R32): Ownership shifted to `@hiero-ledger/hiero-sdk-cpp-maintainers` and `@hiero-ledger/hiero-sdk-cpp-committers`, removing `@hiero-ledger/github-maintainers`.

**Related issue(s)**:

Fixes #744
