### PR TITLE
feat: Add /unassign command to allow contributors to unassign themselves

### DIFF
--- a/.github/scripts/bot-on-comment.js
+++ b/.github/scripts/bot-on-comment.js
@@ -3,12 +3,14 @@
 // bot-on-comment.js
 //
 // Handles issue comment events: reads the comment body, parses commands, and dispatches
-// to the appropriate handler. Implemented commands: /assign (more may be added later).
+// to the appropriate handler. Implemented commands: /assign, /unassign.
 //
 // /assign: see commands/assign.js (skill levels, assignment limits, required labels).
+// /unassign: see commands/unassign.js (authorization, label reversion).
 
 const { createLogger, buildBotContext } = require('./helpers');
 const { handleAssign } = require('./commands/assign');
+const { handleUnassign } = require('./commands/unassign'); 
 
 let logger = createLogger('on-comment');
 
@@ -30,6 +32,10 @@ function parseComment(body) {
   if (/^\s*\/assign\s*$/i.test(body)) {
     logger.log('parseComment: detected /assign');
     return { commands: ['assign'] };
+  }
+  if (/^\s*\/unassign\s*$/i.test(body)) { 
+    logger.log('parseComment: detected /unassign');
+    return { commands: ['unassign'] };
   }
   logger.log('parseComment: no known command', { body: body.substring(0, 80) });
   return { commands: [] };
@@ -70,6 +76,8 @@ module.exports = async ({ github, context }) => {
 
       if (command === 'assign') {
         await handleAssign(botContext);
+      } else if (command === 'unassign') {
+        await handleUnassign(botContext);
       } else {
         logger.log('Unknown command:', command);
       }

--- a/.github/scripts/commands/assign-comments.js
+++ b/.github/scripts/commands/assign-comments.js
@@ -82,6 +82,8 @@ function buildWelcomeComment(username, skillLevel) {
       '',
       'The issue description above has everything you need: implementation steps, contribution workflow, and links to guides. If anything is unclear, just ask — we\'re happy to help.',
       '',
+      'If you realize you cannot complete this issue, simply comment `/unassign` to return it to the community pool.',
+      '',
       'Good luck, and welcome aboard! 🚀',
     ].join('\n');
   }
@@ -89,6 +91,8 @@ function buildWelcomeComment(username, skillLevel) {
     `👋 Hi @${username}, thanks for continuing to contribute to the Hiero C++ SDK! You've been assigned this **${skillDisplayName}** issue. 🙌`,
     '',
     'If this task involves any design decisions or you\'d like early feedback, feel free to share your plan here before diving into the code.',
+    '',
+    'If you realize you cannot complete this issue, simply comment `/unassign` to return it to the pool.',
     '',
     'Good luck! 🚀',
   ].join('\n');

--- a/.github/scripts/commands/unassign-comments.js
+++ b/.github/scripts/commands/unassign-comments.js
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// commands/unassign-comments.js
+//
+// Comment builders for the /unassign command. Pure formatting functions
+// separated from unassignment logic for readability.
+
+const { MAINTAINER_TEAM, LABELS } = require('../helpers');
+
+/**
+ * Builds the comment posted after a successful unassignment.
+ *
+ * @param {string} username - The GitHub username being unassigned.
+ * @returns {string} The formatted Markdown comment body.
+ */
+function buildSuccessfulUnassignComment(username) {
+  return [
+    `👋 Hi @${username}! You have been successfully unassigned from this issue.`,
+    '',
+    `The \`${LABELS.IN_PROGRESS}\` label has been removed, and it is now back to \`${LABELS.READY_FOR_DEV}\` for others to claim. Thanks for letting us know!`,
+  ].join('\n');
+}
+
+/**
+ * Builds the comment posted when a user tries to unassign an issue they don't own.
+ *
+ * @param {string} requesterUsername - The GitHub username who commented /unassign.
+ * @param {string} currentAssignee - The GitHub username of the actual assignee.
+ * @returns {string} The formatted Markdown comment body.
+ */
+function buildNotAssignedToUserComment(requesterUsername, currentAssignee) {
+  const assigneeText = currentAssignee ? `@${currentAssignee}` : 'someone else';
+  return [
+    `⚠️ Hi @${requesterUsername}! You cannot unassign this issue because it is currently assigned to ${assigneeText}.`,
+    '',
+    'Only the current assignee can unassign themselves.',
+  ].join('\n');
+}
+
+/**
+ * Builds the comment posted when the issue has no assignees.
+ *
+ * @param {string} requesterUsername - The GitHub username who commented /unassign.
+ * @returns {string} The formatted Markdown comment body.
+ */
+function buildNoAssigneeComment(requesterUsername) {
+  return [
+    `👋 Hi @${requesterUsername}! This issue doesn't currently have any assignees.`,
+  ].join('\n');
+}
+
+/**
+ * Builds the comment posted when the issue is already closed.
+ *
+ * @param {string} requesterUsername - The GitHub username who commented /unassign.
+ * @returns {string} The formatted Markdown comment body.
+ */
+function buildIssueClosedComment(requesterUsername) {
+  return [
+    `👋 Hi @${requesterUsername}! This issue is already closed, so the \`/unassign\` command cannot be used here.`,
+  ].join('\n');
+}
+
+/**
+ * Builds the comment posted when the unassign API call fails.
+ *
+ * @param {string} requesterUsername - The GitHub username who commented /unassign.
+ * @returns {string} The formatted Markdown comment body.
+ */
+function buildUnassignFailureComment(requesterUsername) {
+  return [
+    `⚠️ Hi @${requesterUsername}! I tried to unassign you, but encountered an unexpected error.`,
+    '',
+    `${MAINTAINER_TEAM} — could you please manually unassign @${requesterUsername}?`,
+  ].join('\n');
+}
+
+module.exports = {
+  buildSuccessfulUnassignComment,
+  buildNotAssignedToUserComment,
+  buildNoAssigneeComment,
+  buildIssueClosedComment,
+  buildUnassignFailureComment,
+};

--- a/.github/scripts/commands/unassign.js
+++ b/.github/scripts/commands/unassign.js
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// commands/unassign.js
+//
+// /unassign command: allows a currently assigned contributor to unassign themselves.
+// Enforces authorization (only assignees can unassign themselves) and reverts
+// status labels back to the community pool.
+
+const {
+  LABELS,
+  ISSUE_STATE,
+  getLogger,
+  hasLabel,
+  addLabels,
+  removeLabel,
+  removeAssignees,
+  postComment,
+} = require('../helpers');
+
+const {
+  buildSuccessfulUnassignComment,
+  buildNotAssignedToUserComment,
+  buildNoAssigneeComment,
+  buildIssueClosedComment,
+  buildUnassignFailureComment,
+} = require('./unassign-comments');
+
+// Delegate to the active logger set by the dispatcher.
+const logger = {
+  log: (...args) => getLogger().log(...args),
+  error: (...args) => getLogger().error(...args),
+};
+
+/**
+ * Main handler for the /unassign command. Runs the following gates in order:
+ *
+ * 1. Is the issue already closed? -> issue-closed comment.
+ * 2. Does the issue have no assignees? -> no-assignee comment.
+ * 3. Is the commenter not the current assignee? -> unauthorized comment.
+ *
+ * On success: removes the user as an assignee, reverts the "in progress"
+ * label to "ready for dev", and posts an acknowledgment comment.
+ *
+ * @param {{ github: object, owner: string, repo: string, number: number,
+ * issue: object, comment: { user: { login: string } } }} botContext
+ * @returns {Promise<void>}
+ */
+async function handleUnassign(botContext) {
+  const requesterUsername = botContext.comment.user.login;
+  const issue = botContext.issue;
+
+  // GATE 1: Issue is closed
+  if (issue.state === ISSUE_STATE.CLOSED) {
+    logger.log('Exit: issue is closed');
+    await postComment(botContext, buildIssueClosedComment(requesterUsername));
+    return;
+  }
+
+  const assignees = issue.assignees || [];
+
+  // GATE 2: No one is assigned at all
+  if (assignees.length === 0) {
+    logger.log('Exit: issue has no assignees');
+    await postComment(botContext, buildNoAssigneeComment(requesterUsername));
+    return;
+  }
+
+  // GATE 3: Authorization check (case-insensitive)
+  const isAssigned = assignees.some(
+    (a) => (a?.login || '').toLowerCase() === requesterUsername.toLowerCase()
+  );
+  if (!isAssigned) {
+    logger.log(`Exit: @${requesterUsername} is not assigned to this issue`);
+    const currentAssignee = assignees[0]?.login; // Grab the actual assignee for the message
+    await postComment(botContext, buildNotAssignedToUserComment(requesterUsername, currentAssignee));
+    return;
+  }
+
+  // ACTION 1: Remove the assignee
+  logger.log(`Unassigning @${requesterUsername}`);
+  const removeResult = await removeAssignees(botContext, [requesterUsername]);
+  if (!removeResult.success) {
+    await postComment(botContext, buildUnassignFailureComment(requesterUsername));
+    return;
+  }
+
+  // ACTION 2: Label Swapping (Mirroring assign.js style - no stale checks)
+  logger.log(`Swapping labels: removing ${LABELS.IN_PROGRESS}, adding ${LABELS.READY_FOR_DEV}`);
+  
+  const removeLabelResult = await removeLabel(botContext, LABELS.IN_PROGRESS);
+  if (!removeLabelResult.success) {
+    logger.error(`Failed to remove ${LABELS.IN_PROGRESS}: ${removeLabelResult.error}`);
+  }
+
+  const addLabelResult = await addLabels(botContext, [LABELS.READY_FOR_DEV]);
+  if (!addLabelResult.success) {
+    logger.error(`Failed to add ${LABELS.READY_FOR_DEV}: ${addLabelResult.error}`);
+  }
+
+  // ACTION 3: Post success acknowledgment
+  await postComment(botContext, buildSuccessfulUnassignComment(requesterUsername));
+  logger.log(`Successfully unassigned @${requesterUsername} and reverted labels`);
+}
+
+module.exports = { handleUnassign };

--- a/.github/scripts/helpers/api.js
+++ b/.github/scripts/helpers/api.js
@@ -188,6 +188,38 @@ async function addAssignees(botContext, assignees) {
 }
 
 /**
+ * Safely removes assignees from an issue or PR.
+ * @param {object} botContext - Bot context (github, owner, repo, number).
+ * @param {string[]} assignees - Array of usernames to remove.
+ * @returns {Promise<{success: boolean, error?: string}>} - Result object.
+ */
+async function removeAssignees(botContext, assignees) {
+  if (!Array.isArray(assignees)) {
+    return { success: false, error: 'assignees must be an array' };
+  }
+
+  try {
+    for (let i = 0; i < assignees.length; i++) {
+      requireSafeUsername(assignees[i], `assignees[${i}]`);
+    }
+
+    await botContext.github.rest.issues.removeAssignees({
+      owner: botContext.owner,
+      repo: botContext.repo,
+      issue_number: botContext.number,
+      assignees,
+    });
+
+    getLogger().log(`Removed assignees: ${assignees.join(', ')}`);
+    return { success: true };
+  } catch (error) {
+    getLogger().error(`Could not remove assignees "${assignees.join(', ')}": ${error.message}`);
+    return { success: false, error: error.message };
+  }
+}
+
+
+/**
  * Safely posts a comment on an issue or PR.
  * @param {object} botContext - Bot context (github, owner, repo, number).
  * @param {string} body - The comment body.
@@ -437,6 +469,7 @@ module.exports = {
   addLabels,
   removeLabel,
   addAssignees,
+  removeAssignees,
   postComment,
   hasLabel,
   postOrUpdateComment,

--- a/.github/scripts/tests/test-assign-bot.js
+++ b/.github/scripts/tests/test-assign-bot.js
@@ -178,6 +178,8 @@ You've been assigned this **Good First Issue**, and the **Good First Issue Suppo
 
 The issue description above has everything you need: implementation steps, contribution workflow, and links to guides. If anything is unclear, just ask — we're happy to help.
 
+If you realize you cannot complete this issue, simply comment \`/unassign\` to return it to the community pool.
+
 Good luck, and welcome aboard! 🚀`,
     ],
   },
@@ -210,6 +212,8 @@ Good luck, and welcome aboard! 🚀`,
       `👋 Hi @experienced-contributor, thanks for continuing to contribute to the Hiero C++ SDK! You've been assigned this **Beginner** issue. 🙌
 
 If this task involves any design decisions or you'd like early feedback, feel free to share your plan here before diving into the code.
+
+If you realize you cannot complete this issue, simply comment \`/unassign\` to return it to the pool.
 
 Good luck! 🚀`,
     ],
@@ -244,6 +248,8 @@ Good luck! 🚀`,
 
 If this task involves any design decisions or you'd like early feedback, feel free to share your plan here before diving into the code.
 
+If you realize you cannot complete this issue, simply comment \`/unassign\` to return it to the pool.
+
 Good luck! 🚀`,
     ],
   },
@@ -276,6 +282,8 @@ Good luck! 🚀`,
       `👋 Hi @senior-contributor, thanks for continuing to contribute to the Hiero C++ SDK! You've been assigned this **Advanced** issue. 🙌
 
 If this task involves any design decisions or you'd like early feedback, feel free to share your plan here before diving into the code.
+
+If you realize you cannot complete this issue, simply comment \`/unassign\` to return it to the pool.
 
 Good luck! 🚀`,
     ],
@@ -311,7 +319,7 @@ Good luck! 🚀`,
     },
     expectedAssignee: 'bypass-user-1',
     expectedComments: [
-      `👋 Hi @bypass-user-1, thanks for continuing to contribute to the Hiero C++ SDK! You've been assigned this **Beginner** issue. 🙌\n\nIf this task involves any design decisions or you'd like early feedback, feel free to share your plan here before diving into the code.\n\nGood luck! 🚀`,
+      `👋 Hi @bypass-user-1, thanks for continuing to contribute to the Hiero C++ SDK! You've been assigned this **Beginner** issue. 🙌\n\nIf this task involves any design decisions or you'd like early feedback, feel free to share your plan here before diving into the code.\n\nIf you realize you cannot complete this issue, simply comment \`/unassign\` to return it to the pool.\n\nGood luck! 🚀`,
     ],
   },
 
@@ -340,7 +348,7 @@ Good luck! 🚀`,
     },
     expectedAssignee: 'bypass-user-2',
     expectedComments: [
-      `👋 Hi @bypass-user-2, thanks for continuing to contribute to the Hiero C++ SDK! You've been assigned this **Beginner** issue. 🙌\n\nIf this task involves any design decisions or you'd like early feedback, feel free to share your plan here before diving into the code.\n\nGood luck! 🚀`,
+      `👋 Hi @bypass-user-2, thanks for continuing to contribute to the Hiero C++ SDK! You've been assigned this **Beginner** issue. 🙌\n\nIf this task involves any design decisions or you'd like early feedback, feel free to share your plan here before diving into the code.\n\nIf you realize you cannot complete this issue, simply comment \`/unassign\` to return it to the pool.\n\nGood luck! 🚀`,
     ],
   },
 
@@ -749,6 +757,8 @@ You've been assigned this **Good First Issue**, and the **Good First Issue Suppo
 
 The issue description above has everything you need: implementation steps, contribution workflow, and links to guides. If anything is unclear, just ask — we're happy to help.
 
+If you realize you cannot complete this issue, simply comment \`/unassign\` to return it to the community pool.
+
 Good luck, and welcome aboard! 🚀`,
     ],
   },
@@ -786,6 +796,8 @@ Good luck, and welcome aboard! 🚀`,
 You've been assigned this **Good First Issue**, and the **Good First Issue Support Team** (@hiero-ledger/hiero-sdk-good-first-issue-support) is ready to help you succeed.
 
 The issue description above has everything you need: implementation steps, contribution workflow, and links to guides. If anything is unclear, just ask — we're happy to help.
+
+If you realize you cannot complete this issue, simply comment \`/unassign\` to return it to the community pool.
 
 Good luck, and welcome aboard! 🚀`,
     ],
@@ -925,6 +937,8 @@ Error details: Simulated assignment failure`,
 You've been assigned this **Good First Issue**, and the **Good First Issue Support Team** (@hiero-ledger/hiero-sdk-good-first-issue-support) is ready to help you succeed.
 
 The issue description above has everything you need: implementation steps, contribution workflow, and links to guides. If anything is unclear, just ask — we're happy to help.
+
+If you realize you cannot complete this issue, simply comment \`/unassign\` to return it to the community pool.
 
 Good luck, and welcome aboard! 🚀`,
       `⚠️ @partially-lucky has been successfully assigned to this issue, but I encountered an error updating the labels.

--- a/.github/scripts/tests/test-unassign-bot.js
+++ b/.github/scripts/tests/test-unassign-bot.js
@@ -1,0 +1,500 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// tests/test-unassign-bot.js
+//
+// Local test script for the /unassign command in bot-on-comment.js.
+// Run with: node .github/scripts/tests/test-unassign-bot.js
+//
+// This script mocks the GitHub API and runs various test scenarios
+// to verify the /unassign command behaves correctly.
+
+const { LABELS, ISSUE_STATE } = require('../helpers');
+const script = require('../bot-on-comment.js');
+const { verifyComments, runTestSuite } = require('./test-utils'); 
+
+// =============================================================================
+// MOCK GITHUB API
+// =============================================================================
+
+/**
+ * Creates a mock GitHub API client for testing.
+ * Tracks all calls made and optionally simulates API failures.
+ *
+ * @param {object} options
+ * @param {boolean} [options.removeAssigneesShouldFail=false]
+ * @param {boolean} [options.removeLabelShouldFail=false]
+ * @param {boolean} [options.addLabelShouldFail=false]
+ * @returns {{ calls: object, rest: object }}
+ */
+function createMockGithub(options = {}) {
+  const {
+    removeAssigneesShouldFail = false,
+    removeLabelShouldFail     = false,
+    addLabelShouldFail        = false,
+  } = options;
+
+  const calls = {
+    comments:         [],
+    assigneesRemoved: [],
+    labelsAdded:      [],
+    labelsRemoved:    [],
+    reactions:        [],
+  };
+
+  return {
+    calls,
+    rest: {
+      reactions: {
+        createForIssueComment: async (params) => {
+          calls.reactions.push({ commentId: params.comment_id, content: params.content });
+          console.log(`\n👍 REACTION ADDED: ${params.content}`);
+        },
+      },
+      issues: {
+        createComment: async (params) => {
+          calls.comments.push(params.body);
+          console.log('\n📝 COMMENT POSTED:');
+          console.log('─'.repeat(60));
+          console.log(params.body);
+          console.log('─'.repeat(60));
+        },
+        removeAssignees: async (params) => {
+          if (removeAssigneesShouldFail) throw new Error('Simulated remove assignees failure');
+          calls.assigneesRemoved.push(...params.assignees);
+          console.log(`\n✅ UNASSIGNED: ${params.assignees.join(', ')}`);
+        },
+        addLabels: async (params) => {
+          if (addLabelShouldFail) throw new Error('Simulated add label failure');
+          calls.labelsAdded.push(...params.labels);
+          console.log(`\n🏷️  LABEL ADDED: ${params.labels.join(', ')}`);
+        },
+        removeLabel: async (params) => {
+          if (removeLabelShouldFail) throw new Error('Simulated remove label failure');
+          calls.labelsRemoved.push(params.name);
+          console.log(`\n🏷️  LABEL REMOVED: ${params.name}`);
+        },
+      },
+    },
+  };
+}
+
+// =============================================================================
+// TEST SCENARIOS
+// =============================================================================
+
+const scenarios = [
+  // ---------------------------------------------------------------------------
+  // HAPPY PATHS
+  // ---------------------------------------------------------------------------
+  {
+    name:        'Happy Path - Unassign Success',
+    description: 'Current assignee successfully unassigns themselves; labels swap correctly',
+    context: {
+      eventName: 'issue_comment',
+      payload: {
+        issue: {
+          number:    100,
+          state:     ISSUE_STATE.OPEN,
+          assignees: [{ login: 'active-contributor' }],
+          labels:    [{ name: LABELS.IN_PROGRESS }],
+        },
+        comment: {
+          id:   1001,
+          body: '/unassign',
+          user: { login: 'active-contributor', type: 'User' },
+        },
+      },
+      repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-cpp' },
+    },
+    githubOptions:           {},
+    expectedAssigneeRemoved: 'active-contributor',
+    expectedLabelRemoved:    LABELS.IN_PROGRESS,
+    expectedLabelAdded:      LABELS.READY_FOR_DEV,
+    expectedComments: [
+      `👋 Hi @active-contributor! You have been successfully unassigned from this issue.\n\nThe \`${LABELS.IN_PROGRESS}\` label has been removed, and it is now back to \`${LABELS.READY_FOR_DEV}\` for others to claim. Thanks for letting us know!`,
+    ],
+  },
+  {
+    name:        'Happy Path - Case-Insensitive Username',
+    description: 'Unassign succeeds even when stored login casing differs from commenter casing',
+    context: {
+      eventName: 'issue_comment',
+      payload: {
+        issue: {
+          number:    106,
+          state:     ISSUE_STATE.OPEN,
+          assignees: [{ login: 'Active-Contributor' }],
+          labels:    [{ name: LABELS.IN_PROGRESS }],
+        },
+        comment: {
+          id:   1007,
+          body: '/unassign',
+          user: { login: 'active-contributor', type: 'User' },
+        },
+      },
+      repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-cpp' },
+    },
+    githubOptions:           {},
+    expectedAssigneeRemoved: 'active-contributor',
+    expectedLabelRemoved:    LABELS.IN_PROGRESS,
+    expectedLabelAdded:      LABELS.READY_FOR_DEV,
+    expectedComments: [
+      `👋 Hi @active-contributor! You have been successfully unassigned from this issue.\n\nThe \`${LABELS.IN_PROGRESS}\` label has been removed, and it is now back to \`${LABELS.READY_FOR_DEV}\` for others to claim. Thanks for letting us know!`,
+    ],
+  },
+  {
+    name:        'Happy Path - Command Casing and Whitespace',
+    description: 'Command successfully routes even with trailing spaces and uppercase letters',
+    context: {
+      eventName: 'issue_comment',
+      payload: {
+        issue: {
+          number:    110,
+          state:     ISSUE_STATE.OPEN,
+          assignees: [{ login: 'active-contributor' }],
+          labels:    [{ name: LABELS.IN_PROGRESS }],
+        },
+        comment: {
+          id:   1011,
+          body: '   /UNASSIGN   ',
+          user: { login: 'active-contributor', type: 'User' },
+        },
+      },
+      repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-cpp' },
+    },
+    githubOptions:           {},
+    expectedAssigneeRemoved: 'active-contributor',
+    expectedLabelRemoved:    LABELS.IN_PROGRESS,
+    expectedLabelAdded:      LABELS.READY_FOR_DEV,
+    expectedComments: [
+      `👋 Hi @active-contributor! You have been successfully unassigned from this issue.\n\nThe \`${LABELS.IN_PROGRESS}\` label has been removed, and it is now back to \`${LABELS.READY_FOR_DEV}\` for others to claim. Thanks for letting us know!`,
+    ],
+  },
+  {
+    name:        'Happy Path - IN_PROGRESS Label Already Missing',
+    description: 'Unassign succeeds if a maintainer manually removed IN_PROGRESS; READY_FOR_DEV is still added',
+    context: {
+      eventName: 'issue_comment',
+      payload: {
+        issue: {
+          number:    107,
+          state:     ISSUE_STATE.OPEN,
+          assignees: [{ login: 'active-contributor' }],
+          labels:    [],
+        },
+        comment: {
+          id:   1008,
+          body: '/unassign',
+          user: { login: 'active-contributor', type: 'User' },
+        },
+      },
+      repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-cpp' },
+    },
+    githubOptions:           {},
+    expectedAssigneeRemoved: 'active-contributor',
+    expectedLabelRemoved:    LABELS.IN_PROGRESS, 
+    expectedLabelAdded:      LABELS.READY_FOR_DEV,
+    expectedComments: [
+      `👋 Hi @active-contributor! You have been successfully unassigned from this issue.\n\nThe \`${LABELS.IN_PROGRESS}\` label has been removed, and it is now back to \`${LABELS.READY_FOR_DEV}\` for others to claim. Thanks for letting us know!`,
+    ],
+  },
+
+  // ---------------------------------------------------------------------------
+  // VALIDATION FAILURES
+  // ---------------------------------------------------------------------------
+  {
+    name:        'Validation - Not Assigned to Requester',
+    description: 'User tries to unassign an issue assigned to someone else; gets auth error',
+    context: {
+      eventName: 'issue_comment',
+      payload: {
+        issue: {
+          number:    101,
+          state:     ISSUE_STATE.OPEN,
+          assignees: [{ login: 'other-contributor' }],
+          labels:    [{ name: LABELS.IN_PROGRESS }],
+        },
+        comment: {
+          id:   1002,
+          body: '/unassign',
+          user: { login: 'sneaky-user', type: 'User' },
+        },
+      },
+      repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-cpp' },
+    },
+    githubOptions:           {},
+    expectedAssigneeRemoved: null,
+    expectedLabelRemoved:    null,
+    expectedLabelAdded:      null,
+    expectedComments: [
+      `⚠️ Hi @sneaky-user! You cannot unassign this issue because it is currently assigned to @other-contributor.\n\nOnly the current assignee can unassign themselves.`,
+    ],
+  },
+  {
+    name:        'Validation - No Assignees on Issue',
+    description: 'User tries to unassign an issue that has no assignees at all',
+    context: {
+      eventName: 'issue_comment',
+      payload: {
+        issue: {
+          number:    102,
+          state:     ISSUE_STATE.OPEN,
+          assignees: [],
+          labels:    [{ name: LABELS.READY_FOR_DEV }],
+        },
+        comment: {
+          id:   1003,
+          body: '/unassign',
+          user: { login: 'confused-user', type: 'User' },
+        },
+      },
+      repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-cpp' },
+    },
+    githubOptions:           {},
+    expectedAssigneeRemoved: null,
+    expectedLabelRemoved:    null,
+    expectedLabelAdded:      null,
+    expectedComments: [
+      `👋 Hi @confused-user! This issue doesn't currently have any assignees.`,
+    ],
+  },
+  {
+    name:        'Validation - Issue Already Closed',
+    description: 'User tries to unassign from a closed issue; command is rejected',
+    context: {
+      eventName: 'issue_comment',
+      payload: {
+        issue: {
+          number:    103,
+          state:     ISSUE_STATE.CLOSED,
+          assignees: [{ login: 'active-contributor' }],
+          labels:    [{ name: LABELS.IN_PROGRESS }],
+        },
+        comment: {
+          id:   1004,
+          body: '/unassign',
+          user: { login: 'active-contributor', type: 'User' },
+        },
+      },
+      repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-cpp' },
+    },
+    githubOptions:           {},
+    expectedAssigneeRemoved: null,
+    expectedLabelRemoved:    null,
+    expectedLabelAdded:      null,
+    expectedComments: [
+      `👋 Hi @active-contributor! This issue is already closed, so the \`/unassign\` command cannot be used here.`,
+    ],
+  },
+
+  // ---------------------------------------------------------------------------
+  // NO ACTION
+  // ---------------------------------------------------------------------------
+  {
+    name:        'No Action - Regular Comment Ignored',
+    description: 'Non-command comments on assigned issues produce zero API calls',
+    context: {
+      eventName: 'issue_comment',
+      payload: {
+        issue: {
+          number:    109,
+          state:     ISSUE_STATE.OPEN,
+          assignees: [{ login: 'active-contributor' }],
+          labels:    [{ name: LABELS.IN_PROGRESS }],
+        },
+        comment: {
+          id:   1010,
+          body: 'Looking good, will review tomorrow!',
+          user: { login: 'active-contributor', type: 'User' },
+        },
+      },
+      repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-cpp' },
+    },
+    githubOptions:           {},
+    expectedAssigneeRemoved: null,
+    expectedLabelRemoved:    null,
+    expectedLabelAdded:      null,
+    expectedComments:        [],
+  },
+  {
+    name:        'No Action - Bot Comment Ignored',
+    description: 'Bot-authored comments are silently ignored to prevent feedback loops',
+    context: {
+      eventName: 'issue_comment',
+      payload: {
+        issue: {
+          number:    108,
+          state:     ISSUE_STATE.OPEN,
+          assignees: [{ login: 'github-actions[bot]' }],
+          labels:    [{ name: LABELS.IN_PROGRESS }],
+        },
+        comment: {
+          id:   1009,
+          body: '/unassign',
+          user: { login: 'github-actions[bot]', type: 'Bot' },
+        },
+      },
+      repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-cpp' },
+    },
+    githubOptions:           {},
+    expectedAssigneeRemoved: null,
+    expectedLabelRemoved:    null,
+    expectedLabelAdded:      null,
+    expectedComments:        [],
+  },
+
+  // ---------------------------------------------------------------------------
+  // ERROR HANDLING
+  // ---------------------------------------------------------------------------
+  {
+    name:        'Error - removeAssignees API Failure',
+    description: 'GitHub API throws on removeAssignees; failure comment posted, no label changes made',
+    context: {
+      eventName: 'issue_comment',
+      payload: {
+        issue: {
+          number:    104,
+          state:     ISSUE_STATE.OPEN,
+          assignees: [{ login: 'active-contributor' }],
+          labels:    [{ name: LABELS.IN_PROGRESS }],
+        },
+        comment: {
+          id:   1005,
+          body: '/unassign',
+          user: { login: 'active-contributor', type: 'User' },
+        },
+      },
+      repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-cpp' },
+    },
+    githubOptions:           { removeAssigneesShouldFail: true },
+    expectedAssigneeRemoved: null,
+    expectedLabelRemoved:    null,
+    expectedLabelAdded:      null,
+    expectedComments: [
+      `⚠️ Hi @active-contributor! I tried to unassign you, but encountered an unexpected error.\n\n@hiero-ledger/hiero-sdk-cpp-maintainers — could you please manually unassign @active-contributor?`,
+    ],
+  },
+  {
+    name:        'Error - Label Swap API Failure',
+    description: 'Label swap fails after successful unassignment; error logged, success comment still posted',
+    context: {
+      eventName: 'issue_comment',
+      payload: {
+        issue: {
+          number:    105,
+          state:     ISSUE_STATE.OPEN,
+          assignees: [{ login: 'active-contributor' }],
+          labels:    [{ name: LABELS.IN_PROGRESS }],
+        },
+        comment: {
+          id:   1006,
+          body: '/unassign',
+          user: { login: 'active-contributor', type: 'User' },
+        },
+      },
+      repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-cpp' },
+    },
+    githubOptions:           { removeLabelShouldFail: true, addLabelShouldFail: true },
+    expectedAssigneeRemoved: 'active-contributor',
+    expectedLabelRemoved:    null,  
+    expectedLabelAdded:      null, 
+    expectedComments: [
+      `👋 Hi @active-contributor! You have been successfully unassigned from this issue.\n\nThe \`${LABELS.IN_PROGRESS}\` label has been removed, and it is now back to \`${LABELS.READY_FOR_DEV}\` for others to claim. Thanks for letting us know!`,
+    ],
+  },
+];
+
+// =============================================================================
+// TEST RUNNER
+// =============================================================================
+
+/**
+ * Runs a single test scenario and returns whether it passed.
+ *
+ * @param {object} scenario - The scenario definition.
+ * @param {number} index - Zero-based scenario index.
+ * @returns {Promise<boolean>}
+ */
+async function runTest(scenario, index) {
+  console.log('\n' + '='.repeat(70));
+  console.log(`TEST ${index + 1}: ${scenario.name}`);
+  console.log(`Description: ${scenario.description}`);
+  console.log('='.repeat(70));
+
+  const mockGithub = createMockGithub(scenario.githubOptions);
+
+  try {
+    await script({ github: mockGithub, context: scenario.context });
+  } catch (error) {
+    console.log(`\n❌ SCRIPT THREW ERROR: ${error.message}`);
+  }
+
+  const results = { passed: true, details: [] };
+
+  // Verify: assignee removed
+  if (scenario.expectedAssigneeRemoved) {
+    if (mockGithub.calls.assigneesRemoved.includes(scenario.expectedAssigneeRemoved)) {
+      results.details.push(`✅ Correctly removed assignee: ${scenario.expectedAssigneeRemoved}`);
+    } else {
+      results.passed = false;
+      results.details.push(`❌ Expected to remove assignee ${scenario.expectedAssigneeRemoved}, got: ${mockGithub.calls.assigneesRemoved.join(', ') || 'none'}`);
+    }
+  } else {
+    if (mockGithub.calls.assigneesRemoved.length === 0) {
+      results.details.push('✅ Correctly did not remove any assignees');
+    } else {
+      results.passed = false;
+      results.details.push(`❌ Should not have removed assignees, but removed: ${mockGithub.calls.assigneesRemoved.join(', ')}`);
+    }
+  }
+
+  // Verify: label removed
+  if ('expectedLabelRemoved' in scenario) {
+    if (scenario.expectedLabelRemoved === null) {
+      if (mockGithub.calls.labelsRemoved.length === 0) {
+        results.details.push('✅ Correctly did not remove any labels');
+      } else {
+        results.passed = false;
+        results.details.push(`❌ Expected NO labels removed, got: ${mockGithub.calls.labelsRemoved.join(', ')}`);
+      }
+    } else {
+      if (mockGithub.calls.labelsRemoved.includes(scenario.expectedLabelRemoved)) {
+        results.details.push(`✅ Correctly removed label: ${scenario.expectedLabelRemoved}`);
+      } else {
+        results.passed = false;
+        results.details.push(`❌ Expected to remove label "${scenario.expectedLabelRemoved}", got: ${mockGithub.calls.labelsRemoved.join(', ') || 'none'}`);
+      }
+    }
+  }
+
+  // Verify: label added
+  if ('expectedLabelAdded' in scenario) {
+    if (scenario.expectedLabelAdded === null) {
+      if (mockGithub.calls.labelsAdded.length === 0) {
+        results.details.push('✅ Correctly did not add any labels');
+      } else {
+        results.passed = false;
+        results.details.push(`❌ Expected NO labels added, got: ${mockGithub.calls.labelsAdded.join(', ')}`);
+      }
+    } else {
+      if (mockGithub.calls.labelsAdded.includes(scenario.expectedLabelAdded)) {
+        results.details.push(`✅ Correctly added label: ${scenario.expectedLabelAdded}`);
+      } else {
+        results.passed = false;
+        results.details.push(`❌ Expected to add label "${scenario.expectedLabelAdded}", got: ${mockGithub.calls.labelsAdded.join(', ') || 'none'}`);
+      }
+    }
+  }
+
+  // Verify: comments
+  const commentResult = verifyComments(scenario.expectedComments || [], mockGithub.calls.comments);
+  if (!commentResult.passed) results.passed = false;
+  results.details.push(...commentResult.details);
+
+  console.log('\n📊 RESULT:');
+  results.details.forEach((d) => console.log(`   ${d}`));
+
+  return results.passed;
+}
+
+runTestSuite('BOT-UNASSIGN-ON-COMMENT TEST SUITE', scenarios, runTest);


### PR DESCRIPTION
**Description**:
Add support for the `/unassign` command to allow contributors to drop issues they no longer have bandwidth for, reducing manual maintainer overhead.

* Add `removeAssignees` helper to `helpers/api.js`
* Implement `/unassign` core logic (`commands/unassign.js`) validating issue state, authorization, and label reversion
* Create dedicated comment builders (`commands/unassign-comments.js`)
* Update `/assign` welcome comment to inform users about the new `/unassign` feature
* Hook `/unassign` route into the comment event dispatcher (`bot-on-comment.js`)

**Related issue(s)**:
Fixes #1239

**Notes for reviewer**:
* Tested locally using a new `test-unassign-bot.js` suite that mirrors the existing custom mock framework.
* The new tests provide full coverage for happy paths, authorization gates (including case-insensitive username matching), edge cases, and API failures.
* API label failures are logged server-side rather than silently failing to ensure system observability.

**Checklist**
- [x] Documented (Code comments)
- [x] Tested (unit, integration, etc.)