### PR TITLE
ci: Automate 'status: needs revision' label on requested changes

### DIFF
--- a/.github/scripts/bot-on-pr-review.js
+++ b/.github/scripts/bot-on-pr-review.js
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// bot-on-pr-review.js
+//
+// Triggers on pull_request_review: submitted.
+// When a maintainer requests changes, automatically swaps the needs-review label
+// to needs-revision.
+
+const {
+  createLogger,
+  buildBotContext,
+  swapStatusLabel,
+} = require('./helpers');
+
+const logger = createLogger('on-pr-review');
+
+module.exports = async ({ github, context }) => {
+  try {
+    const botContext = buildBotContext({ github, context });
+
+    const state = context.payload.review?.state?.toLowerCase();
+
+    if (state !== 'changes_requested') {
+      logger.log(`Review state is '${state}', ignoring`);
+      return;
+    }
+
+    // Force swap to needs-revision (allPassed = false)
+    await swapStatusLabel(botContext, false, { force: true });
+    logger.log(`Successfully swapped status to needs revision`);
+  } catch (error) {
+    logger.error('Error:', {
+      message: error.message,
+      number: context?.payload?.pull_request?.number,
+    });
+    throw error;
+  }
+};

--- a/.github/scripts/helpers/api.js
+++ b/.github/scripts/helpers/api.js
@@ -23,7 +23,7 @@ const { buildBotComment } = require('./comments');
  *
  * @param {{ github: object, context: object }} args - The arguments from the workflow.
  * @returns {{ github: object, owner: string, repo: string, eventType: string, ... }}
- *   - pull_request / pull_request_target: also number, pr
+ *   - pull_request / pull_request_target / pull_request_review: also number, pr
  *   - issues: also number, issue
  *   - issue_comment: also number, issue, comment
  * @throws {Error} If input is invalid or event type is unsupported.
@@ -51,7 +51,8 @@ function buildBotContext({ github, context }) {
   let payloadPart;
   switch (eventType) {
     case 'pull_request':
-    case 'pull_request_target': {
+    case 'pull_request_target':
+    case 'pull_request_review': {
       const pr = payload.pull_request;
       requireObject(pr, 'context.payload.pull_request');
       requirePositiveInt(pr.number, 'pull_request.number');

--- a/.github/scripts/tests/test-on-pr-review-bot.js
+++ b/.github/scripts/tests/test-on-pr-review-bot.js
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// tests/test-on-pr-review-bot.js
+//
+// Integration tests for bot-on-pr-review.js (pull_request_review trigger).
+// Run with: node .github/scripts/tests/test-on-pr-review-bot.js
+
+const { runTestSuite, createMockGithub } = require('./test-utils');
+const script = require('../bot-on-pr-review.js');
+const { LABELS } = require('../helpers/constants');
+
+function defaultContext(overrides = {}) {
+  return {
+    eventName: 'pull_request_review',
+    repo: { owner: 'test-owner', repo: 'test-repo' },
+    payload: {
+      pull_request: {
+        number: 1,
+        user: { login: 'contributor' },
+        labels: [],
+      },
+      review: {
+        state: 'changes_requested',
+      },
+    },
+    ...overrides,
+  };
+}
+
+const scenarios = [
+  {
+    name: 'Changes requested, PR has needs-review label',
+    setup: {
+      state: 'changes_requested',
+      prLabels: [{ name: LABELS.NEEDS_REVIEW }],
+    },
+    verify: ({ calls }) =>
+      calls.labelsRemoved.includes(LABELS.NEEDS_REVIEW) &&
+      calls.labelsAdded.includes(LABELS.NEEDS_REVISION),
+  },
+  {
+    name: 'Changes requested, PR does not have needs-review label',
+    setup: {
+      state: 'changes_requested',
+      prLabels: [],
+    },
+    verify: ({ calls }) =>
+      calls.labelsRemoved.length === 0 &&
+      calls.labelsAdded.includes(LABELS.NEEDS_REVISION),
+  },
+  {
+    name: 'Review approved (ignored)',
+    setup: {
+      state: 'approved',
+      prLabels: [{ name: LABELS.NEEDS_REVIEW }],
+    },
+    verify: ({ calls }) =>
+      calls.labelsRemoved.length === 0 &&
+      calls.labelsAdded.length === 0,
+  },
+  {
+    name: 'Review commented (ignored)',
+    setup: {
+      state: 'commented',
+      prLabels: [{ name: LABELS.NEEDS_REVIEW }],
+    },
+    verify: ({ calls }) =>
+      calls.labelsRemoved.length === 0 &&
+      calls.labelsAdded.length === 0,
+  },
+  {
+    name: 'Uppercase state CHANGES_REQUESTED is handled',
+    setup: {
+      state: 'CHANGES_REQUESTED',
+      prLabels: [{ name: LABELS.NEEDS_REVIEW }],
+    },
+    verify: ({ calls }) =>
+      calls.labelsRemoved.includes(LABELS.NEEDS_REVIEW) &&
+      calls.labelsAdded.includes(LABELS.NEEDS_REVISION),
+  },
+];
+
+async function runScenario(scenario, index) {
+  const opts = scenario.setup;
+
+  const mock = createMockGithub();
+  const github = {
+    rest: mock.rest,
+    graphql: mock.graphql.bind(mock),
+  };
+
+  const context = defaultContext({
+    payload: {
+      pull_request: {
+        number: 1,
+        user: { login: 'contributor' },
+        labels: opts.prLabels || [],
+      },
+      review: {
+        state: opts.state,
+      },
+    },
+  });
+
+  try {
+    await script({ github, context });
+  } catch (error) {
+    console.log(`\n❌ Scenario ${index + 1}: ${scenario.name}`);
+    console.log(`   Script threw: ${error.message}`);
+    return false;
+  }
+
+  if (!scenario.verify({ calls: mock.calls })) {
+    console.log(`\n❌ Scenario ${index + 1}: ${scenario.name}`);
+    console.log('   Verification failed');
+    console.log('   labelsAdded:', JSON.stringify(mock.calls.labelsAdded));
+    console.log('   labelsRemoved:', JSON.stringify(mock.calls.labelsRemoved));
+    return false;
+  }
+
+  return true;
+}
+
+if (require.main === module) {
+  runTestSuite('ON-PR-REVIEW BOT TEST SUITE', scenarios, runScenario);
+} else {
+  module.exports = { runTestSuite: () => runTestSuite('ON-PR-REVIEW BOT TEST SUITE', scenarios, runScenario) };
+}

--- a/.github/workflows/on-pr-review.yaml
+++ b/.github/workflows/on-pr-review.yaml
@@ -1,0 +1,36 @@
+name: Bot - On PR Review
+
+on:
+  pull_request_review:
+    types:
+      - submitted
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  on-pr-review:
+    runs-on: hiero-client-sdk-linux-large
+    if: github.event.pull_request.draft == false
+
+    concurrency:
+      group: pr-bot-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Bot
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const script = require('./.github/scripts/bot-on-pr-review.js');
+            await script({ github, context });

--- a/.github/workflows/zxc-test-bot-scripts.yaml
+++ b/.github/workflows/zxc-test-bot-scripts.yaml
@@ -57,3 +57,6 @@ jobs:
 
       - name: Run On-Comment (Assign) Bot Tests
         run: node .github/scripts/tests/test-assign-bot.js
+
+      - name: Run On-PR-Review Bot Tests
+        run: node .github/scripts/tests/test-on-pr-review-bot.js


### PR DESCRIPTION
**Description**:
Automates the application of the `status: needs revision` label when a maintainer submits a PR review with "CHANGES REQUESTED". Previously, this transition was done manually. 

* Add new GitHub workflow `.github/workflows/on-pr-review.yaml` triggering on review submission
* Add dedicated bot script `.github/scripts/bot-on-pr-review.js` to process review webhook and swap pipeline status
* Update `buildBotContext` helper inside `api.js` to natively digest `pull_request_review` payloads
* Add extensive integration test scenarios via `test-on-pr-review-bot.js`

**Related issue(s)**:

Fixes #1410

**Notes for reviewer**:
All previous validation and integration tests were verified passing locally, including 5 new specialized integrations simulating different review payloads (Approved, Commented, Changes Requested with/without prior labels) handling errors gracefully. 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)

new test file is passing : 

<img width="748" height="535" alt="image" src="https://github.com/user-attachments/assets/780a2903-f6e8-4e35-b2ea-a27148b7b6f5" />
