### PR TITLE
fix: Fixed typo of lenght to length

### DIFF
--- a/src/sdk/main/include/impl/ASN1ECKey.h
+++ b/src/sdk/main/include/impl/ASN1ECKey.h
@@ -8,7 +8,7 @@ namespace Hiero::internal::asn1
 {
 constexpr size_t EC_KEY_LENGTH = 32; // bytes
 // more than this would be a malicious attempt
-constexpr size_t MAX_ENCRYPTED_KEY_LENGHT = 160; // bytes ~ 320 characters
+constexpr size_t MAX_ENCRYPTED_KEY_LENGTH = 160; // bytes ~ 320 characters
 
 /**
  * @class ASN1Key

--- a/src/sdk/main/src/impl/ASN1ECPrivateKey.cc
+++ b/src/sdk/main/src/impl/ASN1ECPrivateKey.cc
@@ -9,7 +9,7 @@ namespace Hiero::internal::asn1
 {
 ASN1ECPrivateKey::ASN1ECPrivateKey(const std::vector<std::byte>& bytes)
 {
-  if (bytes.size() >= MAX_ENCRYPTED_KEY_LENGHT)
+  if (bytes.size() >= MAX_ENCRYPTED_KEY_LENGTH)
   {
     throw BadKeyException("Over maximum possible input bytes for EC Key!");
   }

--- a/src/sdk/main/src/impl/ASN1ECPublicKey.cc
+++ b/src/sdk/main/src/impl/ASN1ECPublicKey.cc
@@ -14,7 +14,7 @@ namespace Hiero::internal::asn1
 {
 ASN1ECPublicKey::ASN1ECPublicKey(const std::vector<std::byte>& bytes)
 {
-  if (bytes.size() >= MAX_ENCRYPTED_KEY_LENGHT)
+  if (bytes.size() >= MAX_ENCRYPTED_KEY_LENGTH)
   {
     throw BadKeyException("Over maximum possible input bytes for EC Key!");
   }

--- a/src/sdk/main/src/impl/ASN1ED25519PrivateKey.cc
+++ b/src/sdk/main/src/impl/ASN1ED25519PrivateKey.cc
@@ -9,7 +9,7 @@ namespace Hiero::internal::asn1
 {
 ASN1ED25519PrivateKey::ASN1ED25519PrivateKey(const std::vector<std::byte>& bytes)
 {
-  if (bytes.size() >= MAX_ENCRYPTED_KEY_LENGHT)
+  if (bytes.size() >= MAX_ENCRYPTED_KEY_LENGTH)
   {
     throw BadKeyException("Over maximum possible input bytes for EC Key!");
   }

--- a/src/sdk/main/src/impl/ASN1ED25519PublicKey.cc
+++ b/src/sdk/main/src/impl/ASN1ED25519PublicKey.cc
@@ -9,7 +9,7 @@ namespace Hiero::internal::asn1
 {
 ASN1ED25519PublicKey::ASN1ED25519PublicKey(const std::vector<std::byte>& bytes)
 {
-  if (bytes.size() >= MAX_ENCRYPTED_KEY_LENGHT)
+  if (bytes.size() >= MAX_ENCRYPTED_KEY_LENGTH)
   {
     throw BadKeyException("Over maximum possible input bytes for EC Key!");
   }


### PR DESCRIPTION
**Description**:
<!--


Add support for ...

* Add config property
* Change column name
* Remove ...
-->
Fix the spelling mistake in the MAX_ENCRYPTED_KEY_LENGHT constant.


**Related issue(s)**: 

Fixes #1214


**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
This PR resolves the beginner issue to fix misspelling of a constant.

Renames MAX_ENCRYPTED_KEY_LENGHT to MAX_ENCRYPTED_KEY_LENGTH in ASN1ECKey.h
Updates all references to the corrected constant name in ASN1ECPrivateKey.cc, ASN1ECPublicKey.cc, ASN1ED25519PrivateKey.cc, and ASN1ED25519PublicKey.cc


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
