### PR TITLE
fix(assign): revalidate fresh issue labels before assignment to close stale-label race

### DIFF
--- a/.github/scripts/commands/assign-comments.js
+++ b/.github/scripts/commands/assign-comments.js
@@ -233,6 +233,31 @@ function buildNoSkillLevelComment(requesterUsername) {
 }
 
 /**
+ * Builds the comment posted when the issue's skill level changes while the
+ * assignment request is queued. Tells the requester to retry so eligibility
+ * checks run against the latest label state.
+ *
+ * @param {string} requesterUsername - The GitHub username who commented /assign.
+ * @param {string} previousSkillLevel - The skill level from the event payload.
+ * @param {string} currentSkillLevel - The skill level from the fresh issue snapshot.
+ * @returns {string} The formatted Markdown comment body.
+ */
+function buildSkillLevelChangedComment(
+  requesterUsername,
+  previousSkillLevel,
+  currentSkillLevel,
+) {
+  return [
+    `👋 Hi @${requesterUsername}! The skill level for this issue changed while your assignment request was being processed.`,
+    "",
+    `**Current label:** \`${currentSkillLevel}\``,
+    `**Previous label:** \`${previousSkillLevel}\``,
+    "",
+    "Please comment `/assign` again to request assignment with the updated skill requirements.",
+  ].join("\n");
+}
+
+/**
  * Builds a GitHub Issues search URL for the given repository and query string.
  *
  * @param {string} owner - Repository owner.
@@ -421,6 +446,7 @@ module.exports = {
   buildNotReadyComment,
   buildPrerequisiteNotMetComment,
   buildNoSkillLevelComment,
+  buildSkillLevelChangedComment,
   buildAssignmentLimitExceededComment,
   buildGfiLimitExceededComment,
   buildApiErrorComment,

--- a/.github/scripts/commands/assign.js
+++ b/.github/scripts/commands/assign.js
@@ -554,6 +554,28 @@ async function assignAndFinalize(botContext, requesterUsername, skillLevel) {
     return;
   }
 
+  // Revalidate labels from the fresh issue snapshot to prevent stale-event
+  // payload eligibility checks when labels change while this run is queued.
+  if (!hasLabel(freshIssue, LABELS.READY_FOR_DEV)) {
+    logger.log("Exit: fresh issue state is missing ready for dev label");
+    await postComment(
+      botContext,
+      buildNotReadyComment(
+        requesterUsername,
+        botContext.owner,
+        botContext.repo,
+      ),
+    );
+    return;
+  }
+
+  const freshSkillLevel = getIssueSkillLevel(freshIssue);
+  if (!freshSkillLevel) {
+    logger.log("Exit: fresh issue state has no skill level label");
+    await postComment(botContext, buildNoSkillLevelComment(requesterUsername));
+    return;
+  }
+
   const assignResult = await addAssignees(botContext, [requesterUsername]);
   if (!assignResult.success) {
     await postComment(
@@ -566,7 +588,7 @@ async function assignAndFinalize(botContext, requesterUsername, skillLevel) {
 
   await postComment(
     botContext,
-    buildWelcomeComment(requesterUsername, skillLevel),
+    buildWelcomeComment(requesterUsername, freshSkillLevel),
   );
   logger.log("Posted welcome comment");
   await updateLabels(botContext, requesterUsername);
@@ -586,7 +608,8 @@ async function assignAndFinalize(botContext, requesterUsername, skillLevel) {
  *   7. GFI cap reached (skill: good first issue only)? -> GFI-limit-exceeded comment.
  *   8. Skill prerequisites not met? -> prerequisite-not-met comment.
  *   9. Issue snatched while queued (fresh fetch)? -> already-assigned comment.
- *   10. Assignment API failure? -> assignment-failure comment (tags maintainers).
+ *   10. Fresh labels invalid while queued? -> not-ready/no-skill-level comment.
+ *   11. Assignment API failure? -> assignment-failure comment (tags maintainers).
  *
  * If all checks pass, the bot assigns the issue, posts a welcome comment,
  * and swaps the "status: ready for dev" label with "status: in progress".
@@ -601,7 +624,9 @@ async function handleAssign(botContext) {
 
   const ack = await acknowledgeComment(botContext, botContext.comment.id);
   if (!ack.success) {
-    logger.log('Aborting /assign: triggering comment was deleted or could not be acknowledged');
+    logger.log(
+      "Aborting /assign: triggering comment was deleted or could not be acknowledged",
+    );
     return;
   }
 

--- a/.github/scripts/commands/assign.js
+++ b/.github/scripts/commands/assign.js
@@ -576,6 +576,28 @@ async function assignAndFinalize(botContext, requesterUsername, skillLevel) {
     return;
   }
 
+  // If the skill level changed while this run was queued, the earlier prerequisite
+  // and GFI-cap gates were run against a stale label. Abort and ask user to retry.
+  if (freshSkillLevel !== skillLevel) {
+    logger.log("Exit: skill level changed while queued", {
+      stalePayloadLevel: skillLevel,
+      freshReadLevel: freshSkillLevel,
+    });
+    await postComment(
+      botContext,
+      [
+        `👋 Hi @${requesterUsername}! The skill level for this issue changed while your assignment request was being processed.`,
+        "",
+        `**Current label:** \`${freshSkillLevel}\``,
+        `**Previous label:** \`${skillLevel}\``,
+        "",
+        "Please comment `/assign` again to request assignment with the updated skill requirements.",
+      ].join("\n"),
+    );
+    logger.log("Posted skill-level-changed comment");
+    return;
+  }
+
   const assignResult = await addAssignees(botContext, [requesterUsername]);
   if (!assignResult.success) {
     await postComment(
@@ -609,7 +631,8 @@ async function assignAndFinalize(botContext, requesterUsername, skillLevel) {
  *   8. Skill prerequisites not met? -> prerequisite-not-met comment.
  *   9. Issue snatched while queued (fresh fetch)? -> already-assigned comment.
  *   10. Fresh labels invalid while queued? -> not-ready/no-skill-level comment.
- *   11. Assignment API failure? -> assignment-failure comment (tags maintainers).
+ *   11. Skill level changed while queued? -> skill-level-changed comment (ask to retry).
+ *   12. Assignment API failure? -> assignment-failure comment (tags maintainers).
  *
  * If all checks pass, the bot assigns the issue, posts a welcome comment,
  * and swaps the "status: ready for dev" label with "status: in progress".

--- a/.github/scripts/commands/assign.js
+++ b/.github/scripts/commands/assign.js
@@ -29,6 +29,7 @@ const {
   buildNotReadyComment,
   buildPrerequisiteNotMetComment,
   buildNoSkillLevelComment,
+  buildSkillLevelChangedComment,
   buildAssignmentLimitExceededComment,
   buildGfiLimitExceededComment,
   buildApiErrorComment,
@@ -585,14 +586,11 @@ async function assignAndFinalize(botContext, requesterUsername, skillLevel) {
     });
     await postComment(
       botContext,
-      [
-        `👋 Hi @${requesterUsername}! The skill level for this issue changed while your assignment request was being processed.`,
-        "",
-        `**Current label:** \`${freshSkillLevel}\``,
-        `**Previous label:** \`${skillLevel}\``,
-        "",
-        "Please comment `/assign` again to request assignment with the updated skill requirements.",
-      ].join("\n"),
+      buildSkillLevelChangedComment(
+        requesterUsername,
+        skillLevel,
+        freshSkillLevel,
+      ),
     );
     logger.log("Posted skill-level-changed comment");
     return;

--- a/.github/scripts/tests/test-assign-bot.js
+++ b/.github/scripts/tests/test-assign-bot.js
@@ -349,6 +349,37 @@ const scenarios = [
     ],
   },
   {
+    name: "Race Condition - Skill Label Changed to Different Level While Queued",
+    description:
+      "Fresh fetch shows a different skill level; bot must abort since prerequisite gates were run against stale level",
+    context: {
+      eventName: "issue_comment",
+      payload: {
+        issue: {
+          number: 126,
+          assignees: [],
+          labels: [
+            { name: "status: ready for dev" },
+            { name: "skill: good first issue" },
+          ],
+        },
+        comment: {
+          id: 1027,
+          body: "/assign",
+          user: { login: "skill-changed-user", type: "User" },
+        },
+      },
+      repo: { owner: "hiero-ledger", repo: "hiero-sdk-cpp" },
+    },
+    githubOptions: {
+      issueLabels: [{ name: LABELS.READY_FOR_DEV }, { name: LABELS.BEGINNER }],
+    },
+    expectedAssignee: null,
+    expectedComments: [
+      `👋 Hi @skill-changed-user! The skill level for this issue changed while your assignment request was being processed.\n\n**Current label:** \`${LABELS.BEGINNER}\`\n**Previous label:** \`${LABELS.GOOD_FIRST_ISSUE}\`\n\nPlease comment \`/assign\` again to request assignment with the updated skill requirements.`,
+    ],
+  },
+  {
     name: "Error - Fresh Issue Fetch API Failure",
     // Note: This failure fires from inside assignAndFinalize(), unlike the
     // other API failure tests which catch errors during precondition checks.

--- a/.github/scripts/tests/test-assign-bot.js
+++ b/.github/scripts/tests/test-assign-bot.js
@@ -15,7 +15,7 @@ const script = require("../bot-on-comment.js");
 // MOCK GITHUB API
 // =============================================================================
 
-function createMockGithub(options = {}) {
+function createMockGithub(options = {}, issueFromPayload = null) {
   const {
     completedIssueCount = 0,
     completedIssueCounts = {},
@@ -30,6 +30,7 @@ function createMockGithub(options = {}) {
     reactionShouldFail = false,
     issueGetShouldFail = false,
     issueAssignees = null,
+    issueLabels = null,
   } = options;
 
   const calls = {
@@ -94,19 +95,28 @@ function createMockGithub(options = {}) {
           if (issueGetShouldFail) {
             throw new Error("Simulated issues.get failure");
           }
+          const freshLabels = Array.isArray(issueLabels)
+            ? issueLabels
+            : Array.isArray(issueFromPayload?.labels)
+              ? issueFromPayload.labels
+              : [];
           if (Array.isArray(issueAssignees)) {
             return {
               data: {
                 assignees: issueAssignees.map((login) => ({ login })),
+                labels: freshLabels,
               },
             };
           }
           if (options.issueAlreadyAssignedTo) {
             return {
-              data: { assignees: [{ login: options.issueAlreadyAssignedTo }] },
+              data: {
+                assignees: [{ login: options.issueAlreadyAssignedTo }],
+                labels: freshLabels,
+              },
             };
           }
-          return { data: { assignees: [] } };
+          return { data: { assignees: [], labels: freshLabels } };
         },
         listForRepo: async (params) => {
           calls.restCalls.push(
@@ -278,6 +288,64 @@ const scenarios = [
     expectedAssignee: null,
     expectedComments: [
       `👋 Hi @third-user! This issue is already assigned to @first-user, @second-user.\n\n👉 **Find another issue to work on:**\n[Browse unassigned issues](https://github.com/hiero-ledger/hiero-sdk-cpp/issues?q=is%3Aissue+is%3Aopen+no%3Aassignee+label%3A%22status%3A+ready+for+dev%22)\n\nOnce you find one you like, comment \`/assign\` to get started!`,
+    ],
+  },
+  {
+    name: "Race Condition - Ready Label Removed While Queued",
+    description:
+      "Fresh fetch no longer has ready-for-dev label; bot must abort assignment",
+    context: {
+      eventName: "issue_comment",
+      payload: {
+        issue: {
+          number: 124,
+          assignees: [],
+          labels: [
+            { name: "status: ready for dev" },
+            { name: "skill: good first issue" },
+          ],
+        },
+        comment: {
+          id: 1025,
+          body: "/assign",
+          user: { login: "stale-ready-user", type: "User" },
+        },
+      },
+      repo: { owner: "hiero-ledger", repo: "hiero-sdk-cpp" },
+    },
+    githubOptions: { issueLabels: [{ name: LABELS.GOOD_FIRST_ISSUE }] },
+    expectedAssignee: null,
+    expectedComments: [
+      `👋 Hi @stale-ready-user! This issue is not ready for development yet.\n\nIssues must have the \`status: ready for dev\` label before they can be assigned.\n\n👉 **Find an issue that's ready:**\n[Browse ready issues](https://github.com/hiero-ledger/hiero-sdk-cpp/issues?q=is%3Aissue+is%3Aopen+no%3Aassignee+label%3A%22status%3A+ready+for+dev%22)\n\nOnce you find one you like, comment \`/assign\` to get started!`,
+    ],
+  },
+  {
+    name: "Race Condition - Skill Label Removed While Queued",
+    description:
+      "Fresh fetch no longer has any skill label; bot must abort and tag maintainers",
+    context: {
+      eventName: "issue_comment",
+      payload: {
+        issue: {
+          number: 125,
+          assignees: [],
+          labels: [
+            { name: "status: ready for dev" },
+            { name: "skill: good first issue" },
+          ],
+        },
+        comment: {
+          id: 1026,
+          body: "/assign",
+          user: { login: "stale-skill-user", type: "User" },
+        },
+      },
+      repo: { owner: "hiero-ledger", repo: "hiero-sdk-cpp" },
+    },
+    githubOptions: { issueLabels: [{ name: LABELS.READY_FOR_DEV }] },
+    expectedAssignee: null,
+    expectedComments: [
+      `👋 Hi @stale-skill-user! This issue doesn't have a skill level label yet.\n\n@hiero-ledger/hiero-sdk-cpp-maintainers — could you please add one of the following labels?\n- \`skill: good first issue\`\n- \`skill: beginner\`\n- \`skill: intermediate\`\n- \`skill: advanced\`\n\n@stale-skill-user, once a maintainer adds the label, comment \`/assign\` again to request assignment.`,
     ],
   },
   {
@@ -1353,7 +1421,10 @@ async function runTest(scenario, index) {
   console.log(`Description: ${scenario.description}`);
   console.log("=".repeat(70));
 
-  const mockGithub = createMockGithub(scenario.githubOptions);
+  const mockGithub = createMockGithub(
+    scenario.githubOptions,
+    scenario.context?.payload?.issue,
+  );
 
   try {
     await script({ github: mockGithub, context: scenario.context });

--- a/.github/workflows/on-comment.yaml
+++ b/.github/workflows/on-comment.yaml
@@ -23,7 +23,7 @@ name: Bot - On Comment
 #   Serialized per issue number (cancel-in-progress: false) to prevent
 #   same-issue races where two different users both see assignees=[] and
 #   both get assigned. Same-user multi-issue bypass is handled by fresh-state
-#   REST counting plus post-write rollback in assign.js.
+#   REST counting plus pre-write fresh issue validation in assign.js.
 # ──────────────────────────────────────────────────────────────────────
 on:
   issue_comment:

--- a/.github/workflows/on-comment.yaml
+++ b/.github/workflows/on-comment.yaml
@@ -22,8 +22,9 @@ name: Bot - On Comment
 # Concurrency:
 #   Serialized per issue number (cancel-in-progress: false) to prevent
 #   same-issue races where two different users both see assignees=[] and
-#   both get assigned. Same-user multi-issue bypass is handled by fresh-state
-#   REST counting plus pre-write fresh issue validation in assign.js.
+#   both get assigned. Same-issue collisions are caught by the pre-write
+#   fresh issues.get() in assignAndFinalize(). Same-user multi-issue limits
+#   are enforced via REST API counting in enforceAssignmentLimit().
 # ──────────────────────────────────────────────────────────────────────
 on:
   issue_comment:


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

Close the stale-label timing window in the `/assign` bot by re-validating label eligibility from the same fresh issue snapshot used for assignee race checks, immediately before assignment is written.

* Re-read current issue labels from the pre-write `issues.get()` fresh snapshot in `assignAndFinalize()`
* Abort assignment when `status: ready for dev` is missing in fresh state and post the existing not-ready guidance comment
* Abort assignment when no skill label is present in fresh state and post the existing no-skill-level + maintainer-tag comment
* Abort assignment when the skill label changed between the event payload and the fresh pre-write snapshot, so prerequisite and GFI-cap checks are always re-run against the correct label on retry
* Use the fresh skill level when building the welcome message to keep output consistent with current labels
* Extend assign-bot test mocks to return fresh labels from `issues.get()` so queued-state changes can be simulated
* Add regression tests for:
  * ready label removed while queued
  * skill label removed while queued
  * skill label changed level while queued
* Update stale workflow comment wording to reflect current design
* Preserve existing behavior and avoid extra API calls by reusing the already-present fresh fetch

**Related issue(s)**:

Fixes #1392

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Validation completed locally:

- Assign bot integration suite: 35/35 passed
- Full bot test sweep passed:
  - test-api.js (39/39)
  - test-assign-bot.js (35/35)
  - test-checks.js (58/58)
  - test-comments.js (32/32)
  - test-finalize-bot.js (35/35)
  - test-on-pr-open-bot.js (13/13)
  - test-on-pr-update-bot.js (27/27)
  - test-recommend-issues-bot.js (23/23)
  - test-unassign-bot.js (11/11)

Scope notes:

- This PR is intentionally limited to stale label revalidation in the pre-write window.
- No new endpoints/calls were introduced; logic is hardened using the existing fresh issue fetch path.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)