### PR TITLE
fix: return null from resolveLinkedIssue when no skill label is present

### DIFF
--- a/.github/scripts/helpers/api.js
+++ b/.github/scripts/helpers/api.js
@@ -554,7 +554,12 @@ async function resolveLinkedIssue(botContext) {
         }
 
         if (issueNumbers.length === 1) {
-            return await fetchIssue(botContext, issueNumbers[0]) || null;
+            const issue = await fetchIssue(botContext, issueNumbers[0]);
+            if (!issue || SKILL_HIERARCHY.findIndex(level => hasLabel(issue, level)) === -1) {
+                getLogger().log('Single linked issue has no skill label', { issueNumber: issueNumbers[0] });
+                return null;
+            }
+            return issue;
         }
 
         const issues = await Promise.all(
@@ -572,6 +577,12 @@ async function resolveLinkedIssue(botContext) {
             const currIndex = SKILL_HIERARCHY.findIndex(level => hasLabel(issue, level));
             return currIndex > bestIndex ? issue : best;
         });
+
+        const selectedIndex = SKILL_HIERARCHY.findIndex(level => hasLabel(selected, level));
+        if (selectedIndex === -1) {
+            getLogger().log('No linked issues have a skill label', { issueNumbers });
+            return null;
+        }
 
         getLogger().log('Multiple linked issues found (using highest level)', {
             issueNumbers,

--- a/.github/scripts/tests/test-api.js
+++ b/.github/scripts/tests/test-api.js
@@ -424,22 +424,22 @@ const unitTests = [
   {
     name: 'resolveLinkedIssue: single linked issue with no skill label → returns null',
     test: async () => {
-        const { botContext } = createMockBotContext({
-            graphql: async () => ({
-                repository: {
-                    pullRequest: {
-                        closingIssuesReferences: {
-                            nodes: [{ number: 7 }],
-                        },
-                    },
-                },
-            }),
-            issues: {
-                7: { number: 7, title: 'Issue 7', labels: [{ name: 'bug' }] },
+      const { botContext } = createMockBotContext({
+        graphql: async () => ({
+          repository: {
+            pullRequest: {
+              closingIssuesReferences: {
+                nodes: [{ number: 7 }],
+              },
             },
-        });
-        const result = await resolveLinkedIssue(botContext);
-        return result === null;
+          },
+        }),
+        issues: {
+          7: { number: 7, title: 'Issue 7', labels: [{ name: 'bug' }] },
+        },
+      });
+      const result = await resolveLinkedIssue(botContext);
+      return result === null;
     },
   },
   {

--- a/.github/scripts/tests/test-api.js
+++ b/.github/scripts/tests/test-api.js
@@ -422,7 +422,7 @@ const unitTests = [
     },
   },
   {
-      name: 'resolveLinkedIssue: single issue, no skill label → returns null',
+      name: 'resolveLinkedIssue: single linked issue with no skill label → returns null',
       test: async () => {
           const { botContext } = createMockBotContext({
               graphql: async () => ({
@@ -443,7 +443,7 @@ const unitTests = [
       },
   },
   {
-    name: 'resolveLinkedIssue: multiple linked issues → returns highest skill level',
+    name: 'resolveLinkedIssue: multiple linked issues with skill label → returns highest skill level',
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -466,7 +466,7 @@ const unitTests = [
     },
   },
   {
-    name: 'resolveLinkedIssue: multiple issues, none with skill label → returns null',
+    name: 'resolveLinkedIssue: multiple linked issues with no skill label → returns null',
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({

--- a/.github/scripts/tests/test-api.js
+++ b/.github/scripts/tests/test-api.js
@@ -422,25 +422,25 @@ const unitTests = [
     },
   },
   {
-      name: 'resolveLinkedIssue: single linked issue with no skill label → returns null',
-      test: async () => {
-          const { botContext } = createMockBotContext({
-              graphql: async () => ({
-                  repository: {
-                      pullRequest: {
-                          closingIssuesReferences: {
-                              nodes: [{ number: 7 }],
-                          },
-                      },
-                  },
-              }),
-              issues: {
-                  7: { number: 7, title: 'Issue 7', labels: [{ name: 'bug' }] },
-              },
-          });
-          const result = await resolveLinkedIssue(botContext);
-          return result === null;
-      },
+    name: 'resolveLinkedIssue: single linked issue with no skill label → returns null',
+    test: async () => {
+        const { botContext } = createMockBotContext({
+            graphql: async () => ({
+                repository: {
+                    pullRequest: {
+                        closingIssuesReferences: {
+                            nodes: [{ number: 7 }],
+                        },
+                    },
+                },
+            }),
+            issues: {
+                7: { number: 7, title: 'Issue 7', labels: [{ name: 'bug' }] },
+            },
+        });
+        const result = await resolveLinkedIssue(botContext);
+        return result === null;
+    },
   },
   {
     name: 'resolveLinkedIssue: multiple linked issues with skill label → returns highest skill level',

--- a/.github/scripts/tests/test-api.js
+++ b/.github/scripts/tests/test-api.js
@@ -404,9 +404,9 @@ const unitTests = [
     },
   },
   {
-    name: 'resolveLinkedIssue: single linked issue → returns it',
+    name: 'resolveLinkedIssue: single linked issue with skill label → returns it',
     test: async () => {
-      const issueData = { number: 10, title: 'Fix bug', labels: [] };
+      const issueData = { number: 10, title: 'Fix bug', labels: [{ name: LABELS.BEGINNER }] };
       const { botContext } = createMockBotContext({
         graphql: async () => ({
           repository: {
@@ -420,6 +420,27 @@ const unitTests = [
       const result = await resolveLinkedIssue(botContext);
       return result !== null && result.number === 10;
     },
+  },
+  {
+      name: 'resolveLinkedIssue: single issue, no skill label → returns null',
+      test: async () => {
+          const { botContext } = createMockBotContext({
+              graphql: async () => ({
+                  repository: {
+                      pullRequest: {
+                          closingIssuesReferences: {
+                              nodes: [{ number: 7 }],
+                          },
+                      },
+                  },
+              }),
+              issues: {
+                  7: { number: 7, title: 'Issue 7', labels: [{ name: 'bug' }] },
+              },
+          });
+          const result = await resolveLinkedIssue(botContext);
+          return result === null;
+      },
   },
   {
     name: 'resolveLinkedIssue: multiple linked issues → returns highest skill level',
@@ -445,7 +466,7 @@ const unitTests = [
     },
   },
   {
-    name: 'resolveLinkedIssue: multiple issues, none with skill label → returns first fetched issue',
+    name: 'resolveLinkedIssue: multiple issues, none with skill label → returns null',
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -463,8 +484,7 @@ const unitTests = [
         },
       });
       const result = await resolveLinkedIssue(botContext);
-      // No skill labels — reduce stays on first, so issue 4
-      return result !== null && result.number === 4;
+      return result === null;
     },
   },
   {


### PR DESCRIPTION
### Summary

#### resolveLinkedIssue skill label enforcement
- Single-issue path now returns null if the issue does not contain a valid skill label
- Multi-issue path now returns null when none of the linked issues contain a skill label
- Issues without skill labels are treated as lowest priority during selection
- Ensures only issues with valid skill levels are considered for downstream logic

#### Test updates
- Updated “single linked issue with skill label → returns it” to use an issue with a valid skill label (LABELS.BEGINNER)
- Updated “multiple linked issues with skill no label→ returns null” to assert result === null
- Added new test: “single linked issue with no skill label → returns null” to cover enforced behavior
- Ensures test suite aligns with stricter skill label contract

### Linked Issues
- Fixes #1360 
