### PR TITLE
fix: remove trailing * in AccountAlloeanceSerializedExample.cpp, fixe…

### DIFF
--- a/src/sdk/examples/AccountAllowanceSerializedExample.cpp
+++ b/src/sdk/examples/AccountAllowanceSerializedExample.cpp
@@ -21,7 +21,7 @@
  * - Attempt to exceed the remaining (1 Hbar) allowance (sending 2 Hbar) to demonstrate ledger enforcement.
  * - Modify the allowance to 3 Hbar and successfully re-attempt the (2 Hbar) transfer.
  * - Query account balances to verify the flow of funds.
- * - Clean up the ledger by resetting the allowance and deleting all generated accounts. *
+ * - Clean up the ledger by resetting the allowance and deleting all generated accounts. 
  *
  * This example highlights how transactions can be transported or stored
  * as raw bytes, reconstructed later, and still maintain correctness


### PR DESCRIPTION
…s #1213

**Description**:
remove trailing * in AccountAlloeanceSerializedExample.cpp

**Related issue(s)**:
Fixes #1213 

**Notes for reviewer**:
In the commit comment I accidentally called it a slash rather than a *

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
