### PR TITLE
docs: fix namespace closing comment in MintTokenParams.h

### DIFF
--- a/src/tck/include/token/params/MintTokenParams.h
+++ b/src/tck/include/token/params/MintTokenParams.h
@@ -37,7 +37,7 @@ struct MintTokenParams
   std::optional<CommonTransactionParams> mCommonTxParams;
 };
 
-} // namespace Hedera::TCK::TokenService
+} // namespace Hiero::TCK::TokenService
 
 namespace nlohmann
 {


### PR DESCRIPTION
- Updated a single namespace closing comment in MintTokenParams.h




- Fixes #1141 