### PR TITLE
fix: Replace skill ordering in getIssueSkillLevel with SKILL_HIERARCHY

### DIFF
--- a/.github/scripts/commands/assign.js
+++ b/.github/scripts/commands/assign.js
@@ -50,8 +50,7 @@ const logger = {
  * @returns {string|null} The matching LABELS constant (e.g. LABELS.BEGINNER), or null.
  */
 function getIssueSkillLevel(issue) {
-  const skillLevels = [LABELS.GOOD_FIRST_ISSUE, LABELS.BEGINNER, LABELS.INTERMEDIATE, LABELS.ADVANCED];
-  for (const level of skillLevels) {
+  for (const level of SKILL_HIERARCHY) {
     if (hasLabel(issue, level)) return level;
   }
   return null;


### PR DESCRIPTION
**Description**:
removes an inline, locally-defined skill-level ordering array in the GitHub automation script and replaces it with the shared SKILL_HIERARCHY constant.

**Related issue(s)**:
Fixes #1238

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
