### PR TITLE
refactor: replace inline logger delegation with shared helper in recommend-issues

### DIFF
--- a/.github/scripts/commands/recommend-issues.js
+++ b/.github/scripts/commands/recommend-issues.js
@@ -12,7 +12,6 @@ const {
   SKILL_HIERARCHY,
   hasLabel,
   postComment,
-  getLogger,
   createDelegatingLogger,
 } = require('../helpers');
 

--- a/.github/scripts/commands/recommend-issues.js
+++ b/.github/scripts/commands/recommend-issues.js
@@ -7,19 +7,16 @@
 // suitable issues based on difficulty level.
 
 const {
-    MAINTAINER_TEAM,
-    LABELS,
-    SKILL_HIERARCHY,
-    hasLabel,
-    postComment,
-    getLogger,
+  MAINTAINER_TEAM,
+  LABELS,
+  SKILL_HIERARCHY,
+  hasLabel,
+  postComment,
+  getLogger,
+  createDelegatingLogger,
 } = require('../helpers');
 
-// Logger delegation 
-const logger = {
-    log: (...args) => getLogger().log(...args),
-    error: (...args) => getLogger().error(...args),
-};
+const logger = createDelegatingLogger();
 
 /**
  * Returns the highest difficulty level of an issue based on its labels.


### PR DESCRIPTION
**Description**:
Replace the inline logger delegation in `recommend-issues.js` with the shared `createDelegatingLogger` helper from `helpers/logger.js` to improve consistency and reduce duplication.

* Import `createDelegatingLogger` from `../helpers`
* Replace inline logger object with `createDelegatingLogger()`

**Related issue(s)**:
Fixes #1361

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)