### PR TITLE
docs: fix grammar in documentation comments

### DIFF
--- a/src/sdk/main/include/PrivateKey.h
+++ b/src/sdk/main/include/PrivateKey.h
@@ -47,7 +47,7 @@ public:
    * Construct a PrivateKey object from a hex-encoded, DER-encoded key string.
    *
    * @param key The DER-encoded hex string from which to construct a PrivateKey.
-   * @return A pointer to an PrivateKey representing the input DER-encoded hex string.
+   * @return A pointer to a PrivateKey representing the input DER-encoded hex string.
    * @throws BadKeyException If the private key type (ED25519 or ECDSAsecp256k1) is unable to be determined or realized
    *                         from the input hex string.
    */

--- a/src/sdk/main/include/PublicKey.h
+++ b/src/sdk/main/include/PublicKey.h
@@ -45,7 +45,7 @@ public:
    * Construct a PublicKey object from a hex-encoded, DER-encoded key string.
    *
    * @param key The DER-encoded hex string from which to construct a PublicKey.
-   * @return A pointer to an PublicKey representing the input DER-encoded hex string.
+   * @return A pointer to a PublicKey representing the input DER-encoded hex string.
    * @throws BadKeyException If the public key type (ED25519 or ECDSAsecp256k1) is unable to be determined or realized
    *                         from the input hex string.
    */


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

Replace "an" with "a" in `@return` documentation for `fromStringDer()` in `PublicKey.h` and `PrivateKey.h`.

**Related issue(s)**:

Fixes #1138

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)