### PR TITLE
docs: fix wrong class name in TokenCancelAirdropTransaction doc comment

### DIFF
--- a/src/sdk/main/include/TokenCancelAirdropTransaction.h
+++ b/src/sdk/main/include/TokenCancelAirdropTransaction.h
@@ -56,7 +56,7 @@ public:
    * Set the Pending Airdrops to be claimed
    *
    * @param pendingAirdrops The list of Pending Airdrop Id objects
-   * @return A reference to this TokenClaimAirdropTransaction with the newly-set pending airdrops.
+   * @return A reference to this TokenCancelAirdropTransaction with the newly-set pending airdrops.
    */
   TokenCancelAirdropTransaction& setPendingAirdrops(const std::vector<PendingAirdropId>& pendingAirdrops);
 


### PR DESCRIPTION
**Description**:

Fixes a copy-paste error in the `@return` tag within the `setPendingAirdrops()` method doc comment, where `TokenClaimAirdropTransaction` was incorrectly referenced instead of the correct `TokenCancelAirdropTransaction`.

* Update incorrect class name reference in TokenCancelAirdropTransaction

**Related issue(s)**:

Fixes #1340

**Notes for reviewer**:

This is exclusively a documentation fix to eliminate confusion. No logic, SDK behavior, or public APIs were modified. It aligns the class naming in the Javadoc with the file it's actually in.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
