### PR TITLE
Fix typo in BurnTokenParams.h

### DIFF
--- a/src/tck/include/token/params/BurnTokenParams.h
+++ b/src/tck/include/token/params/BurnTokenParams.h
@@ -37,7 +37,7 @@ struct BurnTokenParams
   std::optional<CommonTransactionParams> mCommonTxParams;
 };
 
-} // namespace Hedera::TCK::TokenService
+} // namespace Hiero::TCK::TokenService
 
 namespace nlohmann
 {


### PR DESCRIPTION
**Description**:

Fix typo in the line 40 of the BurnTokenParams.h file
