### PR TITLE
test: Add ToString unit test for AccountInfo

### DIFF
--- a/src/sdk/tests/unit/AccountInfoUnitTests.cc
+++ b/src/sdk/tests/unit/AccountInfoUnitTests.cc
@@ -126,3 +126,34 @@ TEST_F(AccountInfoUnitTests, FromProtobuf)
   EXPECT_EQ(accountInfo.mStakingInfo.mStakedAccountId, getTestStakedAccountId());
   EXPECT_FALSE(accountInfo.mStakingInfo.mStakedNodeId.has_value());
 }
+
+//-----
+TEST_F(AccountInfoUnitTests, ToString)
+{
+  // Given
+  AccountInfo accountInfo;
+  accountInfo.mAccountId = getTestAccountId();
+  accountInfo.mContractAccountId = getTestContractAccountId();
+  accountInfo.mIsDeleted = getTestIsDeleted();
+  accountInfo.mProxyReceived = getTestProxyReceived();
+  accountInfo.mKey = getTestPublicKey();
+  accountInfo.mBalance = getTestBalance();
+  accountInfo.mReceiverSignatureRequired = getTestReceiverSignatureRequired();
+  accountInfo.mExpirationTime = getTestExpirationTime();
+  accountInfo.mAutoRenewPeriod = getTestAutoRenewPeriod();
+  accountInfo.mMemo = getTestMemo();
+  accountInfo.mOwnedNfts = getTestOwnedNfts();
+  accountInfo.mMaxAutomaticTokenAssociations = getTestMaxAutomaticTokenAssociations();
+  accountInfo.mPublicKeyAlias = getTestPublicKeyAlias();
+  accountInfo.mLedgerId = getTestLedgerId();
+
+  // When
+  const std::string result = accountInfo.toString();
+
+  // Then
+  EXPECT_FALSE(result.empty());
+  EXPECT_NE(result.find(getTestAccountId().toString()), std::string::npos);
+  EXPECT_NE(result.find(getTestContractAccountId()), std::string::npos);
+  EXPECT_NE(result.find(getTestBalance().toString()), std::string::npos);
+  EXPECT_NE(result.find(getTestMemo()), std::string::npos);
+}


### PR DESCRIPTION
**Description**:
This PR adds a dedicated unit test for `AccountInfo::toString()` to ensure string serialization behavior does not regress without targeted coverage.

* Add `ToString` test in `AccountInfoUnitTests.cc`
* Construct `AccountInfo` with known fixture values
* Assert non-empty output and presence of selected key values
* Follow established non-brittle assertion style using `find()`

**Related issue(s)**:

Fixes #1368

**Notes for reviewer**:
The new test uses the `EXPECT_FALSE(result.empty())` and `EXPECT_NE(result.find(...), std::string::npos)` pattern matching the style in `ExchangeRateUnitTests.cc`. This avoids brittle full-JSON equality checks while properly validating the serialized fields (Account ID, Contract Account ID, Balance, and Memo).

**Checklist**

- [x] Tested (unit, integration, etc.)
