### PR TITLE
fix: resolve `ReferenceError: getIssueSkillLevel is not defined` in assign bot

### DIFF
--- a/.github/scripts/commands/assign.js
+++ b/.github/scripts/commands/assign.js
@@ -556,7 +556,7 @@ async function assignAndFinalize(botContext, requesterUsername, skillLevel) {
     return;
   }
 
-  const freshSkillLevel = getIssueSkillLevel(freshIssue);
+  const freshSkillLevel = getHighestIssueSkillLevel(freshIssue);
   if (!freshSkillLevel) {
     logger.log("Exit: fresh issue state has no skill level label");
     await postComment(botContext, buildNoSkillLevelComment(requesterUsername));


### PR DESCRIPTION
## Summary

Fixes a crash in the `/assign` bot that silently blocked qualified contributors from being assigned to issues. When a contributor met all prerequisites and the bot reached the final assignment step, it threw `ReferenceError: getIssueSkillLevel is not defined`, causing the workflow run to fail with no response posted to the contributor.

**Key Changes:**
- Rename one function call in `assignAndFinalize` from the removed `getIssueSkillLevel` to the correct `getHighestIssueSkillLevel`

## Changes

### Bug Fix — Stale Function Name in Fresh-Label Revalidation Block

**Problem:** The `/assign` bot was crashing for any contributor who fully qualified for an issue. The crash only affected the `assignAndFinalize` code path — contributors who failed prerequisites were unaffected and received the expected gating comment.

**Root Cause:** Two commits created a naming mismatch:
1. `7b24076` removed the local `getIssueSkillLevel` function from `assign.js` and replaced all call sites with the shared import `getHighestIssueSkillLevel`
2. `2e69f05` added a new fresh-label revalidation block that called `getIssueSkillLevel(freshIssue)` — the now-removed name

Because `2e69f05` was developed against a state that still had the local function, the regression was not caught before merge.

**Fix:** Replace the stale call with the already-imported `getHighestIssueSkillLevel`.

```js
// Before
const freshSkillLevel = getIssueSkillLevel(freshIssue);

// After
const freshSkillLevel = getHighestIssueSkillLevel(freshIssue);
```

**Files Changed:**
- `.github/scripts/commands/assign.js` — line 559, single call site

## Testing

**Confirmed via GitHub Actions log** for run `24407536702` (`Bot - On Comment`, issue #1412, 2026-04-14T15:22:34Z):

```
[on-assign] Prerequisites met: { required: 3, completed: 3 }
[on-assign] Assigning issue to Egbaiyelo
[on-assign] Error: { message: 'getIssueSkillLevel is not defined', ... }
ReferenceError: getIssueSkillLevel is not defined
    at assignAndFinalize (.../assign.js:559:27)
```

The fix targets exactly the line and function shown in the stack trace.

**Test Plan:**
- [x] Verified `getHighestIssueSkillLevel` is already imported at line 20 of `assign.js` — no new import needed
- [x] Confirmed no other call sites use the old name (grep across all scripts returns zero matches)
- [x] All existing bot tests continue to pass

## Files Changed Summary

| Category | Files |
|----------|-------|
| Bot scripts | `.github/scripts/commands/assign.js` |

## Breaking Changes

**None.** The fix corrects an internal call to an already-imported function. No public APIs, workflow interfaces, or contributor-facing behavior change beyond the bug being fixed.

## Additional Information

- Surfaced by Egbaiyelo's `/assign` comment on issue #1412, which you manually resolved
- Closes #1432
