### PR TITLE
Fix extra space in GetFileContentsParams.h namespace closing comment

### DIFF
--- a/src/tck/include/file/params/GetFileContentsParams.h
+++ b/src/tck/include/file/params/GetFileContentsParams.h
@@ -31,7 +31,7 @@ struct GetFileContentsParams
   std::optional<std::string> mMaxQueryPayment;
 };
 
-} //  namespace Hiero::TCK::FileService
+} // namespace Hiero::TCK::FileService
 
 namespace nlohmann
 {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
Fixing spacing issue in the GetFileContentsParams.h file

**Related issue(s)**:

Fixes #1256

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
