### PR TITLE
test: add ToString test to SemanticVersionUnitTests

### DIFF
--- a/src/sdk/tests/unit/SemanticVersionUnitTests.cc
+++ b/src/sdk/tests/unit/SemanticVersionUnitTests.cc
@@ -133,4 +133,5 @@ TEST_F(SemanticVersionUnitTests, ToString)
   EXPECT_NE(result.find(std::to_string(getTestMinor())), std::string::npos);
   EXPECT_NE(result.find(std::to_string(getTestPatch())), std::string::npos);
   EXPECT_NE(result.find(getTestPrerelease()), std::string::npos);
+  EXPECT_NE(result.find(getTestBuildMetadata()), std::string::npos);
 }


### PR DESCRIPTION
**Description**:
Add a `ToString` test to `SemanticVersionUnitTests.cc` following the same pattern used in `ExchangeRateUnitTests.cc`.

* Add `ToString` unit test to `SemanticVersionUnitTests.cc`

**Related issue(s)**:
Fixes #1352

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)