### PR TITLE
docs: fix typo in FileService.h doc comment

### DIFF
--- a/src/tck/include/file/FileService.h
+++ b/src/tck/include/file/FileService.h
@@ -19,7 +19,7 @@ struct UpdateFileParams;
 /**
  * The parameters to use to append a file.
  *
- * @param params The parameters use to append a file.
+ * @param params The parameters to use to append a file.
  * @return A JSON response containing the status of the appended file.
  */
 nlohmann::json appendFile(const AppendFileParams& params);


### PR DESCRIPTION

This PR fixes a small typo in the documentation comment for the appendFile function in 
`src/tck/include/file/FileService.h.`
This has been corrected to:
`@param params The parameters to use to append a file.`

Preserve all other imports and existing logic

Fixes #1257