### PR TITLE
docs: fix documentation errors in TokenId.h

### DIFF
--- a/src/sdk/main/include/TokenId.h
+++ b/src/sdk/main/include/TokenId.h
@@ -100,7 +100,7 @@ public:
    * Construct an NftId from this TokenId and a serial number.
    *
    * @param serial The serial number of the NftId.
-   * @param The constructed NftId.
+   * @return The constructed NftId.
    */
   [[nodiscard]] NftId nft(uint64_t serial) const;
 
@@ -134,9 +134,9 @@ public:
   [[nodiscard]] std::vector<std::byte> toBytes() const;
 
   /**
-   * Get the checksum of this ContractId.
+   * Get the checksum of this TokenId.
    *
-   * @return The checksum of this ContractId.
+   * @return The checksum of this TokenId.
    */
   [[nodiscard]] inline std::string getChecksum() const { return mChecksum; }
 
@@ -157,7 +157,7 @@ public:
 
 private:
   /**
-   * The checksum of this TokenIds.
+   * The checksum of this TokenId.
    */
   mutable std::string mChecksum;
 };


### PR DESCRIPTION
Fix documentation errors in TokenId.h for better clarity and accuracy.

Correct missing @return tag in nft() method

Replace "ContractId" with "TokenId" in getChecksum() documentation

Fix plural typo "TokenIds" → "TokenId" in private member comment

Related issue(s):
Fixes #1095

Notes for reviewer:

Only documentation comments updated, no logic or API changes.

Verified that the file compiles and existing tests pass.

Checklist

 Documented (Code comments)

 Tested (No runtime/compile issues, existing CI passes)