### PR TITLE
ci: enable TCK unit tests in Linux CI builds

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -158,7 +158,7 @@ jobs:
           VCPKG_BINARY_SOURCES: clear
         run: |
           echo "::group::Configure Project"
-          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-debug -DBUILD_TESTS=ON
+          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-debug -DBUILD_TESTS=ON -DBUILD_TCK_TESTS=ON
           echo "::endgroup::"
 
           echo "::group::Build Project"
@@ -171,7 +171,7 @@ jobs:
           VCPKG_BINARY_SOURCES: clear
         run: |
           echo "::group::Configure Project"
-          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-release -DBUILD_TESTS=ON
+          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-release -DBUILD_TESTS=ON -DBUILD_TCK_TESTS=ON
           echo "::endgroup::"
 
           echo "::group::Build Project"


### PR DESCRIPTION
Enable TCK unit tests in Linux CI builds.

* Add -DBUILD_TCK_TESTS=ON to Linux Debug CMake configure step
* Add -DBUILD_TCK_TESTS=ON to Linux Release CMake configure step
* Ensure TCK unit tests are built and executed during CI runs

Fixes #1112 

Scope limited to .github/workflows/zxc-build-library.yaml.

This change enables TCK unit tests in Linux Debug and Release builds.
Windows and macOS workflows are unchanged.

No functional SDK code was modified.

**Checklist**

- [] Documented (Code comments, README, etc.)
- [] Tested (unit, integration, etc.)
