### PR TITLE
refactor: unify getIssueSkillLevel behavior across assign and recomme…

### DIFF
--- a/.github/scripts/commands/assign.js
+++ b/.github/scripts/commands/assign.js
@@ -42,9 +42,6 @@ const {
 const logger = createDelegatingLogger();
 
 /**
- * Counts issues assigned to a user matching specified criteria via GraphQL search.
- * When state is OPEN and no label filter is given, issues with "status: blocked" are
- * excluded from the count (so blocked issues don't penalize the assignment limit).
  * Formats a count for user-facing text when a threshold short-circuit may have
  * capped the value. If count reaches the short-circuit threshold, return an
  * "at least" style display (e.g. "3+") rather than implying an exact value.

--- a/.github/scripts/commands/assign.js
+++ b/.github/scripts/commands/assign.js
@@ -17,6 +17,7 @@ const {
   addAssignees,
   postComment,
   acknowledgeComment,
+  getHighestIssueSkillLevel,
 } = require('../helpers');
 
 const {
@@ -39,21 +40,6 @@ const {
 // Delegate to the active logger set by the dispatcher (bot-on-comment.js).
 // This ensures the correct prefix is used after command parsing.
 const logger = createDelegatingLogger();
-
-/**
- * Returns the skill-level label on an issue, checking in ascending order:
- * Good First Issue -> Beginner -> Intermediate -> Advanced.
- * Returns the first match, or null if the issue has no skill-level label.
- *
- * @param {{ labels: Array<string|{ name: string }> }} issue - The issue object from the GitHub payload.
- * @returns {string|null} The matching LABELS constant (e.g. LABELS.BEGINNER), or null.
- */
-function getIssueSkillLevel(issue) {
-  for (const level of SKILL_HIERARCHY) {
-    if (hasLabel(issue, level)) return level;
-  }
-  return null;
-}
 
 /**
  * Counts issues assigned to a user matching specified criteria via GraphQL search.
@@ -269,7 +255,7 @@ async function validateIssueState(botContext, requesterUsername) {
     return null;
   }
 
-  const skillLevel = getIssueSkillLevel(botContext.issue);
+  const skillLevel = getHighestIssueSkillLevel(botContext.issue);
   if (!skillLevel) {
     logger.log('Exit: issue has no skill level label');
     await postComment(botContext, buildNoSkillLevelComment(requesterUsername));

--- a/.github/scripts/commands/recommend-issues.js
+++ b/.github/scripts/commands/recommend-issues.js
@@ -232,7 +232,7 @@ async function handleRecommendIssues(botContext) {
         return;
     }
 
-    const skillLevel = getIssueSkillLevel(botContext.issue);
+    const skillLevel = getHighestIssueSkillLevel(botContext.issue);
     if (!skillLevel) {
         logger.log('No skill level found, skipping recommendation', {
             issueNumber: botContext.issue?.number,
@@ -279,7 +279,6 @@ async function handleRecommendIssues(botContext) {
 
 module.exports = { 
     handleRecommendIssues,
-    getIssueSkillLevel,
     getNextLevel,
     getFallbackLevel,
     getRecommendedIssues,

--- a/.github/scripts/commands/recommend-issues.js
+++ b/.github/scripts/commands/recommend-issues.js
@@ -13,6 +13,7 @@ const {
     hasLabel,
     postComment,
     getLogger,
+    getHighestIssueSkillLevel,
 } = require('../helpers');
 
 // Logger delegation 
@@ -20,21 +21,6 @@ const logger = {
     log: (...args) => getLogger().log(...args),
     error: (...args) => getLogger().error(...args),
 };
-
-/**
- * Returns the highest difficulty level of an issue based on its labels.
- *
- * Checks labels against SKILL_HIERARCHY in descending order and returns the first match.
- *
- * @param {{ labels: Array<string|{ name: string }> }} issue
- * @returns {string|null} Matching level or null if none found.
- */
-function getIssueSkillLevel(issue) {
-    for (const level of [...SKILL_HIERARCHY].reverse()) {
-        if (hasLabel(issue, level)) return level;
-    }
-    return null;
-}
 
 /**
  * Returns the next difficulty level in the hierarchy.

--- a/.github/scripts/helpers/api.js
+++ b/.github/scripts/helpers/api.js
@@ -597,10 +597,10 @@ async function resolveLinkedIssue(botContext) {
  * @returns {string|null} Matching level or null if none found.
  */
 function getHighestIssueSkillLevel(issue) {
-    for (const level of [...SKILL_HIERARCHY].reverse()) {
-        if (hasLabel(issue, level)) return level;
-    }
-    return null;
+  for (const level of [...SKILL_HIERARCHY].reverse()) {
+    if (hasLabel(issue, level)) return level;
+  }
+  return null;
 }
 
 module.exports = {

--- a/.github/scripts/helpers/api.js
+++ b/.github/scripts/helpers/api.js
@@ -588,6 +588,21 @@ async function resolveLinkedIssue(botContext) {
     }
 }
 
+/**
+ * Returns the highest difficulty level of an issue based on its labels.
+ *
+ * Checks labels against SKILL_HIERARCHY in descending order and returns the first match.
+ *
+ * @param {{ labels: Array<string|{ name: string }> }} issue
+ * @returns {string|null} Matching level or null if none found.
+ */
+function getHighestIssueSkillLevel(issue) {
+    for (const level of [...SKILL_HIERARCHY].reverse()) {
+        if (hasLabel(issue, level)) return level;
+    }
+    return null;
+}
+
 module.exports = {
   buildBotContext,
   addLabels,
@@ -606,4 +621,5 @@ module.exports = {
   runAllChecksAndComment,
   resolveLinkedIssue,
   acknowledgeComment,
+  getHighestIssueSkillLevel,
 };

--- a/.github/scripts/tests/test-api.js
+++ b/.github/scripts/tests/test-api.js
@@ -14,6 +14,7 @@ const {
   swapStatusLabel,
   hasLabel,
   resolveLinkedIssue,
+  getHighestIssueSkillLevel,
 } = require('../helpers/api');
 const { LABELS } = require('../helpers/constants');
 const { isSafeSearchToken } = require('../helpers/validation');
@@ -600,8 +601,40 @@ const unitTests = [
     name: 'isSafeSearchToken: string with multiple brackets → false',
     test: () => isSafeSearchToken('bad[[admin]') === false,
   },
-];
 
+  // ---------------------------------------------------------------------------
+  // getIssueSkillLevel
+  // ---------------------------------------------------------------------------
+  {
+    name: 'getIssueSkillLevel: issue with one skill label → returns that level',
+    test: () => {
+      const issue = makeIssue([BEGINNER, LABELS.READY_FOR_DEV]);
+      return getIssueSkillLevel(issue) === BEGINNER;
+    },
+  },
+  {
+    name: 'getIssueSkillLevel: issue with no skill labels → returns null',
+    test: () => {
+      const issue = makeIssue(['bug', 'enhancement']);
+      return getIssueSkillLevel(issue) === null;
+    },
+  },
+  {
+    name: 'getIssueSkillLevel: issue with multiple skill labels → returns highest',
+    test: () => {
+      // recommend-issues iterates reversed, so highest wins
+      const issue = makeIssue([GFI, BEGINNER, MID]);
+      return getIssueSkillLevel(issue) === MID;
+    },
+  },
+  {
+    name: 'getIssueSkillLevel: issue with empty labels → returns null',
+    test: () => {
+      return getIssueSkillLevel(makeIssue([])) === null;
+    },
+  },
+  
+];
 // =============================================================================
 // TEST RUNNER
 // =============================================================================

--- a/.github/scripts/tests/test-api.js
+++ b/.github/scripts/tests/test-api.js
@@ -633,7 +633,6 @@ const unitTests = [
       return getHighestIssueSkillLevel(issue) === null;
     },
   },
-  
 ];
 // =============================================================================
 // TEST RUNNER

--- a/.github/scripts/tests/test-api.js
+++ b/.github/scripts/tests/test-api.js
@@ -603,34 +603,34 @@ const unitTests = [
   },
 
   // ---------------------------------------------------------------------------
-  // getIssueSkillLevel
+  // getHighestIssueSkillLevel
   // ---------------------------------------------------------------------------
   {
-    name: 'getIssueSkillLevel: issue with one skill label → returns that level',
+    name: 'getHighestIssueSkillLevel: issue with one skill label → returns that level',
     test: () => {
-      const issue = makeIssue([BEGINNER, LABELS.READY_FOR_DEV]);
-      return getIssueSkillLevel(issue) === BEGINNER;
+      const issue = { number: 1, title: 'Test', labels: [{ name: LABELS.BEGINNER }, { name: LABELS.READY_FOR_DEV }] };
+      return getHighestIssueSkillLevel(issue) === LABELS.BEGINNER;
     },
   },
   {
-    name: 'getIssueSkillLevel: issue with no skill labels → returns null',
+    name: 'getHighestIssueSkillLevel: issue with no skill labels → returns null',
     test: () => {
-      const issue = makeIssue(['bug', 'enhancement']);
-      return getIssueSkillLevel(issue) === null;
+      const issue = { number: 1, title: 'Test', labels: [{ name: 'bug' }, { name: 'enhancement' }] };
+      return getHighestIssueSkillLevel(issue) === null;
     },
   },
   {
-    name: 'getIssueSkillLevel: issue with multiple skill labels → returns highest',
+    name: 'getHighestIssueSkillLevel: issue with multiple skill labels → returns highest',
     test: () => {
-      // recommend-issues iterates reversed, so highest wins
-      const issue = makeIssue([GFI, BEGINNER, MID]);
-      return getIssueSkillLevel(issue) === MID;
+      const issue = { number: 1, title: 'Test', labels: [{ name: LABELS.GOOD_FIRST_ISSUE }, { name: LABELS.BEGINNER }, { name: LABELS.INTERMEDIATE }] };
+      return getHighestIssueSkillLevel(issue) === LABELS.INTERMEDIATE;
     },
   },
   {
-    name: 'getIssueSkillLevel: issue with empty labels → returns null',
+    name: 'getHighestIssueSkillLevel: issue with empty labels → returns null',
     test: () => {
-      return getIssueSkillLevel(makeIssue([])) === null;
+      const issue = { number: 1, title: 'Test', labels: [] };
+      return getHighestIssueSkillLevel(issue) === null;
     },
   },
   

--- a/.github/scripts/tests/test-recommend-issues-bot.js
+++ b/.github/scripts/tests/test-recommend-issues-bot.js
@@ -76,38 +76,6 @@ const TOP      = SKILL_HIERARCHY[SKILL_HIERARCHY.length - 1];
 const unitTests = [
 
   // ---------------------------------------------------------------------------
-  // getIssueSkillLevel
-  // ---------------------------------------------------------------------------
-  {
-    name: 'getIssueSkillLevel: issue with one skill label → returns that level',
-    test: () => {
-      const issue = makeIssue([BEGINNER, LABELS.READY_FOR_DEV]);
-      return getIssueSkillLevel(issue) === BEGINNER;
-    },
-  },
-  {
-    name: 'getIssueSkillLevel: issue with no skill labels → returns null',
-    test: () => {
-      const issue = makeIssue(['bug', 'enhancement']);
-      return getIssueSkillLevel(issue) === null;
-    },
-  },
-  {
-    name: 'getIssueSkillLevel: issue with multiple skill labels → returns highest',
-    test: () => {
-      // recommend-issues iterates reversed, so highest wins
-      const issue = makeIssue([GFI, BEGINNER, MID]);
-      return getIssueSkillLevel(issue) === MID;
-    },
-  },
-  {
-    name: 'getIssueSkillLevel: issue with empty labels → returns null',
-    test: () => {
-      return getIssueSkillLevel(makeIssue([])) === null;
-    },
-  },
-
-  // ---------------------------------------------------------------------------
   // getNextLevel
   // ---------------------------------------------------------------------------
   {

--- a/.github/scripts/tests/test-recommend-issues-bot.js
+++ b/.github/scripts/tests/test-recommend-issues-bot.js
@@ -9,7 +9,6 @@ const { runTestSuite } = require('./test-utils');
 const { LABELS, SKILL_HIERARCHY, MAINTAINER_TEAM } = require('../helpers/constants');
 const {
   handleRecommendIssues,
-  getIssueSkillLevel,
   getNextLevel,
   getFallbackLevel,
   getRecommendedIssues,


### PR DESCRIPTION
### Summary

#### Refactor skill level detection into shared helper
- Unified duplicate implementations from assign.js and recommend-issues.js
- Introduced getHighestIssueSkillLevel to return the highest matching level

#### Code organization updates
- Moved helper to helpers/api.js
- Updated both commands to use the shared implementation

#### Tests
- Migrated tests to test-api.js
- Updated tests to reflect the shared helper implementation

### Linked Issue
- Fixes #1359 