### PR TITLE
Fix namespace comment in FreezeTokenParams.h

### DIFF
--- a/src/tck/include/token/params/FreezeTokenParams.h
+++ b/src/tck/include/token/params/FreezeTokenParams.h
@@ -32,7 +32,7 @@ struct FreezeTokenParams
   std::optional<CommonTransactionParams> mCommonTxParams;
 };
 
-} // namespace Hedera::TCK::TokenService
+} // namespace Hiero::TCK::TokenService
 
 namespace nlohmann
 {


### PR DESCRIPTION
This PR fixes an inconsistent namespace closing comment in FreezeTokenParams.h.

Closes #1142
