### PR TITLE
test: add ToString test to StakingInfoUnitTests

### DIFF
--- a/src/sdk/tests/unit/StakingInfoUnitTests.cc
+++ b/src/sdk/tests/unit/StakingInfoUnitTests.cc
@@ -2,9 +2,9 @@
 #include "StakingInfo.h"
 #include "impl/TimestampConverter.h"
 
-#include <services/basic_types.pb.h>
 #include <chrono>
 #include <gtest/gtest.h>
+#include <services/basic_types.pb.h>
 
 using namespace Hiero;
 
@@ -57,21 +57,21 @@ TEST_F(StakingInfoUnitTests, FromProtobuf)
 //-----
 TEST_F(StakingInfoUnitTests, ToString)
 {
-    // Given
-    StakingInfo stakingInfo;
-    stakingInfo.mDeclineRewards = getTestDeclineReward();
-    stakingInfo.mStakePeriodStart = getTestStakePeriodStart();
-    stakingInfo.mPendingReward = Hbar(getTestPendingReward(), HbarUnit::TINYBAR());
-    stakingInfo.mStakedToMe = Hbar(getTestStakedToMe(), HbarUnit::TINYBAR());
-    stakingInfo.mStakedNodeId = getTestStakedNodeId();
+  // Given
+  StakingInfo stakingInfo;
+  stakingInfo.mDeclineRewards = getTestDeclineReward();
+  stakingInfo.mStakePeriodStart = getTestStakePeriodStart();
+  stakingInfo.mPendingReward = Hbar(getTestPendingReward(), HbarUnit::TINYBAR());
+  stakingInfo.mStakedToMe = Hbar(getTestStakedToMe(), HbarUnit::TINYBAR());
+  stakingInfo.mStakedNodeId = getTestStakedNodeId();
 
-    // When
-    const std::string result = stakingInfo.toString();
+  // When
+  const std::string result = stakingInfo.toString();
 
-    // Then
-    EXPECT_NE(result.find("mDeclineRewards"), std::string::npos);
-    EXPECT_NE(result.find("mStakePeriodStart"), std::string::npos);
-    EXPECT_NE(result.find("mPendingReward"), std::string::npos);
-    EXPECT_NE(result.find("mStakedToMe"), std::string::npos);
-    EXPECT_NE(result.find(std::to_string(getTestStakedNodeId())), std::string::npos);
+  // Then
+  EXPECT_NE(result.find("mDeclineRewards"), std::string::npos);
+  EXPECT_NE(result.find("mStakePeriodStart"), std::string::npos);
+  EXPECT_NE(result.find("mPendingReward"), std::string::npos);
+  EXPECT_NE(result.find("mStakedToMe"), std::string::npos);
+  EXPECT_NE(result.find(std::to_string(getTestStakedNodeId())), std::string::npos);
 }


### PR DESCRIPTION
**Description**:
<!--
Add a ToString test to StakingInfoUnitTests.cc following the same pattern used in TokenAssociationUnitTests.cc

* Add ToString test to StakingInfoUnitTests.cc
-->

**Related issue(s)**:
Fixes #1353

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)