### PR TITLE
fix: unify GTest to vcpkg across all platforms

### DIFF
--- a/src/sdk/tests/CMakeLists.txt
+++ b/src/sdk/tests/CMakeLists.txt
@@ -1,16 +1,5 @@
-if (APPLE OR WIN32)
-    include(FetchContent)
-    FetchContent_Declare(googletest
-            GIT_REPOSITORY https://github.com/google/googletest.git
-            GIT_TAG release-1.12.1)
-
-    set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(googletest)
-    include(googletest)
-else ()
-    find_package(GTest CONFIG REQUIRED)
-    include(GoogleTest)
-endif ()
+find_package(GTest CONFIG REQUIRED)
+include(GoogleTest)
 
 add_subdirectory(unit)
 add_subdirectory(integration)

--- a/src/sdk/tests/integration/CMakeLists.txt
+++ b/src/sdk/tests/integration/CMakeLists.txt
@@ -1,6 +1,3 @@
-find_package(GTest CONFIG REQUIRED)
-include(GoogleTest)
-
 set(TEST_PROJECT_NAME ${PROJECT_NAME}-integration-tests)
 add_executable(${TEST_PROJECT_NAME}
         AccountAllowanceApproveTransactionIntegrationTests.cc

--- a/src/sdk/tests/unit/CMakeLists.txt
+++ b/src/sdk/tests/unit/CMakeLists.txt
@@ -1,6 +1,3 @@
-find_package(GTest CONFIG REQUIRED)
-include(GoogleTest)
-
 set(TEST_PROJECT_NAME ${PROJECT_NAME}-unit-tests)
 add_executable(${TEST_PROJECT_NAME}
         AccountAllowanceApproveTransactionUnitTests.cc

--- a/src/tck/tests/CMakeLists.txt
+++ b/src/tck/tests/CMakeLists.txt
@@ -1,18 +1,7 @@
 # TCK Tests CMakeLists.txt
 # Sets up Google Test and includes test subdirectories
 
-if (APPLE OR WIN32)
-    include(FetchContent)
-    FetchContent_Declare(googletest
-            GIT_REPOSITORY https://github.com/google/googletest.git
-            GIT_TAG release-1.12.1)
-
-    set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(googletest)
-    include(googletest)
-else ()
-    find_package(GTest CONFIG REQUIRED)
-    include(GoogleTest)
-endif ()
+find_package(GTest CONFIG REQUIRED)
+include(GoogleTest)
 
 add_subdirectory(unit)

--- a/src/tck/tests/unit/CMakeLists.txt
+++ b/src/tck/tests/unit/CMakeLists.txt
@@ -4,8 +4,6 @@
 
 find_package(httplib CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
-find_package(GTest CONFIG REQUIRED)
-include(GoogleTest)
 
 # Set the test executable name
 set(TCK_TEST_NAME ${PROJECT_NAME}-tck-tests)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -42,7 +42,8 @@
       "version>=": "0.14.1"
     },
     {
-      "name": "gtest"
+      "name": "gtest",
+      "version>=": "1.16.0"
     }
   ]
 }


### PR DESCRIPTION
**Description**:
Makes Google Test (GTest) consistent across all platforms

**Related issue(s)**:

Fixes #1184

**Notes for reviewer**:
CI will automatically verify

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
