### PR TITLE
docs: expand class documentation in TokenUnpauseTransaction

### DIFF
--- a/src/sdk/main/include/TokenUnpauseTransaction.h
+++ b/src/sdk/main/include/TokenUnpauseTransaction.h
@@ -18,6 +18,17 @@ namespace Hiero
  * in transactions. The token's pause key is required to sign the transaction. Once the unpause transaction is submitted
  * the token pause status is updated to unpause.
  *
+ * Once a token is unpaused, the following operations are restored and can be performed again:
+ *  - Updating the token
+ *  - Transferring the token
+ *  - Transferring any other token where it has its paused key in a custom fee schedule
+ *  - Deleting the token
+ *  - Minting or burning a token
+ *  - Freezing or unfreezing an account that holds the token
+ *  - Enabling or disabling KYC
+ *  - Associating or disassociating a token
+ *  - Wiping a token
+ *
  * Transaction Signing Requirements:
  *  - The pause key of the token.
  *  - Transaction fee payer account key.


### PR DESCRIPTION
**Description**:

Expands the class-level documentation in `TokenUnpauseTransaction.h` to explicitly list the operations that are restored when a token is unpaused, mirroring the documentation format established in `TokenPauseTransaction.h`.

* Add list of restored token operations to `TokenUnpauseTransaction` class comment

**Related issue(s)**:

Fixes #1339

**Notes for reviewer**:
This is a standard documentation update to improve API clarity for first-time users. No SDK logic, behavior, or public APIs were modified. 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
