### PR TITLE
fix: validate protobuf parsing in TopicId::fromBytes

### DIFF
--- a/src/sdk/main/src/TopicId.cc
+++ b/src/sdk/main/src/TopicId.cc
@@ -8,6 +8,7 @@
 #include <services/basic_types.pb.h>
 
 #include <limits>
+#include <stdexcept>
 
 namespace Hiero
 {
@@ -60,7 +61,11 @@ TopicId TopicId::fromProtobuf(const proto::TopicID& proto)
 TopicId TopicId::fromBytes(const std::vector<std::byte>& bytes)
 {
   proto::TopicID proto;
-  proto.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
+  if (!proto.ParseFromArray(bytes.data(), static_cast<int>(bytes.size())))
+  {
+    throw std::invalid_argument("Failed to parse TopicId from provided bytes");
+  }
+
   return fromProtobuf(proto);
 }
 

--- a/src/sdk/tests/unit/TopicIdUnitTests.cc
+++ b/src/sdk/tests/unit/TopicIdUnitTests.cc
@@ -189,6 +189,17 @@ TEST_F(TopicIdUnitTests, FromBytes)
 }
 
 //-----
+TEST_F(TopicIdUnitTests, FromBytesInvalidBytes)
+{
+  // Given
+  const std::vector<std::byte> invalidBytes = { std::byte(0xFF), std::byte(0xFF), std::byte(0xFF),
+                                                 std::byte(0xFF), std::byte(0xFF) };
+
+  // When / Then
+  EXPECT_THROW(TopicId::fromBytes(invalidBytes), std::invalid_argument);
+}
+
+//-----
 TEST_F(TopicIdUnitTests, ToProtobuf)
 {
   // Given


### PR DESCRIPTION
**Description**:

Update `TopicId::fromBytes()` to validate the returned value of `ParseFromArray`, preventing the SDK from silently falling back to a default/invalid `TopicId` on malformed input bytes. 

* Add parse validation to `TopicId::fromBytes` by checking `ParseFromArray` return value
* Throw `std::invalid_argument` with a descriptive message upon parse failure
* Add `<stdexcept>` header to `TopicId.cc`
* Add unit test `FromBytesInvalidBytes` in `TopicIdUnitTests.cc` to ensure `std::invalid_argument` is thrown for invalid bytes

**Related issue**:

Fixes #1367

**Notes for reviewer**:

This addresses the beginner issue [1367] checking whether parsing the protobuf succeeded. A test case passing dummy invalid bytes `0xFF` was added successfully asserting the required exception behavior.

**Checklist**

- [x] Tested (unit, integration, etc.)
