### PR TITLE
CI: enable all build targets in CI

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -160,7 +160,8 @@ jobs:
           VCPKG_BINARY_SOURCES: clear
         run: |
           echo "::group::Configure Project"
-          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-debug -DBUILD_TESTS=ON -DBUILD_TCK_TESTS=ON
+          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-debug \
+            -DBUILD_TESTS=ON -DBUILD_TCK=ON -DBUILD_TCK_TESTS=ON -DBUILD_EXAMPLES=ON
           echo "::endgroup::"
 
           echo "::group::Build Project"
@@ -173,7 +174,8 @@ jobs:
           VCPKG_BINARY_SOURCES: clear
         run: |
           echo "::group::Configure Project"
-          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-release -DBUILD_TESTS=ON -DBUILD_TCK_TESTS=ON
+          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-debug \
+            -DBUILD_TESTS=ON -DBUILD_TCK=ON -DBUILD_TCK_TESTS=ON -DBUILD_EXAMPLES=ON
           echo "::endgroup::"
 
           echo "::group::Build Project"

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -174,7 +174,7 @@ jobs:
           VCPKG_BINARY_SOURCES: clear
         run: |
           echo "::group::Configure Project"
-          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-debug \
+          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-release \
             -DBUILD_TESTS=ON -DBUILD_TCK=ON -DBUILD_TCK_TESTS=ON -DBUILD_EXAMPLES=ON
           echo "::endgroup::"
 


### PR DESCRIPTION
 ## Changes
- Added `-DBUILD_TCK=ON` and `-DBUILD_EXAMPLES=ON` to the CMake configure step
- Applied changes to both debug and release build configurations
- Retained all existing build flags without modification

 ### Linked issue
- Fixes #1277