### PR TITLE
fix: updated Fileservice.cc to handle mAdminKeys as value type

### DIFF
--- a/src/tck/src/file/FileService.cc
+++ b/src/tck/src/file/FileService.cc
@@ -118,7 +118,7 @@ nlohmann::json createFile(const CreateFileParams& params)
 
   return {
     {"fileId",  txReceipt.mFileId.value().toString() },
-    {"status", gStatusToString.at(txReceipt.mStatus)}
+    { "status", gStatusToString.at(txReceipt.mStatus)}
   };
 }
 


### PR DESCRIPTION
- Updated FileService.cc to correctly handle `mAdminKeys` as a value type instead of a pointer.





- Fixes #1272