### PR TITLE
docs: fix grammar in TransactionId.h - remove duplicate word 'for'

### DIFF
--- a/src/sdk/main/include/TransactionId.h
+++ b/src/sdk/main/include/TransactionId.h
@@ -361,7 +361,7 @@ public:
   /**
    * Get this TransactionId's nonce value.
    *
-   * @return The nonce value for of TransactionId.
+   * @return The nonce value of TransactionId.
    */
   [[nodiscard]] inline int getNonce() const { return mNonce; }
 


### PR DESCRIPTION
Fixes #1317

Removed the duplicate word 'for' from the doc comment on line 364 
in `src/sdk/main/include/TransactionId.h`.

Before:
* @return The nonce value for of TransactionId.

After:
* @return The nonce value of TransactionId.

This is a one-word removal in a comment. No logic or behavior is affected.