### PR TITLE
docs: Fix misleading key type comment in CreateAccountExample.cpp

### DIFF
--- a/src/sdk/examples/CreateAccountExample.cpp
+++ b/src/sdk/examples/CreateAccountExample.cpp
@@ -23,7 +23,7 @@ int main(int argc, char** argv)
   Client client = Client::forTestnet();
   client.setOperator(operatorAccountId, operatorPrivateKey);
 
-  // Generate a ED25519 private, public key pair
+  // Generate an ECDSA secp256k1 private, public key pair
   const std::unique_ptr<PrivateKey> privateKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
   const std::shared_ptr<PublicKey> publicKey = privateKey->getPublicKey();
 


### PR DESCRIPTION
Fixes #1074

**Description**
This PR updates the comment in `src/sdk/examples/CreateAccountExample.cpp` to accurately reflect the code.
* **Original:** Stated the key pair was ED25519.
* **Updated:** Corrected to state the key pair is ECDSA secp256k1.

**Changes**
* Updated line 26 to match the `ECDSAsecp256k1PrivateKey::generatePrivateKey()` call.

I have verified the change and signed the commit as requested.