### PR TITLE
docs: Reflow docstring in client

### DIFF
--- a/src/sdk/main/include/Client.h
+++ b/src/sdk/main/include/Client.h
@@ -350,10 +350,9 @@ public:
   [[nodiscard]] bool isAutoValidateChecksumsEnabled() const;
 
   /**
-   * Set whether receipt and record queries may fail over to other nodes when the submitting node is unavailable.
-   * When enabled, queries still start with the submitting node and advance
-   * to other eligible nodes in deterministic order only on failure. When
-   * disabled (default), strict single-node pinning is preserved.
+   * Set whether receipt and record queries may fail over to other nodes when the submitting node is unavailable. When
+   * enabled, queries still start with the submitting node and advance to other eligible nodes in deterministic order
+   * only on failure. When disabled (default), strict single-node pinning is preserved.
    *
    * @param allow \c true to allow receipt/record query failover to other nodes.
    * @return A reference to this Client with the newly-set failover policy.


### PR DESCRIPTION
**Description**:
This PR reflows the docstring in the Client.h file.

**Related issue(s)**:

Fixes #1233 
