### PR TITLE
fix: resolve documentation typos in token transaction header files

### DIFF
--- a/src/sdk/main/include/TokenDeleteTransaction.h
+++ b/src/sdk/main/include/TokenDeleteTransaction.h
@@ -17,7 +17,7 @@ namespace Hiero
 {
 /**
  * Deleting a token marks a token as deleted, though it will remain in the ledger. The operation must be signed by the
- * specified admin key of the token. If the admin key is not set, the transaction will result in TOKEN_IS_IMMUTABlE.
+ * specified admin key of the token. If the admin key is not set, the transaction will result in TOKEN_IS_IMMUTABLE.
  * Once deleted, update, mint, burn, wipe, freeze, unfreeze, grant KYC, revoke KYC and token transfer transactions will
  * resolve to TOKEN_WAS_DELETED.
  *
@@ -61,7 +61,7 @@ public:
   /**
    * Get the ID of the token this TokenDeleteTransaction is currently configured to delete.
    *
-   * @return The ID of the account this TokenDeleteTransaction is currently configured to delete. Uninitialized if no
+   * @return The ID of the token this TokenDeleteTransaction is currently configured to delete. Uninitialized if no
    *         token ID has been set.
    */
   [[nodiscard]] inline std::optional<TokenId> getTokenId() const { return mTokenId; }

--- a/src/sdk/main/include/TokenUpdateTransaction.h
+++ b/src/sdk/main/include/TokenUpdateTransaction.h
@@ -26,7 +26,7 @@ namespace Hiero
  * any of the token properties. The admin key can update existing keys, but cannot add new keys if they were not set
  * during the creation of the token. If no value is given for a field, that field is left unchanged. For an immutable
  * token (that is, a token created without an admin key), only the expiry may be updated. Setting any other field, in
- * that case, will cause the transaction status to resolve to TOKEN_IS_IMMUTABlE.
+ * that case, will cause the transaction status to resolve to TOKEN_IS_IMMUTABLE.
  *
  * Transaction Signing Requirements
  *  - Admin key is required to sign to update any token properties.


### PR DESCRIPTION
- fixed address documentation typos in token transaction headers.
 

-  Fixes #1182  