### PR TITLE
ci(bug-fix): Fix workflow version of github-action-markdown-link-check

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Check Markdown links
-      uses: step-security/github-action-markdown-link-check@d952f9c54968d30422678f866a3482759f7c8214 # v1.0.18
+      uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
       with:
         check-modified-files-only: 'yes'
         config-file: '.mlc_config.json'


### PR DESCRIPTION
## Description

This pull request updates the GitHub Actions workflow to use a different action for checking Markdown links. The new action is from a different maintainer and uses a more recent version.

Workflow update:

* Switched the Markdown link checking action in `.github/workflows/flow-pull-request-checks.yaml` from `step-security/github-action-markdown-link-check@v1.0.18` to `tcort/github-action-markdown-link-check@v1.1.2`.

## Related Issue(s)

Fixes #1303 