### PR TITLE
fix: address HIP-1195 bugs

### DIFF
--- a/src/sdk/main/include/hooks/EvmHookCall.h
+++ b/src/sdk/main/include/hooks/EvmHookCall.h
@@ -74,7 +74,7 @@ private:
   /**
    * The gas limit to use.
    */
-  uint64_t mGasLimit;
+  uint64_t mGasLimit = 0ULL;
 };
 
 } // namespace Hiero

--- a/src/sdk/main/include/hooks/HookEntityId.h
+++ b/src/sdk/main/include/hooks/HookEntityId.h
@@ -3,6 +3,7 @@
 #define HIERO_SDK_CPP_HOOK_ENTITY_ID_H_
 
 #include "AccountId.h"
+#include "ContractId.h"
 
 #include <memory>
 #include <optional>
@@ -52,9 +53,17 @@ public:
    * Set the ID of the owning entity as an account. This will reset other entity ID values.
    *
    * @param accountId The ID of the owning account.
-   * @return A reference to this HookCreationDetails object with the newly-set account ID.
+   * @return A reference to this HookEntityId object with the newly-set account ID.
    */
   HookEntityId& setAccountId(const AccountId& accountId);
+
+  /**
+   * Set the ID of the owning entity as a contract. This will reset other entity ID values.
+   *
+   * @param contractId The ID of the owning contract.
+   * @return A reference to this HookEntityId object with the newly-set contract ID.
+   */
+  HookEntityId& setContractId(const ContractId& contractId);
 
   /**
    * Get the account ID.
@@ -63,11 +72,23 @@ public:
    */
   [[nodiscard]] inline std::optional<AccountId> getAccountId() const { return mAccountId; }
 
+  /**
+   * Get the contract ID.
+   *
+   * @return The contract ID.
+   */
+  [[nodiscard]] inline std::optional<ContractId> getContractId() const { return mContractId; }
+
 private:
   /**
    * The account owning the hook.
    */
   std::optional<AccountId> mAccountId;
+
+  /**
+   * The contract owning the hook.
+   */
+  std::optional<ContractId> mContractId;
 };
 
 } // namespace Hiero

--- a/src/sdk/main/src/ContractUpdateTransaction.cc
+++ b/src/sdk/main/src/ContractUpdateTransaction.cc
@@ -244,12 +244,12 @@ void ContractUpdateTransaction::initFromSourceTransactionBody()
     mDeclineStakingReward = body.decline_reward().value();
   }
 
-  for (int i = 0; body.hook_ids_to_delete_size(); ++i)
+  for (int i = 0; i < body.hook_ids_to_delete_size(); ++i)
   {
     mHooksToDelete.push_back(body.hook_ids_to_delete(i));
   }
 
-  for (int i = 0; body.hook_creation_details_size(); ++i)
+  for (int i = 0; i < body.hook_creation_details_size(); ++i)
   {
     mHookCreationDetails.push_back(HookCreationDetails::fromProtobuf(body.hook_creation_details(i)));
   }

--- a/src/sdk/main/src/hooks/HookEntityId.cc
+++ b/src/sdk/main/src/hooks/HookEntityId.cc
@@ -15,6 +15,10 @@ HookEntityId HookEntityId::fromProtobuf(const proto::HookEntityId& proto)
   {
     hookEntityId.mAccountId = AccountId::fromProtobuf(proto.account_id());
   }
+  else if (proto.has_contract_id())
+  {
+    hookEntityId.mContractId = ContractId::fromProtobuf(proto.contract_id());
+  }
 
   return hookEntityId;
 }
@@ -28,6 +32,10 @@ std::unique_ptr<proto::HookEntityId> HookEntityId::toProtobuf() const
   {
     proto->set_allocated_account_id(mAccountId->toProtobuf().release());
   }
+  else if (mContractId.has_value())
+  {
+    proto->set_allocated_contract_id(mContractId->toProtobuf().release());
+  }
 
   return proto;
 }
@@ -39,12 +47,25 @@ void HookEntityId::validateChecksums(const Client& client) const
   {
     mAccountId->validateChecksum(client);
   }
+  else if (mContractId.has_value())
+  {
+    mContractId->validateChecksum(client);
+  }
 }
 
 //-----
 HookEntityId& HookEntityId::setAccountId(const AccountId& accountId)
 {
   mAccountId = accountId;
+  mContractId.reset();
+  return *this;
+}
+
+//-----
+HookEntityId& HookEntityId::setContractId(const ContractId& contractId)
+{
+  mContractId = contractId;
+  mAccountId.reset();
   return *this;
 }
 

--- a/src/sdk/tests/unit/ContractUpdateTransactionUnitTests.cc
+++ b/src/sdk/tests/unit/ContractUpdateTransactionUnitTests.cc
@@ -10,6 +10,7 @@
 #include <services/contract_update.pb.h>
 #include <gtest/gtest.h>
 #include <limits>
+#include <services/hook_types.pb.h>
 #include <services/transaction.pb.h>
 
 using namespace Hiero;
@@ -400,4 +401,35 @@ TEST_F(ContractUpdateTransactionUnitTests, ResetStakedNodeId)
   // Then
   EXPECT_TRUE(transaction.getStakedAccountId().has_value());
   EXPECT_FALSE(transaction.getStakedNodeId().has_value());
+}
+
+//-----
+TEST_F(ContractUpdateTransactionUnitTests, ConstructFromProtobufWithHooks)
+{
+  // Given
+  auto body = std::make_unique<proto::ContractUpdateTransactionBody>();
+  body->set_allocated_contractid(getTestContractId().toProtobuf().release());
+
+  body->add_hook_ids_to_delete(10LL);
+  body->add_hook_ids_to_delete(20LL);
+  body->add_hook_ids_to_delete(30LL);
+
+  body->add_hook_creation_details()->set_hook_id(100LL);
+  body->add_hook_creation_details()->set_hook_id(200LL);
+
+  proto::TransactionBody txBody;
+  txBody.set_allocated_contractupdateinstance(body.release());
+
+  // When
+  const ContractUpdateTransaction contractUpdateTransaction(txBody);
+
+  // Then
+  ASSERT_EQ(contractUpdateTransaction.getHooksToDelete().size(), 3U);
+  EXPECT_EQ(contractUpdateTransaction.getHooksToDelete().at(0), 10LL);
+  EXPECT_EQ(contractUpdateTransaction.getHooksToDelete().at(1), 20LL);
+  EXPECT_EQ(contractUpdateTransaction.getHooksToDelete().at(2), 30LL);
+
+  ASSERT_EQ(contractUpdateTransaction.getHooksToCreate().size(), 2U);
+  EXPECT_EQ(contractUpdateTransaction.getHooksToCreate().at(0).getHookId(), 100LL);
+  EXPECT_EQ(contractUpdateTransaction.getHooksToCreate().at(1).getHookId(), 200LL);
 }

--- a/src/sdk/tests/unit/HookEntityIdUnitTests.cc
+++ b/src/sdk/tests/unit/HookEntityIdUnitTests.cc
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
+#include "ContractId.h"
 #include "hooks/HookEntityId.h"
 
 #include <gtest/gtest.h>
-#include <services/hook_types.pb.h>
+#include <services/basic_types.pb.h>
 
 using namespace Hiero;
 
@@ -10,9 +11,11 @@ class HookEntityIdUnitTests : public ::testing::Test
 {
 protected:
   [[nodiscard]] inline const AccountId& getTestAccountId() const { return mAccountId; }
+  [[nodiscard]] inline const ContractId& getTestContractId() const { return mContractId; }
 
 private:
   const AccountId mAccountId = AccountId(1ULL, 2ULL, 3ULL);
+  const ContractId mContractId = ContractId(1ULL, 2ULL, 3ULL);
 };
 
 //-----
@@ -56,4 +59,81 @@ TEST_F(HookEntityIdUnitTests, ToProtobuf)
   EXPECT_EQ(protoHookEntityId->account_id().shardnum(), getTestAccountId().mShardNum);
   EXPECT_EQ(protoHookEntityId->account_id().realmnum(), getTestAccountId().mRealmNum);
   EXPECT_EQ(protoHookEntityId->account_id().accountnum(), getTestAccountId().mAccountNum);
+}
+
+//-----
+TEST_F(HookEntityIdUnitTests, GetSetContractId)
+{
+  // Given
+  HookEntityId hookEntityId;
+
+  // When
+  EXPECT_NO_THROW(hookEntityId.setContractId(getTestContractId()));
+
+  // Then
+  EXPECT_EQ(hookEntityId.getContractId(), getTestContractId());
+}
+
+//-----
+TEST_F(HookEntityIdUnitTests, FromProtobufWithContractId)
+{
+  // Given
+  proto::HookEntityId protoHookEntityId;
+  protoHookEntityId.set_allocated_contract_id(getTestContractId().toProtobuf().release());
+
+  // When
+  const HookEntityId hookEntityId = HookEntityId::fromProtobuf(protoHookEntityId);
+
+  // Then
+  EXPECT_EQ(hookEntityId.getContractId(), getTestContractId());
+}
+
+//-----
+TEST_F(HookEntityIdUnitTests, ToProtobufWithContractId)
+{
+  // Given
+  HookEntityId hookEntityId;
+  hookEntityId.setContractId(getTestContractId());
+
+  // When
+  const std::unique_ptr<proto::HookEntityId> protoHookEntityId = hookEntityId.toProtobuf();
+
+  // Then
+  EXPECT_EQ(protoHookEntityId->contract_id().shardnum(), getTestContractId().mShardNum);
+  EXPECT_EQ(protoHookEntityId->contract_id().realmnum(), getTestContractId().mRealmNum);
+  ASSERT_TRUE(getTestContractId().mContractNum.has_value());
+  EXPECT_EQ(static_cast<uint64_t>(protoHookEntityId->contract_id().contractnum()),
+            getTestContractId().mContractNum.value());
+}
+
+//-----
+TEST_F(HookEntityIdUnitTests, SetContractIdResetsAccountId)
+{
+  // Given
+  HookEntityId hookEntityId;
+  hookEntityId.setAccountId(getTestAccountId());
+  ASSERT_TRUE(hookEntityId.getAccountId().has_value());
+
+  // When
+  hookEntityId.setContractId(getTestContractId());
+
+  // Then
+  EXPECT_FALSE(hookEntityId.getAccountId().has_value());
+  EXPECT_EQ(hookEntityId.getContractId(), getTestContractId());
+}
+
+//-----
+TEST_F(HookEntityIdUnitTests, SetAccountIdResetsContractId)
+{
+  // Given
+  HookEntityId hookEntityId;
+  hookEntityId.setContractId(getTestContractId());
+  ASSERT_TRUE(hookEntityId.getContractId().has_value());
+
+  // When
+  hookEntityId.setAccountId(getTestAccountId());
+
+  // Then
+  EXPECT_FALSE(hookEntityId.getContractId().has_value());
+  EXPECT_EQ(hookEntityId.getAccountId(), getTestAccountId());
 }


### PR DESCRIPTION
## Summary

This PR fixes several bugs in the hooks implementation introduced earlier, and adds unit test coverage for the new and fixed behavior.

**Key Changes:**
- Fix infinite-loop bug in `ContractUpdateTransaction` protobuf deserialization
- Add `ContractId` support to `HookEntityId` (alongside the existing `AccountId` support)
- Fix uninitialized `mGasLimit` member in `EvmHookCall`
- Add unit tests covering all new and fixed behavior

Fixes #1395

## Changes

### `ContractUpdateTransaction` — for-loop bug fix

Two `for` loops in `initFromSourceTransactionBody` used the loop termination condition `body.hook_ids_to_delete_size()` / `body.hook_creation_details_size()` instead of `i < body.hook_ids_to_delete_size()` / `i < body.hook_creation_details_size()`. Because a non-zero integer is truthy, any transaction body containing hook fields would spin in an infinite loop during deserialization.

**Fix:** Added the missing `i <` comparison in both loop conditions.

**Files Changed:**
- `src/sdk/main/src/ContractUpdateTransaction.cc`

### `HookEntityId` — contract ID support

`HookEntityId` previously only modeled account ownership. The proto `HookEntityId` message defines `account_id` and `contract_id` as a `oneof`, so contract-owned hooks could not be round-tripped through the SDK.

**Changes:**
- Added `#include "ContractId.h"` to the header
- Added `setContractId(const ContractId&)` setter (resets `mAccountId`)
- Updated `setAccountId` to reset `mContractId` (mutual exclusion)
- Added `getContractId()` getter
- Added `mContractId` private member (`std::optional<ContractId>`)
- Updated `fromProtobuf`, `toProtobuf`, and `validateChecksums` to handle `contract_id`

**Files Changed:**
- `src/sdk/main/include/hooks/HookEntityId.h`
- `src/sdk/main/src/hooks/HookEntityId.cc`

### `EvmHookCall` — default member initializer

`mGasLimit` was declared without a default value, leaving it uninitialized for default-constructed `EvmHookCall` objects. Added `= 0ULL` to the member declaration.

**Files Changed:**
- `src/sdk/main/include/hooks/EvmHookCall.h`

### Unit tests

| Test file | Tests added |
|-----------|-------------|
| `HookEntityIdUnitTests.cc` | `GetSetContractId`, `FromProtobufWithContractId`, `ToProtobufWithContractId`, `SetContractIdResetsAccountId`, `SetAccountIdResetsContractId` |
| `ContractUpdateTransactionUnitTests.cc` | `ConstructFromProtobufWithHooks` |

`ConstructFromProtobufWithHooks` is a direct regression test for the for-loop fix: it populates a `ContractUpdateTransactionBody` with 3 `hook_ids_to_delete` and 2 `hook_creation_details` entries and asserts all are deserialized correctly.

**Files Changed:**
- `src/sdk/tests/unit/HookEntityIdUnitTests.cc`
- `src/sdk/tests/unit/ContractUpdateTransactionUnitTests.cc`

## Testing

**Test plan:**
- [x] `ConstructFromProtobufWithHooks` — regression test for the infinite-loop fix
- [x] `GetSetContractId` — new public API round-trip
- [x] `FromProtobufWithContractId` — protobuf deserialization with contract ID
- [x] `ToProtobufWithContractId` — protobuf serialization with contract ID
- [x] `SetContractIdResetsAccountId` — mutual exclusion between account and contract IDs
- [x] `SetAccountIdResetsContractId` — mutual exclusion between account and contract IDs

## Files Changed Summary

| Category | Files |
|----------|-------|
| Source | `src/sdk/main/src/ContractUpdateTransaction.cc`, `src/sdk/main/src/hooks/HookEntityId.cc` |
| Headers | `src/sdk/main/include/hooks/HookEntityId.h`, `src/sdk/main/include/hooks/EvmHookCall.h` |
| Unit tests | `src/sdk/tests/unit/HookEntityIdUnitTests.cc`, `src/sdk/tests/unit/ContractUpdateTransactionUnitTests.cc` |

## Breaking Changes

**None.** All public API additions are backward-compatible. The `setAccountId` behavior change (now also resets `mContractId`) is consistent with the existing `oneof` semantics in the protobuf schema.
