### PR TITLE
fix gramar error on line 127

### DIFF
--- a/src/sdk/main/include/AccountInfo.h
+++ b/src/sdk/main/include/AccountInfo.h
@@ -124,7 +124,7 @@ public:
   std::chrono::system_clock::time_point mExpirationTime = std::chrono::system_clock::now();
 
   /**
-   * The duration of time the queried account uses to automatically extend its expiration period. It it doesn't have
+   * The duration of time the queried account uses to automatically extend its expiration period. If it doesn't have
    * enough balance, it extends as long as possible. If it is empty when it expires, then it is deleted.
    */
   std::chrono::system_clock::duration mAutoRenewPeriod;


### PR DESCRIPTION
**Description**:
Fixes #1398 : https://github.com/hiero-ledger/hiero-sdk-cpp/issues/1398
Fixes grammar error on line 127, in src/sdk/main/include/AccountInfo.h.
- Tested bash cmake --preset linux-x64-debug && cmake --build --preset linux-x64-debug  without any issue
