### PR TITLE
fix: add equality operator to ExchangeRates for comparison

### DIFF
--- a/src/sdk/main/include/ExchangeRates.h
+++ b/src/sdk/main/include/ExchangeRates.h
@@ -78,6 +78,7 @@ public:
    * @return \c TRUE if this ExchangeRates is the same as the input ExchangeRates, otherwise \c FALSE.
    */
   [[nodiscard]] bool operator==(const ExchangeRates& other) const;
+
   /**
    * Write this ExchangeRates to an output stream.
    *

--- a/src/sdk/main/include/ExchangeRates.h
+++ b/src/sdk/main/include/ExchangeRates.h
@@ -72,6 +72,13 @@ public:
   [[nodiscard]] std::string toString() const;
 
   /**
+   * Compare this ExchangeRates to another ExchangeRates and determine if they represent the same exchange rates.
+   *
+   * @param other The other ExchangeRates with which to compare this ExchangeRates.
+   * @return \c TRUE if this ExchangeRates is the same as the input ExchangeRates, otherwise \c FALSE.
+   */
+  [[nodiscard]] bool operator==(const ExchangeRates& other) const;
+  /**
    * Write this ExchangeRates to an output stream.
    *
    * @param os    The output stream.

--- a/src/sdk/main/src/ExchangeRates.cc
+++ b/src/sdk/main/src/ExchangeRates.cc
@@ -60,4 +60,10 @@ std::ostream& operator<<(std::ostream& os, const ExchangeRates& rates)
   return os;
 }
 
+//-----
+bool ExchangeRates::operator==(const ExchangeRates& other) const
+{
+  return (mCurrentRate == other.mCurrentRate) && (mNextRate == other.mNextRate);
+}
+
 } // namespace Hiero

--- a/src/sdk/main/src/ExchangeRates.cc
+++ b/src/sdk/main/src/ExchangeRates.cc
@@ -54,16 +54,16 @@ std::string ExchangeRates::toString() const
 }
 
 //-----
+bool ExchangeRates::operator==(const ExchangeRates& other) const
+{
+  return (mCurrentRate == other.mCurrentRate) && (mNextRate == other.mNextRate);
+}
+
+//-----
 std::ostream& operator<<(std::ostream& os, const ExchangeRates& rates)
 {
   os << rates.toString();
   return os;
-}
-
-//-----
-bool ExchangeRates::operator==(const ExchangeRates& other) const
-{
-  return (mCurrentRate == other.mCurrentRate) && (mNextRate == other.mNextRate);
 }
 
 } // namespace Hiero

--- a/src/sdk/tests/unit/ExchangeRateUnitTests.cc
+++ b/src/sdk/tests/unit/ExchangeRateUnitTests.cc
@@ -200,8 +200,7 @@ TEST_F(ExchangeRateUnitTests, ExchangeRatesOperatorEqualsDefaults)
   ExchangeRates rhs;
 
   // Then
-  EXPECT_TRUE(lhs.mCurrentRate == rhs.mCurrentRate);
-  EXPECT_TRUE(lhs.mNextRate == rhs.mNextRate);
+  EXPECT_TRUE(lhs == rhs);
 }
 
 //-----

--- a/src/sdk/tests/unit/ExchangeRateUnitTests.cc
+++ b/src/sdk/tests/unit/ExchangeRateUnitTests.cc
@@ -191,3 +191,47 @@ TEST_F(ExchangeRateUnitTests, OperatorEqualsDiff)
   EXPECT_FALSE(lhs == diffCents);
   EXPECT_FALSE(lhs == diffExpirationTime);
 }
+
+//-----
+TEST_F(ExchangeRateUnitTests, ExchangeRatesOperatorEqualsDefaults)
+{
+  // Given
+  ExchangeRates lhs;
+  ExchangeRates rhs;
+
+  // Then
+  EXPECT_TRUE(lhs.mCurrentRate == rhs.mCurrentRate);
+  EXPECT_TRUE(lhs.mNextRate == rhs.mNextRate);
+}
+
+//-----
+TEST_F(ExchangeRateUnitTests, ExchangeRatesOperatorEqualsSimilar)
+{
+  // Given
+  const ExchangeRate currentRate(getTestHbar(), getTestCents(), getTestExpirationTime());
+  const ExchangeRate nextRate(getTestHbar(), getTestCents(), getTestExpirationTime());
+  const ExchangeRates lhs(currentRate, nextRate);
+  const ExchangeRates rhs(currentRate, nextRate);
+
+  // Then
+  EXPECT_TRUE(lhs == rhs);
+}
+
+//-----
+TEST_F(ExchangeRateUnitTests, ExchangeRatesOperatorEqualsDiff)
+{
+  // Given
+  const ExchangeRate currentRate(getTestHbar(), getTestCents(), getTestExpirationTime());
+  const ExchangeRate nextRate(getTestHbar(), getTestCents(), getTestExpirationTime());
+
+  const ExchangeRates lhs(currentRate, nextRate);
+  const ExchangeRates diffCurrentRate(ExchangeRate(3, getTestCents(), getTestExpirationTime()), nextRate);
+  const ExchangeRates diffNextRate(currentRate, ExchangeRate(getTestHbar(), 3, getTestExpirationTime()));
+  const ExchangeRates diffNextRateExpiration(
+    currentRate, ExchangeRate(getTestHbar(), getTestCents(), getTestExpirationTime() + std::chrono::seconds(1)));
+
+  // Then
+  EXPECT_FALSE(lhs == diffCurrentRate);
+  EXPECT_FALSE(lhs == diffNextRate);
+  EXPECT_FALSE(lhs == diffNextRateExpiration);
+}


### PR DESCRIPTION
**Description**:
adds comparison functionality to the `ExchangeRates` class, allowing to check if two `ExchangeRates` objects represent the same rates.

**Related issue(s)**:

Fixes #1296

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
