### PR TITLE
fix(issue-1299): 修复Add operator== to TokenNftTransfer

### DIFF
--- a/src/sdk/main/include/TokenFreezeTransaction.h
+++ b/src/sdk/main/include/TokenFreezeTransaction.h
@@ -85,6 +85,14 @@ public:
    */
   [[nodiscard]] inline TokenId getTokenId() const { return mTokenId; }
 
+ /* if Without
+    operator==, callers must compare NFT transfer objects field - by -
+                        field
+                          .Other SDK value types(e.g.NftId, AccountId, PendingAirdropId)
+                            already implement operator== as a pattern — TokenNftTransfer should follow suit.*/
+  
+  [[nodiscard]] friend bool operator==(const TokenNftTransfer&, const TokenNftTransfer&);
+
 private:
   friend class WrappedTransaction;
 

--- a/src/sdk/main/src/TokenNftTransfer.cc
+++ b/src/sdk/main/src/TokenNftTransfer.cc
@@ -138,4 +138,9 @@ std::ostream& operator<<(std::ostream& os, const TokenNftTransfer& transfer)
   return os;
 }
 
+bool operator==(const TokenNftTransfer& lns, const TokenNftTransfer& rhs)
+{
+  return lns.mNftId == rhs.mNftId && lns.mSenderAccountId == lns.mSenderAccountId &&
+         lns.mReceiverAccountId == rhs.mReceiverAccountId && lns.mIsApproval == rhs.mIsApproval;
+}
 } // namespace Hiero


### PR DESCRIPTION
**Description**:
<!--
This PR adds the operator== overload for the TokenNftTransfer class to resolve issue #1299
-->

**Related issue(s)**:

Fixes #1299 

**Notes for reviewer**:
Please check the logic in `TokenNftTransfer.cc` 'TokenNftTransfer.h'

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
