### PR TITLE
add missing Linux dependencies to README #1146

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The C++ SDK for interacting with a [Hiero](https://hiero.org) network.
 
 - **ninja**
   - macOS: `brew install ninja`
-  - Linux: `apt-get install ninja-build`
+  - Linux: `apt-get install ninja-build zip unzip linux-libc-dev`
 - **pkg-config**
   - macOS: `brew install pkg-config`
   - Linux: `apt-get install pkg-config`


### PR DESCRIPTION
This PR updates the Linux prerequisites section in the README by adding zip, unzip, and linux-libc-dev to the installation instructions.
