### PR TITLE
remove unused hasLabel import in unassign command

### DIFF
--- a/.github/scripts/commands/unassign.js
+++ b/.github/scripts/commands/unassign.js
@@ -10,7 +10,6 @@ const {
   LABELS,
   ISSUE_STATE,
   getLogger,
-  hasLabel,
   addLabels,
   removeLabel,
   removeAssignees,


### PR DESCRIPTION
Remove unused hasLabel import from .github/scripts/commands/unassign.js to clean up the code and reduce confusion for new contributors.

Remove hasLabel from the destructured import at line 13

Preserve all other imports and existing logic

Fixes  #1255