### PR TITLE
Update zxc-build-library.yaml

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -182,7 +182,7 @@ jobs:
         id: solo
         uses: hiero-ledger/hiero-solo-action@692b186bd2e4c8d46b9deb1c067dc6ddcf0abcd7 # v0.18.0
         with:
-          soloVersion: v0.67.0
+          soloVersion: v0.68.0
           installMirrorNode: true
           mirrorNodeVersion: v0.151.0
           hieroVersion: v0.72.0


### PR DESCRIPTION
**Description**:
Updated the single soloVersion value in .github/workflows/zxc-build-library.yaml from v0.67.0 to v0.68.0
**Related issue(s)**:

Fixes #1357

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
