### PR TITLE
fix: change singer to signer in comment of Transaction.h line 561

### DIFF
--- a/src/sdk/main/include/Transaction.h
+++ b/src/sdk/main/include/Transaction.h
@@ -558,7 +558,7 @@ private:
    * function was generated.
    *
    * @param publicKey  The PublicKey to add.
-   * @param signer     The singer function to add.
+   * @param signer     The signer function to add.
    * @param privateKey The PrivateKey to add.
    * @return A reference to this derived Transaction object with the newly-set "signature(s)".
    */


### PR DESCRIPTION
The line src/sdk/main/include/Transaction.h contained a typo in a comment on line 561 where signer was miswritten as singer. I have fixed this typo.
Fixes #1116

<img width="559" height="21" alt="image" src="https://github.com/user-attachments/assets/ddec9a90-f741-45d2-999f-9112797806cb" />