### PR TITLE
Fix typo in TransferTransaction NFT documentation

### DIFF
--- a/src/sdk/main/include/TransferTransaction.h
+++ b/src/sdk/main/include/TransferTransaction.h
@@ -92,7 +92,7 @@ public:
    *
    * @param nftId             The ID of the NFT associated with this transfer.
    * @param senderAccountId   The ID of the account sending the NFT.
-   * @param receiverAccountId The ID of the receiving sending the NFT.
+   * @param receiverAccountId The ID of the account receiving the NFT.
    * @return A reference to this TransferTransaction object with the newly-added NFT transfer.
    * @throws IllegalStateException If this TransferTransaction is frozen.
    */
@@ -144,7 +144,7 @@ public:
    *
    * @param nftId             The ID of the NFT associated with this transfer.
    * @param senderAccountId   The ID of the account sending the NFT.
-   * @param receiverAccountId The ID of the receiving sending the NFT.
+   * @param receiverAccountId The ID of the account receiving the NFT.
    * @return A reference to this TransferTransaction object with the newly-added approved NFT transfer.
    * @throws IllegalStateException If this TransferTransaction is frozen.
    */


### PR DESCRIPTION
Fixes documentation typo in addNftTransfer and addApprovedNftTransfer.

Replaces "receiving sending" with "account receiving".

No logic or API changes.

Fixes #1075
