### PR TITLE
fix: correct typo in TokenWipeTransaction.h documentation

### DIFF
--- a/src/sdk/main/include/TokenWipeTransaction.h
+++ b/src/sdk/main/include/TokenWipeTransaction.h
@@ -195,7 +195,7 @@ private:
   uint64_t mAmount = 0ULL;
 
   /**
-   * Applicable to tokens of type NON_FUNGIBLE_UNIQUE. THe list of serial numbers to be wiped from the account.
+   * Applicable to tokens of type NON_FUNGIBLE_UNIQUE. The list of serial numbers to be wiped from the account.
    */
   std::vector<uint64_t> mSerialNumbers;
 };


### PR DESCRIPTION
**Description**:
Minor documentation fix in the `TokenWipeTransaction` class. 

**Related issue(s)**:

Fixes #1316 

**Checklist**

- [x] Tested (unit, integration, etc.)
