### PR TITLE
Fix/operator== fee components

### DIFF
--- a/.github/scripts/commands/assign-comments.js
+++ b/.github/scripts/commands/assign-comments.js
@@ -233,6 +233,31 @@ function buildNoSkillLevelComment(requesterUsername) {
 }
 
 /**
+ * Builds the comment posted when the issue's skill level changes while the
+ * assignment request is queued. Tells the requester to retry so eligibility
+ * checks run against the latest label state.
+ *
+ * @param {string} requesterUsername - The GitHub username who commented /assign.
+ * @param {string} previousSkillLevel - The skill level from the event payload.
+ * @param {string} currentSkillLevel - The skill level from the fresh issue snapshot.
+ * @returns {string} The formatted Markdown comment body.
+ */
+function buildSkillLevelChangedComment(
+  requesterUsername,
+  previousSkillLevel,
+  currentSkillLevel,
+) {
+  return [
+    `👋 Hi @${requesterUsername}! The skill level for this issue changed while your assignment request was being processed.`,
+    "",
+    `**Current label:** \`${currentSkillLevel}\``,
+    `**Previous label:** \`${previousSkillLevel}\``,
+    "",
+    "Please comment `/assign` again to request assignment with the updated skill requirements.",
+  ].join("\n");
+}
+
+/**
  * Builds a GitHub Issues search URL for the given repository and query string.
  *
  * @param {string} owner - Repository owner.
@@ -421,6 +446,7 @@ module.exports = {
   buildNotReadyComment,
   buildPrerequisiteNotMetComment,
   buildNoSkillLevelComment,
+  buildSkillLevelChangedComment,
   buildAssignmentLimitExceededComment,
   buildGfiLimitExceededComment,
   buildApiErrorComment,

--- a/.github/scripts/commands/assign.js
+++ b/.github/scripts/commands/assign.js
@@ -17,7 +17,8 @@ const {
   addAssignees,
   postComment,
   acknowledgeComment,
-} = require("../helpers");
+  getHighestIssueSkillLevel,
+} = require('../helpers');
 
 const {
   MAX_OPEN_ASSIGNMENTS,
@@ -51,21 +52,6 @@ const logger = createDelegatingLogger();
  */
 function formatThresholdedCount(count, threshold) {
   return count >= threshold ? `${threshold}+` : String(count);
-}
-
-/**
- * Returns the skill-level label on an issue, checking in ascending order:
- * Good First Issue -> Beginner -> Intermediate -> Advanced.
- * Returns the first match, or null if the issue has no skill-level label.
- *
- * @param {{ labels: Array<string|{ name: string }> }} issue - The issue object from the GitHub payload.
- * @returns {string|null} The matching LABELS constant (e.g. LABELS.BEGINNER), or null.
- */
-function getIssueSkillLevel(issue) {
-  for (const level of SKILL_HIERARCHY) {
-    if (hasLabel(issue, level)) return level;
-  }
-  return null;
 }
 
 /**
@@ -417,7 +403,7 @@ async function validateIssueState(botContext, requesterUsername) {
     return null;
   }
 
-  const skillLevel = getIssueSkillLevel(botContext.issue);
+  const skillLevel = getHighestIssueSkillLevel(botContext.issue);
   if (!skillLevel) {
     logger.log("Exit: issue has no skill level label");
     await postComment(botContext, buildNoSkillLevelComment(requesterUsername));

--- a/.github/scripts/commands/assign.js
+++ b/.github/scripts/commands/assign.js
@@ -556,7 +556,7 @@ async function assignAndFinalize(botContext, requesterUsername, skillLevel) {
     return;
   }
 
-  const freshSkillLevel = getIssueSkillLevel(freshIssue);
+  const freshSkillLevel = getHighestIssueSkillLevel(freshIssue);
   if (!freshSkillLevel) {
     logger.log("Exit: fresh issue state has no skill level label");
     await postComment(botContext, buildNoSkillLevelComment(requesterUsername));

--- a/.github/scripts/commands/assign.js
+++ b/.github/scripts/commands/assign.js
@@ -30,6 +30,7 @@ const {
   buildNotReadyComment,
   buildPrerequisiteNotMetComment,
   buildNoSkillLevelComment,
+  buildSkillLevelChangedComment,
   buildAssignmentLimitExceededComment,
   buildGfiLimitExceededComment,
   buildApiErrorComment,
@@ -540,6 +541,47 @@ async function assignAndFinalize(botContext, requesterUsername, skillLevel) {
     return;
   }
 
+  // Revalidate labels from the fresh issue snapshot to prevent stale-event
+  // payload eligibility checks when labels change while this run is queued.
+  if (!hasLabel(freshIssue, LABELS.READY_FOR_DEV)) {
+    logger.log("Exit: fresh issue state is missing ready for dev label");
+    await postComment(
+      botContext,
+      buildNotReadyComment(
+        requesterUsername,
+        botContext.owner,
+        botContext.repo,
+      ),
+    );
+    return;
+  }
+
+  const freshSkillLevel = getIssueSkillLevel(freshIssue);
+  if (!freshSkillLevel) {
+    logger.log("Exit: fresh issue state has no skill level label");
+    await postComment(botContext, buildNoSkillLevelComment(requesterUsername));
+    return;
+  }
+
+  // If the skill level changed while this run was queued, the earlier prerequisite
+  // and GFI-cap gates were run against a stale label. Abort and ask user to retry.
+  if (freshSkillLevel !== skillLevel) {
+    logger.log("Exit: skill level changed while queued", {
+      stalePayloadLevel: skillLevel,
+      freshReadLevel: freshSkillLevel,
+    });
+    await postComment(
+      botContext,
+      buildSkillLevelChangedComment(
+        requesterUsername,
+        skillLevel,
+        freshSkillLevel,
+      ),
+    );
+    logger.log("Posted skill-level-changed comment");
+    return;
+  }
+
   const assignResult = await addAssignees(botContext, [requesterUsername]);
   if (!assignResult.success) {
     await postComment(
@@ -552,7 +594,7 @@ async function assignAndFinalize(botContext, requesterUsername, skillLevel) {
 
   await postComment(
     botContext,
-    buildWelcomeComment(requesterUsername, skillLevel),
+    buildWelcomeComment(requesterUsername, freshSkillLevel),
   );
   logger.log("Posted welcome comment");
   await updateLabels(botContext, requesterUsername);
@@ -572,7 +614,9 @@ async function assignAndFinalize(botContext, requesterUsername, skillLevel) {
  *   7. GFI cap reached (skill: good first issue only)? -> GFI-limit-exceeded comment.
  *   8. Skill prerequisites not met? -> prerequisite-not-met comment.
  *   9. Issue snatched while queued (fresh fetch)? -> already-assigned comment.
- *   10. Assignment API failure? -> assignment-failure comment (tags maintainers).
+ *   10. Fresh labels invalid while queued? -> not-ready/no-skill-level comment.
+ *   11. Skill level changed while queued? -> skill-level-changed comment (ask to retry).
+ *   12. Assignment API failure? -> assignment-failure comment (tags maintainers).
  *
  * If all checks pass, the bot assigns the issue, posts a welcome comment,
  * and swaps the "status: ready for dev" label with "status: in progress".
@@ -587,7 +631,9 @@ async function handleAssign(botContext) {
 
   const ack = await acknowledgeComment(botContext, botContext.comment.id);
   if (!ack.success) {
-    logger.log('Aborting /assign: triggering comment was deleted or could not be acknowledged');
+    logger.log(
+      "Aborting /assign: triggering comment was deleted or could not be acknowledged",
+    );
     return;
   }
 

--- a/.github/scripts/commands/recommend-issues.js
+++ b/.github/scripts/commands/recommend-issues.js
@@ -13,6 +13,7 @@ const {
     hasLabel,
     postComment,
     getLogger,
+    getHighestIssueSkillLevel,
 } = require('../helpers');
 
 // Logger delegation 
@@ -20,21 +21,6 @@ const logger = {
     log: (...args) => getLogger().log(...args),
     error: (...args) => getLogger().error(...args),
 };
-
-/**
- * Returns the highest difficulty level of an issue based on its labels.
- *
- * Checks labels against SKILL_HIERARCHY in descending order and returns the first match.
- *
- * @param {{ labels: Array<string|{ name: string }> }} issue
- * @returns {string|null} Matching level or null if none found.
- */
-function getIssueSkillLevel(issue) {
-    for (const level of [...SKILL_HIERARCHY].reverse()) {
-        if (hasLabel(issue, level)) return level;
-    }
-    return null;
-}
 
 /**
  * Returns the next difficulty level in the hierarchy.
@@ -246,7 +232,7 @@ async function handleRecommendIssues(botContext) {
         return;
     }
 
-    const skillLevel = getIssueSkillLevel(botContext.issue);
+    const skillLevel = getHighestIssueSkillLevel(botContext.issue);
     if (!skillLevel) {
         logger.log('No skill level found, skipping recommendation', {
             issueNumber: botContext.issue?.number,
@@ -293,7 +279,6 @@ async function handleRecommendIssues(botContext) {
 
 module.exports = { 
     handleRecommendIssues,
-    getIssueSkillLevel,
     getNextLevel,
     getFallbackLevel,
     getRecommendedIssues,

--- a/.github/scripts/helpers/api.js
+++ b/.github/scripts/helpers/api.js
@@ -599,6 +599,21 @@ async function resolveLinkedIssue(botContext) {
     }
 }
 
+/**
+ * Returns the highest difficulty level of an issue based on its labels.
+ *
+ * Checks labels against SKILL_HIERARCHY in descending order and returns the first match.
+ *
+ * @param {{ labels: Array<string|{ name: string }> }} issue
+ * @returns {string|null} Matching level or null if none found.
+ */
+function getHighestIssueSkillLevel(issue) {
+  for (const level of [...SKILL_HIERARCHY].reverse()) {
+    if (hasLabel(issue, level)) return level;
+  }
+  return null;
+}
+
 module.exports = {
   buildBotContext,
   addLabels,
@@ -617,4 +632,5 @@ module.exports = {
   runAllChecksAndComment,
   resolveLinkedIssue,
   acknowledgeComment,
+  getHighestIssueSkillLevel,
 };

--- a/.github/scripts/helpers/checks.js
+++ b/.github/scripts/helpers/checks.js
@@ -143,6 +143,23 @@ function parseIssueNumbers(body) {
 }
 
 /**
+ * Identifies the issue numbers referenced in the PR title so they can be excluded from the GraphQL fallback results.
+ * @param {string} value 
+ * @returns {Set<number>}
+ */
+function extractNumbersFromTitle(value) {
+  const numbers = new Set();
+  const pattern = /#(\d+)/g;
+  if (!value) return numbers;
+
+  let match;
+  while ((match = pattern.exec(value)) !== null) {
+    numbers.add(parseInt(match[1], 10));
+  }
+  return numbers;
+}
+
+/**
  * Fetches each issue by number and checks whether the given author is assigned.
  * Issues that fail to fetch are silently skipped (logged only).
  * @param {object} botContext
@@ -187,8 +204,12 @@ async function checkIssueLink(botContext, { fetchIssue, fetchClosingIssueNumbers
   const issueNumbers = parseIssueNumbers(body);
 
   if (issueNumbers.size === 0) {
+    const prTitle = botContext.pr?.title || '';
+    const prTitleIssues = extractNumbersFromTitle(prTitle);
     const graphqlIssues = await fetchClosingIssueNumbers(botContext);
-    graphqlIssues.forEach(n => issueNumbers.add(n));
+    graphqlIssues
+      .filter(n => !prTitleIssues.has(n))
+      .forEach(n => issueNumbers.add(n));
   }
 
   if (issueNumbers.size === 0) {
@@ -222,4 +243,5 @@ module.exports = {
   checkGPG,
   checkMergeConflict,
   checkIssueLink,
+  extractNumbersFromTitle,
 };

--- a/.github/scripts/tests/test-api.js
+++ b/.github/scripts/tests/test-api.js
@@ -14,6 +14,7 @@ const {
   swapStatusLabel,
   hasLabel,
   resolveLinkedIssue,
+  getHighestIssueSkillLevel,
 } = require('../helpers/api');
 const { LABELS } = require('../helpers/constants');
 const { isSafeSearchToken } = require('../helpers/validation');
@@ -620,8 +621,39 @@ const unitTests = [
     name: 'isSafeSearchToken: string with multiple brackets → false',
     test: () => isSafeSearchToken('bad[[admin]') === false,
   },
-];
 
+  // ---------------------------------------------------------------------------
+  // getHighestIssueSkillLevel
+  // ---------------------------------------------------------------------------
+  {
+    name: 'getHighestIssueSkillLevel: issue with one skill label → returns that level',
+    test: () => {
+      const issue = { number: 1, title: 'Test', labels: [{ name: LABELS.BEGINNER }, { name: LABELS.READY_FOR_DEV }] };
+      return getHighestIssueSkillLevel(issue) === LABELS.BEGINNER;
+    },
+  },
+  {
+    name: 'getHighestIssueSkillLevel: issue with no skill labels → returns null',
+    test: () => {
+      const issue = { number: 1, title: 'Test', labels: [{ name: 'bug' }, { name: 'enhancement' }] };
+      return getHighestIssueSkillLevel(issue) === null;
+    },
+  },
+  {
+    name: 'getHighestIssueSkillLevel: issue with multiple skill labels → returns highest',
+    test: () => {
+      const issue = { number: 1, title: 'Test', labels: [{ name: LABELS.GOOD_FIRST_ISSUE }, { name: LABELS.BEGINNER }, { name: LABELS.INTERMEDIATE }] };
+      return getHighestIssueSkillLevel(issue) === LABELS.INTERMEDIATE;
+    },
+  },
+  {
+    name: 'getHighestIssueSkillLevel: issue with empty labels → returns null',
+    test: () => {
+      const issue = { number: 1, title: 'Test', labels: [] };
+      return getHighestIssueSkillLevel(issue) === null;
+    },
+  },
+];
 // =============================================================================
 // TEST RUNNER
 // =============================================================================

--- a/.github/scripts/tests/test-assign-bot.js
+++ b/.github/scripts/tests/test-assign-bot.js
@@ -15,7 +15,7 @@ const script = require("../bot-on-comment.js");
 // MOCK GITHUB API
 // =============================================================================
 
-function createMockGithub(options = {}) {
+function createMockGithub(options = {}, issueFromPayload = null) {
   const {
     completedIssueCount = 0,
     completedIssueCounts = {},
@@ -30,6 +30,7 @@ function createMockGithub(options = {}) {
     reactionShouldFail = false,
     issueGetShouldFail = false,
     issueAssignees = null,
+    issueLabels = null,
   } = options;
 
   const calls = {
@@ -94,19 +95,28 @@ function createMockGithub(options = {}) {
           if (issueGetShouldFail) {
             throw new Error("Simulated issues.get failure");
           }
+          const freshLabels = Array.isArray(issueLabels)
+            ? issueLabels
+            : Array.isArray(issueFromPayload?.labels)
+              ? issueFromPayload.labels
+              : [];
           if (Array.isArray(issueAssignees)) {
             return {
               data: {
                 assignees: issueAssignees.map((login) => ({ login })),
+                labels: freshLabels,
               },
             };
           }
           if (options.issueAlreadyAssignedTo) {
             return {
-              data: { assignees: [{ login: options.issueAlreadyAssignedTo }] },
+              data: {
+                assignees: [{ login: options.issueAlreadyAssignedTo }],
+                labels: freshLabels,
+              },
             };
           }
-          return { data: { assignees: [] } };
+          return { data: { assignees: [], labels: freshLabels } };
         },
         listForRepo: async (params) => {
           calls.restCalls.push(
@@ -278,6 +288,95 @@ const scenarios = [
     expectedAssignee: null,
     expectedComments: [
       `👋 Hi @third-user! This issue is already assigned to @first-user, @second-user.\n\n👉 **Find another issue to work on:**\n[Browse unassigned issues](https://github.com/hiero-ledger/hiero-sdk-cpp/issues?q=is%3Aissue+is%3Aopen+no%3Aassignee+label%3A%22status%3A+ready+for+dev%22)\n\nOnce you find one you like, comment \`/assign\` to get started!`,
+    ],
+  },
+  {
+    name: "Race Condition - Ready Label Removed While Queued",
+    description:
+      "Fresh fetch no longer has ready-for-dev label; bot must abort assignment",
+    context: {
+      eventName: "issue_comment",
+      payload: {
+        issue: {
+          number: 124,
+          assignees: [],
+          labels: [
+            { name: "status: ready for dev" },
+            { name: "skill: good first issue" },
+          ],
+        },
+        comment: {
+          id: 1025,
+          body: "/assign",
+          user: { login: "stale-ready-user", type: "User" },
+        },
+      },
+      repo: { owner: "hiero-ledger", repo: "hiero-sdk-cpp" },
+    },
+    githubOptions: { issueLabels: [{ name: LABELS.GOOD_FIRST_ISSUE }] },
+    expectedAssignee: null,
+    expectedComments: [
+      `👋 Hi @stale-ready-user! This issue is not ready for development yet.\n\nIssues must have the \`status: ready for dev\` label before they can be assigned.\n\n👉 **Find an issue that's ready:**\n[Browse ready issues](https://github.com/hiero-ledger/hiero-sdk-cpp/issues?q=is%3Aissue+is%3Aopen+no%3Aassignee+label%3A%22status%3A+ready+for+dev%22)\n\nOnce you find one you like, comment \`/assign\` to get started!`,
+    ],
+  },
+  {
+    name: "Race Condition - Skill Label Removed While Queued",
+    description:
+      "Fresh fetch no longer has any skill label; bot must abort and tag maintainers",
+    context: {
+      eventName: "issue_comment",
+      payload: {
+        issue: {
+          number: 125,
+          assignees: [],
+          labels: [
+            { name: "status: ready for dev" },
+            { name: "skill: good first issue" },
+          ],
+        },
+        comment: {
+          id: 1026,
+          body: "/assign",
+          user: { login: "stale-skill-user", type: "User" },
+        },
+      },
+      repo: { owner: "hiero-ledger", repo: "hiero-sdk-cpp" },
+    },
+    githubOptions: { issueLabels: [{ name: LABELS.READY_FOR_DEV }] },
+    expectedAssignee: null,
+    expectedComments: [
+      `👋 Hi @stale-skill-user! This issue doesn't have a skill level label yet.\n\n@hiero-ledger/hiero-sdk-cpp-maintainers — could you please add one of the following labels?\n- \`skill: good first issue\`\n- \`skill: beginner\`\n- \`skill: intermediate\`\n- \`skill: advanced\`\n\n@stale-skill-user, once a maintainer adds the label, comment \`/assign\` again to request assignment.`,
+    ],
+  },
+  {
+    name: "Race Condition - Skill Label Changed to Different Level While Queued",
+    description:
+      "Fresh fetch shows a different skill level; bot must abort since prerequisite gates were run against stale level",
+    context: {
+      eventName: "issue_comment",
+      payload: {
+        issue: {
+          number: 126,
+          assignees: [],
+          labels: [
+            { name: "status: ready for dev" },
+            { name: "skill: good first issue" },
+          ],
+        },
+        comment: {
+          id: 1027,
+          body: "/assign",
+          user: { login: "skill-changed-user", type: "User" },
+        },
+      },
+      repo: { owner: "hiero-ledger", repo: "hiero-sdk-cpp" },
+    },
+    githubOptions: {
+      issueLabels: [{ name: LABELS.READY_FOR_DEV }, { name: LABELS.BEGINNER }],
+    },
+    expectedAssignee: null,
+    expectedComments: [
+      `👋 Hi @skill-changed-user! The skill level for this issue changed while your assignment request was being processed.\n\n**Current label:** \`${LABELS.BEGINNER}\`\n**Previous label:** \`${LABELS.GOOD_FIRST_ISSUE}\`\n\nPlease comment \`/assign\` again to request assignment with the updated skill requirements.`,
     ],
   },
   {
@@ -1353,7 +1452,10 @@ async function runTest(scenario, index) {
   console.log(`Description: ${scenario.description}`);
   console.log("=".repeat(70));
 
-  const mockGithub = createMockGithub(scenario.githubOptions);
+  const mockGithub = createMockGithub(
+    scenario.githubOptions,
+    scenario.context?.payload?.issue,
+  );
 
   try {
     await script({ github: mockGithub, context: scenario.context });

--- a/.github/scripts/tests/test-checks.js
+++ b/.github/scripts/tests/test-checks.js
@@ -628,6 +628,36 @@ const unitTests = [
       return r.passed === false && r.reason === 'no_issue_linked' && r.issues.length === 0;
     },
   },
+  {
+    name: 'checkIssueLink: PR with a title containing an issue number and a body with none',
+    test: async () => {
+      const ctx = { pr: { title: 'Feature relates to #314', body: 'Fixes #', user: { login: 'monte' } } };
+      const fetchIssue = async () => ({
+        title: 'Feature request',
+        assignees: [{ login: 'monte' }],
+      });
+      const r = await checkIssueLink(ctx, {
+        fetchIssue,
+        fetchClosingIssueNumbers: async () => [314],
+      });
+      return r.passed === false && r.reason === 'no_issue_linked' && r.issues.length === 0;
+    },
+  },
+  {
+    name: 'checkIssueLink: PR with a title that contains no issue references and an empty body',
+    test: async () => {
+      const ctx = { pr: { title: 'Fix', body: 'Fixing something', user: { login: 'mark' } } };
+      const fetchIssue = async () => ({
+        title: 'Bug',
+        assignees: [{ login: 'mark' }],
+      });
+      const r = await checkIssueLink(ctx, {
+        fetchIssue,
+        fetchClosingIssueNumbers: async () => [12],
+      });
+      return r.passed === true && r.issues.length === 1 && r.issues[0].number === 12;
+    },
+  },
 ];
 
 // =============================================================================

--- a/.github/scripts/tests/test-recommend-issues-bot.js
+++ b/.github/scripts/tests/test-recommend-issues-bot.js
@@ -9,7 +9,6 @@ const { runTestSuite } = require('./test-utils');
 const { LABELS, SKILL_HIERARCHY, MAINTAINER_TEAM } = require('../helpers/constants');
 const {
   handleRecommendIssues,
-  getIssueSkillLevel,
   getNextLevel,
   getFallbackLevel,
   getRecommendedIssues,
@@ -74,38 +73,6 @@ const TOP      = SKILL_HIERARCHY[SKILL_HIERARCHY.length - 1];
 // =============================================================================
 
 const unitTests = [
-
-  // ---------------------------------------------------------------------------
-  // getIssueSkillLevel
-  // ---------------------------------------------------------------------------
-  {
-    name: 'getIssueSkillLevel: issue with one skill label → returns that level',
-    test: () => {
-      const issue = makeIssue([BEGINNER, LABELS.READY_FOR_DEV]);
-      return getIssueSkillLevel(issue) === BEGINNER;
-    },
-  },
-  {
-    name: 'getIssueSkillLevel: issue with no skill labels → returns null',
-    test: () => {
-      const issue = makeIssue(['bug', 'enhancement']);
-      return getIssueSkillLevel(issue) === null;
-    },
-  },
-  {
-    name: 'getIssueSkillLevel: issue with multiple skill labels → returns highest',
-    test: () => {
-      // recommend-issues iterates reversed, so highest wins
-      const issue = makeIssue([GFI, BEGINNER, MID]);
-      return getIssueSkillLevel(issue) === MID;
-    },
-  },
-  {
-    name: 'getIssueSkillLevel: issue with empty labels → returns null',
-    test: () => {
-      return getIssueSkillLevel(makeIssue([])) === null;
-    },
-  },
 
   // ---------------------------------------------------------------------------
   // getNextLevel

--- a/.github/workflows/on-comment.yaml
+++ b/.github/workflows/on-comment.yaml
@@ -22,8 +22,9 @@ name: Bot - On Comment
 # Concurrency:
 #   Serialized per issue number (cancel-in-progress: false) to prevent
 #   same-issue races where two different users both see assignees=[] and
-#   both get assigned. Same-user multi-issue bypass is handled by fresh-state
-#   REST counting plus post-write rollback in assign.js.
+#   both get assigned. Same-issue collisions are caught by the pre-write
+#   fresh issues.get() in assignAndFinalize(). Same-user multi-issue limits
+#   are enforced via REST API counting in enforceAssignmentLimit().
 # ──────────────────────────────────────────────────────────────────────
 on:
   issue_comment:

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -160,7 +160,8 @@ jobs:
           VCPKG_BINARY_SOURCES: clear
         run: |
           echo "::group::Configure Project"
-          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-debug -DBUILD_TESTS=ON -DBUILD_TCK_TESTS=ON
+          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-debug \
+            -DBUILD_TESTS=ON -DBUILD_TCK=ON -DBUILD_TCK_TESTS=ON -DBUILD_EXAMPLES=ON
           echo "::endgroup::"
 
           echo "::group::Build Project"
@@ -173,7 +174,8 @@ jobs:
           VCPKG_BINARY_SOURCES: clear
         run: |
           echo "::group::Configure Project"
-          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-release -DBUILD_TESTS=ON -DBUILD_TCK_TESTS=ON
+          ${{ steps.cgroup.outputs.exec }} cmake --preset ${{ matrix.preset }}-release \
+            -DBUILD_TESTS=ON -DBUILD_TCK=ON -DBUILD_TCK_TESTS=ON -DBUILD_EXAMPLES=ON
           echo "::endgroup::"
 
           echo "::group::Build Project"

--- a/src/sdk/main/include/AccountInfo.h
+++ b/src/sdk/main/include/AccountInfo.h
@@ -125,7 +125,7 @@ public:
 
   /**
    * The duration of time the queried account uses to automatically extend its expiration period. If it doesn't have
-   * enough balance, it extends as long as possible. It it is empty when it expires, then it is deleted.
+   * enough balance, it extends as long as possible. If it is empty when it expires, then it is deleted.
    */
   std::chrono::system_clock::duration mAutoRenewPeriod;
 

--- a/src/sdk/main/include/AccountInfo.h
+++ b/src/sdk/main/include/AccountInfo.h
@@ -125,7 +125,7 @@ public:
 
   /**
    * The duration of time the queried account uses to automatically extend its expiration period. If it doesn't have
-   * enough balance, it extends as long as possible. If it is empty when it expires, then it is deleted.
+   * enough balance, it extends as long as possible. It it is empty when it expires, then it is deleted.
    */
   std::chrono::system_clock::duration mAutoRenewPeriod;
 

--- a/src/sdk/main/include/AccountUpdateTransaction.h
+++ b/src/sdk/main/include/AccountUpdateTransaction.h
@@ -364,7 +364,7 @@ private:
   std::optional<bool> mReceiverSignatureRequired;
 
   /**
-   * The new duration to use for the account to automatically extend its expiration period. It it doesn't have enough
+   * The new duration to use for the account to automatically extend its expiration period. If it doesn't have enough
    * balance, it extends as long as possible. If it is empty when it expires, then it is deleted.
    */
   std::optional<std::chrono::system_clock::duration> mAutoRenewPeriod;

--- a/src/sdk/main/include/ContractDeleteTransaction.h
+++ b/src/sdk/main/include/ContractDeleteTransaction.h
@@ -80,6 +80,15 @@ public:
   ContractDeleteTransaction& setTransferContractId(const ContractId& contractId);
 
   /**
+   * Set the permanent removal flag. If true, marks this as a system-initiated permanent removal.
+   *
+   * @param permanentRemoval The permanent removal flag.
+   * @return A reference to this ContractDeleteTransaction object with the newly-set permanent removal flag.
+   * @throws IllegalStateException If this ContractDeleteTransaction is frozen.
+   */
+  ContractDeleteTransaction& setPermanentRemoval(bool permanentRemoval);
+
+  /**
    * Get the ID of the contract to delete.
    *
    * @return The ID of the contract to delete.
@@ -101,6 +110,13 @@ public:
    *         uninitialized if a value has not yet been set, or if a transfer account ID has been set most recently.
    */
   [[nodiscard]] inline std::optional<ContractId> getTransferContractId() const { return mTransferContractId; }
+
+  /**
+   * Get the permanent removal flag.
+   *
+   * @return The permanent removal flag. Returns uninitialized if a value has not yet been set.
+   */
+  [[nodiscard]] inline std::optional<bool> getPermanentRemoval() const { return mPermanentRemoval; }
 
 private:
   friend class WrappedTransaction;
@@ -164,6 +180,11 @@ private:
    * The ID of the contract that will receive the deleted smart contract's remaining Hbars.
    */
   std::optional<ContractId> mTransferContractId;
+
+  /**
+   * If set to true, marks this as a system-initiated permanent removal.
+   */
+  std::optional<bool> mPermanentRemoval;
 };
 
 } // namespace Hiero

--- a/src/sdk/main/include/FeeComponents.h
+++ b/src/sdk/main/include/FeeComponents.h
@@ -324,6 +324,15 @@ private:
    * The price of bandwidth for data retrieved from disk for a response, measured in bytes.
    */
   int64_t mResponseDiskByte = 0LL;
+
+  /**
+   * Compare this FeeComponents to another FeeComponents and determine if they represent an equivalent set of fees.
+   *
+   * @param lhs The left-hand side FeeComponents to compare.
+   * @param rhs The right-hand side FeeComponents to compare.
+   * @return \c TRUE if this FeeComponents is the same as the input FeeComponents, otherwise \c FALSE.
+   */
+  [[nodiscard]] friend bool operator==(const FeeComponents& lhs, const FeeComponents& rhs);
 };
 
 } // namespace Hiero

--- a/src/sdk/main/include/TokenRelationship.h
+++ b/src/sdk/main/include/TokenRelationship.h
@@ -28,7 +28,7 @@ namespace Hiero
 class TokenRelationship
 {
 public:
-  TokenRelationship() = default;
+  TokenRelationship();
 
   /**
    * Constructor for TokenRelationship.

--- a/src/sdk/main/src/ContractDeleteTransaction.cc
+++ b/src/sdk/main/src/ContractDeleteTransaction.cc
@@ -49,6 +49,14 @@ ContractDeleteTransaction& ContractDeleteTransaction::setTransferContractId(cons
 }
 
 //-----
+ContractDeleteTransaction& ContractDeleteTransaction::setPermanentRemoval(bool permanentRemoval)
+{
+  requireNotFrozen();
+  mPermanentRemoval = permanentRemoval;
+  return *this;
+}
+
+//-----
 grpc::Status ContractDeleteTransaction::submitRequest(const proto::Transaction& request,
                                                       const std::shared_ptr<internal::Node>& node,
                                                       const std::chrono::system_clock::time_point& deadline,
@@ -106,6 +114,8 @@ void ContractDeleteTransaction::initFromSourceTransactionBody()
   {
     mTransferContractId = ContractId::fromProtobuf(body.transfercontractid());
   }
+
+  mPermanentRemoval = body.permanent_removal();
 }
 
 //-----
@@ -123,6 +133,11 @@ proto::ContractDeleteTransactionBody* ContractDeleteTransaction::build() const
   else if (mTransferContractId.has_value())
   {
     body->set_allocated_transfercontractid(mTransferContractId->toProtobuf().release());
+  }
+
+  if (mPermanentRemoval.has_value())
+  {
+    body->set_permanent_removal(mPermanentRemoval.value());
   }
 
   return body.release();

--- a/src/sdk/main/src/FeeComponents.cc
+++ b/src/sdk/main/src/FeeComponents.cc
@@ -75,4 +75,17 @@ std::string FeeComponents::toString() const
   return json.dump();
 }
 
+//-----
+bool operator==(const FeeComponents& lhs, const FeeComponents& rhs)
+{
+  return (lhs.mMin == rhs.mMin) && (lhs.mMax == rhs.mMax) && (lhs.mConstant == rhs.mConstant) &&
+         (lhs.mTransactionBandwidthBytes == rhs.mTransactionBandwidthBytes) &&
+         (lhs.mTransactionVerification == rhs.mTransactionVerification) &&
+         (lhs.mTransactionRamByteHour == rhs.mTransactionRamByteHour) &&
+         (lhs.mTransactionStorageByteHour == rhs.mTransactionStorageByteHour) &&
+         (lhs.mContractTransactionGas == rhs.mContractTransactionGas) &&
+         (lhs.mTransferVolumeHbar == rhs.mTransferVolumeHbar) &&
+         (lhs.mResponseMemoryByte == rhs.mResponseMemoryByte) && (lhs.mResponseDiskByte == rhs.mResponseDiskByte);
+}
+
 } // namespace Hiero

--- a/src/sdk/main/src/TokenRelationship.cc
+++ b/src/sdk/main/src/TokenRelationship.cc
@@ -7,6 +7,18 @@
 using namespace Hiero;
 
 //-----
+TokenRelationship::TokenRelationship()
+  : mTokenId()
+  , mSymbol("")
+  , mBalance(0)
+  , mDecimals(0)
+  , mKycStatus()
+  , mFreezeStatus()
+  , mAutomaticAssociation(false)
+{
+}
+
+//-----
 TokenRelationship::TokenRelationship(const TokenId& tokenId,
                                      const std::string& symbol,
                                      uint64_t balance,
@@ -54,6 +66,7 @@ std::unique_ptr<proto::TokenRelationship> TokenRelationship::toProtobuf() const
   proto->set_decimals(mDecimals);
   proto->set_kycstatus(getKycStatus());
   proto->set_freezestatus(getFreezeStatus());
+  proto->set_automatic_association(mAutomaticAssociation);
 
   return proto;
 }

--- a/src/sdk/tests/integration/NetworkIntegrationTests.cc
+++ b/src/sdk/tests/integration/NetworkIntegrationTests.cc
@@ -6,6 +6,7 @@
 #include "Client.h"
 #include "impl/Network.h"
 
+#include <algorithm>
 #include <gtest/gtest.h>
 #include <unordered_map>
 #include <vector>
@@ -38,15 +39,8 @@ TEST_F(NetworkIntegrationTests, GetNodeAccountIdsForExecuteReturnsHealthyNodes)
   // verifying that algorithm worked properly
   for (const auto& accountId : accountIds)
   {
-    bool found = false;
-    for (const auto& [url, mapAccountId] : networkMap)
-    {
-      if (accountId == mapAccountId)
-      {
-        found = true;
-        break;
-      }
-    }
+    const bool found = std::any_of(
+      networkMap.cbegin(), networkMap.cend(), [&accountId](const auto& entry) { return entry.second == accountId; });
 
     EXPECT_TRUE(found);
   }

--- a/src/sdk/tests/unit/CMakeLists.txt
+++ b/src/sdk/tests/unit/CMakeLists.txt
@@ -124,6 +124,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenNftTransferUnitTests.cc
         TokenPauseTransactionUnitTests.cc
         TokenRejectTransactionUnitTests.cc
+        TokenRelationshipUnitTests.cc
         TokenRevokeKycTransactionUnitTests.cc
         TokenSupplyTypeUnitTests.cc
         TokenTransferHookUnitTests.cc

--- a/src/sdk/tests/unit/CMakeLists.txt
+++ b/src/sdk/tests/unit/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(${TEST_PROJECT_NAME}
         EvmHookSpecUnitTests.cc
         ExchangeRateUnitTests.cc
         FeeAssessmentMethodUnitTests.cc
+        FeeComponentsUnitTests.cc
         FileAppendTransactionUnitTests.cc
         FileContentsQueryUnitTests.cc
         FileCreateTransactionUnitTests.cc

--- a/src/sdk/tests/unit/FeeComponentsUnitTests.cc
+++ b/src/sdk/tests/unit/FeeComponentsUnitTests.cc
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+
+
 #include "FeeComponents.h"
 
 #include <gtest/gtest.h>

--- a/src/sdk/tests/unit/FeeComponentsUnitTests.cc
+++ b/src/sdk/tests/unit/FeeComponentsUnitTests.cc
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "FeeComponents.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hiero;
+
+class FeeComponentsUnitTests : public ::testing::Test
+{
+protected:
+  FeeComponents feeComponents;
+};
+
+//-----
+TEST_F(FeeComponentsUnitTests, DefaultConstructor)
+{
+  // Then
+  EXPECT_EQ(feeComponents.getMin(), 0LL);
+  EXPECT_EQ(feeComponents.getMax(), 0LL);
+  EXPECT_EQ(feeComponents.getConstant(), 0LL);
+  EXPECT_EQ(feeComponents.getTransactionBandwidthBytes(), 0LL);
+  EXPECT_EQ(feeComponents.getTransactionVerification(), 0LL);
+  EXPECT_EQ(feeComponents.getTransactionRamByteHour(), 0LL);
+  EXPECT_EQ(feeComponents.getTransactionStorageByteHour(), 0LL);
+  EXPECT_EQ(feeComponents.getContractTransactionGas(), 0LL);
+  EXPECT_EQ(feeComponents.getTransferVolumeHbar(), 0LL);
+  EXPECT_EQ(feeComponents.getResponseMemoryByte(), 0LL);
+  EXPECT_EQ(feeComponents.getResponseDiskByte(), 0LL);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorEqualsDefaultConstructed)
+{
+  // Given
+  FeeComponents lhs;
+  FeeComponents rhs;
+
+  // Then
+  EXPECT_TRUE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorEqualsIdentical)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setMin(1LL)
+    .setMax(2LL)
+    .setConstant(3LL)
+    .setTransactionBandwidthBytes(4LL)
+    .setTransactionVerification(5LL)
+    .setTransactionRamByteHour(6LL)
+    .setTransactionStorageByteHour(7LL)
+    .setContractTransactionGas(8LL)
+    .setTransferVolumeHbar(9LL)
+    .setResponseMemoryByte(10LL)
+    .setResponseDiskByte(11LL);
+
+  FeeComponents rhs;
+  rhs.setMin(1LL)
+    .setMax(2LL)
+    .setConstant(3LL)
+    .setTransactionBandwidthBytes(4LL)
+    .setTransactionVerification(5LL)
+    .setTransactionRamByteHour(6LL)
+    .setTransactionStorageByteHour(7LL)
+    .setContractTransactionGas(8LL)
+    .setTransferVolumeHbar(9LL)
+    .setResponseMemoryByte(10LL)
+    .setResponseDiskByte(11LL);
+
+  // Then
+  EXPECT_TRUE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentMin)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setMin(1LL);
+  FeeComponents rhs;
+  rhs.setMin(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentMax)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setMax(1LL);
+  FeeComponents rhs;
+  rhs.setMax(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentConstant)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setConstant(1LL);
+  FeeComponents rhs;
+  rhs.setConstant(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentTransactionBandwidthBytes)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setTransactionBandwidthBytes(1LL);
+  FeeComponents rhs;
+  rhs.setTransactionBandwidthBytes(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentTransactionVerification)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setTransactionVerification(1LL);
+  FeeComponents rhs;
+  rhs.setTransactionVerification(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentTransactionRamByteHour)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setTransactionRamByteHour(1LL);
+  FeeComponents rhs;
+  rhs.setTransactionRamByteHour(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentTransactionStorageByteHour)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setTransactionStorageByteHour(1LL);
+  FeeComponents rhs;
+  rhs.setTransactionStorageByteHour(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentContractTransactionGas)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setContractTransactionGas(1LL);
+  FeeComponents rhs;
+  rhs.setContractTransactionGas(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentTransferVolumeHbar)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setTransferVolumeHbar(1LL);
+  FeeComponents rhs;
+  rhs.setTransferVolumeHbar(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentResponseMemoryByte)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setResponseMemoryByte(1LL);
+  FeeComponents rhs;
+  rhs.setResponseMemoryByte(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentResponseDiskByte)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setResponseDiskByte(1LL);
+  FeeComponents rhs;
+  rhs.setResponseDiskByte(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}

--- a/src/sdk/tests/unit/TokenRelationshipUnitTests.cc
+++ b/src/sdk/tests/unit/TokenRelationshipUnitTests.cc
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "TokenRelationship.h"
+
+#include <gtest/gtest.h>
+#include <services/basic_types.pb.h>
+#include <services/crypto_get_info.pb.h>
+
+using namespace Hiero;
+
+class TokenRelationshipUnitTests : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTokenId; }
+  [[nodiscard]] inline const std::string& getTestSymbol() const { return mSymbol; }
+  [[nodiscard]] inline const uint64_t getTestBalance() const { return mBalance; }
+  [[nodiscard]] inline const uint32_t getTestDecimals() const { return mDecimals; }
+  [[nodiscard]] inline int getTestKycStatus() const { return mKycStatus; }
+  [[nodiscard]] inline int getTestFreezeStatus() const { return mFreezeStatus; }
+  [[nodiscard]] inline bool getTestAutomaticAssociation() const { return mAutomaticAssociation; }
+
+  TokenRelationship createWithStatuses(int kyc, int freeze)
+  {
+    return TokenRelationship(getTestTokenId(),
+                             getTestSymbol(),
+                             getTestBalance(),
+                             getTestDecimals(),
+                             kyc,
+                             freeze,
+                             getTestAutomaticAssociation());
+  }
+
+private:
+  const TokenId mTokenId = TokenId(10ULL);
+  const std::string mSymbol = "";
+  const uint64_t mBalance = 3000LL;
+  const uint32_t mDecimals = 0;
+  const int mKycStatus = 0;
+  const int mFreezeStatus = 0;
+  const bool mAutomaticAssociation = false;
+};
+
+//-----
+TEST_F(TokenRelationshipUnitTests, DefaultConstruction)
+{
+  // Given / When
+  TokenRelationship tokenRelationship;
+
+  // Then
+  EXPECT_EQ(tokenRelationship.mTokenId, TokenId());
+  EXPECT_EQ(tokenRelationship.mSymbol, "");
+  EXPECT_EQ(tokenRelationship.mBalance, 0);
+  EXPECT_EQ(tokenRelationship.mDecimals, 0);
+  EXPECT_FALSE(tokenRelationship.mKycStatus.has_value());
+  EXPECT_FALSE(tokenRelationship.mFreezeStatus.has_value());
+  EXPECT_EQ(tokenRelationship.mAutomaticAssociation, false);
+}
+
+//-----
+TEST_F(TokenRelationshipUnitTests, ConstructWithParameters)
+{
+  // Given / When
+  const TokenRelationship tokenRelationship(getTestTokenId(),
+                                            getTestSymbol(),
+                                            getTestBalance(),
+                                            getTestDecimals(),
+                                            getTestKycStatus(),
+                                            getTestFreezeStatus(),
+                                            getTestAutomaticAssociation());
+
+  // Then
+  EXPECT_EQ(tokenRelationship.mTokenId, getTestTokenId());
+  EXPECT_EQ(tokenRelationship.mSymbol, getTestSymbol());
+  EXPECT_EQ(tokenRelationship.mBalance, getTestBalance());
+  EXPECT_EQ(tokenRelationship.mDecimals, getTestDecimals());
+  EXPECT_FALSE(tokenRelationship.mKycStatus.has_value());
+  EXPECT_FALSE(tokenRelationship.mFreezeStatus.has_value());
+  EXPECT_EQ(tokenRelationship.mAutomaticAssociation, getTestAutomaticAssociation());
+}
+
+//-----
+TEST_F(TokenRelationshipUnitTests, FromProtobuf)
+{
+  // Given
+  proto::TokenRelationship protoRel;
+  protoRel.set_allocated_tokenid(getTestTokenId().toProtobuf().release());
+  protoRel.set_symbol(getTestSymbol());
+  protoRel.set_balance(getTestBalance());
+  protoRel.set_decimals(getTestDecimals());
+  protoRel.set_kycstatus(proto::TokenKycStatus::Granted);
+  protoRel.set_freezestatus(proto::TokenFreezeStatus::Frozen);
+  protoRel.set_automatic_association(true);
+
+  // When
+  const TokenRelationship rel = TokenRelationship::fromProtobuf(protoRel);
+
+  // Then
+  EXPECT_EQ(rel.mTokenId, getTestTokenId());
+  EXPECT_EQ(rel.mSymbol, getTestSymbol());
+  EXPECT_EQ(rel.mBalance, getTestBalance());
+  EXPECT_EQ(rel.mDecimals, getTestDecimals());
+  ASSERT_TRUE(rel.mKycStatus.has_value());
+  EXPECT_TRUE(rel.mKycStatus.value());
+  ASSERT_TRUE(rel.mFreezeStatus.has_value());
+  EXPECT_TRUE(rel.mFreezeStatus.value());
+  EXPECT_TRUE(rel.mAutomaticAssociation);
+
+  // Round-trip: automatic_association must survive toProtobuf()
+  const auto roundTripped = rel.toProtobuf();
+  EXPECT_TRUE(roundTripped->automatic_association());
+}
+
+//-----
+TEST_F(TokenRelationshipUnitTests, ToProtobuf)
+{
+  // Given
+  TokenRelationship rel(getTestTokenId(),
+                        getTestSymbol(),
+                        getTestBalance(),
+                        getTestDecimals(),
+                        getTestKycStatus(),
+                        getTestFreezeStatus(),
+                        getTestAutomaticAssociation());
+
+  // When
+  auto protoRel = rel.toProtobuf();
+
+  // Then
+  EXPECT_EQ(protoRel->tokenid().tokennum(), getTestTokenId().mTokenNum);
+  EXPECT_EQ(protoRel->symbol(), getTestSymbol());
+  EXPECT_EQ(protoRel->balance(), getTestBalance());
+  EXPECT_EQ(protoRel->decimals(), getTestDecimals());
+  EXPECT_EQ(protoRel->kycstatus(), getTestKycStatus());
+  EXPECT_EQ(protoRel->freezestatus(), getTestFreezeStatus());
+  EXPECT_EQ(protoRel->automatic_association(), getTestAutomaticAssociation());
+}
+
+//-----
+TEST_F(TokenRelationshipUnitTests, ToStringDefaultValues)
+{
+  // Given
+  TokenRelationship rel;
+
+  // When
+  std::string result = rel.toString();
+
+  // Then
+  EXPECT_NE(result.find("tokenId: " + rel.mTokenId.toString()), std::string::npos);
+  EXPECT_NE(result.find("symbol: " + rel.mSymbol), std::string::npos);
+  EXPECT_NE(result.find("balance: " + std::to_string(rel.mBalance)), std::string::npos);
+  EXPECT_NE(result.find("decimals: " + std::to_string(rel.mDecimals)), std::string::npos);
+  EXPECT_NE(result.find("kycStatus: null"), std::string::npos);
+  EXPECT_NE(result.find("freezeStatus: null"), std::string::npos);
+  EXPECT_NE(result.find("automaticAssociation: false"), std::string::npos);
+}
+
+//-----
+TEST_F(TokenRelationshipUnitTests, ToStringWithStatuses)
+{
+  // Given
+  TokenRelationship rel = createWithStatuses(1, 1);
+
+  // When
+  std::string result = rel.toString();
+
+  // Then
+  EXPECT_NE(result.find("kycStatus: 1"), std::string::npos);
+  EXPECT_NE(result.find("freezeStatus: 1"), std::string::npos);
+}
+
+//-----
+TEST_F(TokenRelationshipUnitTests, SetGetFreezeStatus)
+{
+  // Given / When
+  TokenRelationship relFrozen = createWithStatuses(getTestKycStatus(), 1);
+  TokenRelationship relUnfrozen = createWithStatuses(getTestKycStatus(), 2);
+  TokenRelationship relNotApplicable = createWithStatuses(getTestKycStatus(), 0);
+
+  // Then
+  ASSERT_TRUE(relFrozen.mFreezeStatus.has_value());
+  EXPECT_TRUE(relFrozen.mFreezeStatus.value());
+  ASSERT_TRUE(relUnfrozen.mFreezeStatus.has_value());
+  EXPECT_FALSE(relUnfrozen.mFreezeStatus.value());
+  EXPECT_FALSE(relNotApplicable.mFreezeStatus.has_value());
+  EXPECT_THROW(TokenRelationship relInvalidFreeze = createWithStatuses(getTestKycStatus(), 3);, std::invalid_argument);
+  EXPECT_THROW(TokenRelationship relInvalidFreeze1 = createWithStatuses(getTestKycStatus(), -1);
+               , std::invalid_argument);
+}
+
+//-----
+TEST_F(TokenRelationshipUnitTests, SetGetKycStatus)
+{
+  // Given / When
+  TokenRelationship relGranted = createWithStatuses(1, getTestFreezeStatus());
+  TokenRelationship relRevoked = createWithStatuses(2, getTestFreezeStatus());
+  TokenRelationship relNotApplicable = createWithStatuses(0, getTestFreezeStatus());
+
+  // Then
+  ASSERT_TRUE(relGranted.mKycStatus.has_value());
+  EXPECT_TRUE(relGranted.mKycStatus.value());
+  ASSERT_TRUE(relRevoked.mKycStatus.has_value());
+  EXPECT_FALSE(relRevoked.mKycStatus.value());
+  EXPECT_FALSE(relNotApplicable.mKycStatus.has_value());
+  EXPECT_THROW(TokenRelationship relInvalidKyc = createWithStatuses(3, getTestFreezeStatus());, std::invalid_argument);
+  EXPECT_THROW(TokenRelationship relInvalidKyc1 = createWithStatuses(-1, getTestFreezeStatus());
+               , std::invalid_argument);
+}

--- a/src/tck/CMakeLists.txt
+++ b/src/tck/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TCK_SERVER_NAME ${PROJECT_NAME}-tck)
 add_executable(${TCK_SERVER_NAME}
         src/account/AccountService.cc
+        src/contract/ContractService.cc
         src/file/FileService.cc
         src/json/JsonRpcException.cc
         src/json/JsonRpcParser.cc

--- a/src/tck/include/contract/ContractService.h
+++ b/src/tck/include/contract/ContractService.h
@@ -10,6 +10,10 @@ namespace Hiero::TCK::ContractService
  * Forward declarations.
  */
 struct DeleteContractParams;
+struct CreateContractParams;
+struct ContractByteCodeQueryParams;
+struct ContractCallQueryParams;
+struct ContractInfoQueryParams;
 
 /**
  * Delete a contract.
@@ -19,6 +23,37 @@ struct DeleteContractParams;
  */
 nlohmann::json deleteContract(const DeleteContractParams& params);
 
+/**
+ * Create a contract.
+ *
+ * @param params The parameters to use to create a contract.
+ * @return A JSON response containing the created contract ID and status.
+ */
+nlohmann::json createContract(const CreateContractParams& params);
+
+/**
+ * Query a bytecode of contract.
+ *
+ * @param params The parameters to use for the contract bytecode query.
+ * @return A JSON response containing the contract bytecode.
+ */
+nlohmann::json contractByteCodeQuery(const ContractByteCodeQueryParams& params);
+
+/**
+ * Query a smart contract function without changing state.
+ *
+ * @param params The parameters to use for the contract call query.
+ * @return A JSON response containing contract function result fields.
+ */
+nlohmann::json contractCallQuery(const ContractCallQueryParams& params);
+
+/**
+ * Query full smart contract metadata.
+ *
+ * @param params The parameters to use for the contract info query.
+ * @return A JSON response containing contract metadata fields.
+ */
+nlohmann::json contractInfoQuery(const ContractInfoQueryParams& params);
 } // namespace Hiero::TCK::ContractService
 
 #endif // HIERO_TCK_CPP_CONTRACT_SERVICE_H_

--- a/src/tck/include/contract/ContractService.h
+++ b/src/tck/include/contract/ContractService.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef HIERO_TCK_CPP_CONTRACT_SERVICE_H_
+#define HIERO_TCK_CPP_CONTRACT_SERVICE_H_
+
+#include <nlohmann/json_fwd.hpp>
+
+namespace Hiero::TCK::ContractService
+{
+/**
+ * Forward declarations.
+ */
+struct DeleteContractParams;
+
+/**
+ * Delete a contract.
+ *
+ * @param params The parameters to use to delete a contract.
+ * @return A JSON response containing the status of the contract deletion.
+ */
+nlohmann::json deleteContract(const DeleteContractParams& params);
+
+} // namespace Hiero::TCK::ContractService
+
+#endif // HIERO_TCK_CPP_CONTRACT_SERVICE_H_

--- a/src/tck/include/contract/params/ContractByteCodeQueryParams.h
+++ b/src/tck/include/contract/params/ContractByteCodeQueryParams.h
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef HIERO_TCK_CPP_CONTRACT_BYTE_CODE_QUERY_PARAMS_H_
+#define HIERO_TCK_CPP_CONTRACT_BYTE_CODE_QUERY_PARAMS_H_
+
+#include "json/JsonUtils.h"
+
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+
+namespace Hiero::TCK::ContractService
+{
+/**
+ * Struct to hold the arguments of the `contractByteCodeQuery` JSON-RPC method call.
+ */
+struct ContractByteCodeQueryParams
+{
+  /**
+   * The ID of the contract of which to request the byte code.
+   */
+  std::optional<std::string> mContractId;
+
+  /**
+   * The maximum payment amount willing to be paid for this query in tinybars.
+   */
+  std::optional<std::string> mMaxQueryPayment;
+
+  /**
+   * The explicit payment amount for this query in tinybars.
+   */
+  std::optional<std::string> mQueryPayment;
+};
+} // namespace Hiero::TCK::ContractService
+
+namespace nlohmann
+{
+/**
+ * JSON serialiser template specialisation required to convert contractByteCodeQuery arguments properly.
+ */
+template<>
+struct [[maybe_unused]] adl_serializer<Hiero::TCK::ContractService::ContractByteCodeQueryParams>
+{
+  /**
+   * Convert a Json object to a ContractByteCodeQueryParams.
+   *
+   * @param jsonFrom The Json object with which to fill the ContractByteCodeQueryParams.
+   * @param params The ContractByteCodeQueryParams to fill with the JSON object.
+   */
+  static void from_json(const json& jsonFrom, Hiero::TCK::ContractService::ContractByteCodeQueryParams& params)
+  {
+    params.mContractId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "contractId");
+
+    params.mMaxQueryPayment = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "maxQueryPayment");
+
+    params.mQueryPayment = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "queryPayment");
+  }
+};
+} // namespace nlohmann
+
+#endif // HIERO_TCK_CPP_CONTRACT_BYTE_CODE_QUERY_PARAMS_H_

--- a/src/tck/include/contract/params/ContractCallQueryParams.h
+++ b/src/tck/include/contract/params/ContractCallQueryParams.h
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef HIERO_TCK_CPP_CONTRACT_CALL_QUERY_PARAMS_H_
+#define HIERO_TCK_CPP_CONTRACT_CALL_QUERY_PARAMS_H_
+
+#include "json/JsonUtils.h"
+
+#include <cstdint>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+
+namespace Hiero::TCK::ContractService
+{
+/**
+ * Struct to hold the arguments of the `contractCallQuery` JSON-RPC method call.
+ */
+struct ContractCallQueryParams
+{
+  /**
+   * The ID of the contract to query.
+   */
+  std::optional<std::string> mContractId;
+
+  /**
+   * Gas limit for the contract call query.
+   */
+  std::optional<int64_t> mGas;
+
+  /**
+   * The function name for the call.
+   */
+  std::optional<std::string> mFunctionName;
+
+  /**
+   * ABI-encoded function parameters as a hex string.
+   */
+  std::optional<std::string> mFunctionParameters;
+
+  /**
+   * The maximum payment amount in tinybars willing to be paid for this query.
+   */
+  std::optional<std::string> mMaxQueryPayment;
+
+  /**
+   * The exact query payment amount in tinybars.
+   */
+  std::optional<std::string> mQueryPayment;
+};
+
+} // namespace Hiero::TCK::ContractService
+
+namespace nlohmann
+{
+/**
+ * JSON serializer template specialization required to convert ContractCallQueryParams arguments properly.
+ */
+template<>
+struct [[maybe_unused]] adl_serializer<Hiero::TCK::ContractService::ContractCallQueryParams>
+{
+  /**
+   * Convert a JSON object to ContractCallQueryParams.
+   *
+   * @param jsonFrom The JSON object with which to fill ContractCallQueryParams.
+   * @param params   The ContractCallQueryParams to fill with the JSON object.
+   */
+  static void from_json(const json& jsonFrom, Hiero::TCK::ContractService::ContractCallQueryParams& params)
+  {
+    params.mContractId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "contractId");
+    params.mGas = Hiero::TCK::getOptionalJsonParameter<int64_t>(jsonFrom, "gas");
+    params.mFunctionName = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "functionName");
+    params.mFunctionParameters = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "functionParameters");
+    params.mMaxQueryPayment = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "maxQueryPayment");
+    params.mQueryPayment = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "queryPayment");
+  }
+};
+
+} // namespace nlohmann
+
+#endif // HIERO_TCK_CPP_CONTRACT_CALL_QUERY_PARAMS_H_

--- a/src/tck/include/contract/params/ContractInfoQueryParams.h
+++ b/src/tck/include/contract/params/ContractInfoQueryParams.h
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef HIERO_TCK_CPP_CONTRACT_INFO_QUERY_PARAMS_H_
+#define HIERO_TCK_CPP_CONTRACT_INFO_QUERY_PARAMS_H_
+
+#include "json/JsonUtils.h"
+
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+
+namespace Hiero::TCK::ContractService
+{
+/**
+ * Struct to hold the arguments of the `contractInfoQuery` JSON-RPC method call.
+ */
+struct ContractInfoQueryParams
+{
+  /**
+   * The ID of the contract to query.
+   */
+  std::optional<std::string> mContractId;
+
+  /**
+   * The maximum payment amount in tinybars willing to be paid for this query.
+   */
+  std::optional<std::string> mMaxQueryPayment;
+
+  /**
+   * The exact query payment amount in tinybars.
+   */
+  std::optional<std::string> mQueryPayment;
+};
+
+} // namespace Hiero::TCK::ContractService
+
+namespace nlohmann
+{
+/**
+ * JSON serializer template specialization required to convert ContractInfoQueryParams arguments properly.
+ */
+template<>
+struct [[maybe_unused]] adl_serializer<Hiero::TCK::ContractService::ContractInfoQueryParams>
+{
+  /**
+   * Convert a JSON object to ContractInfoQueryParams.
+   *
+   * @param jsonFrom The JSON object with which to fill ContractInfoQueryParams.
+   * @param params   The ContractInfoQueryParams to fill with the JSON object.
+   */
+  static void from_json(const json& jsonFrom, Hiero::TCK::ContractService::ContractInfoQueryParams& params)
+  {
+    params.mContractId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "contractId");
+    params.mMaxQueryPayment = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "maxQueryPayment");
+    params.mQueryPayment = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "queryPayment");
+  }
+};
+
+} // namespace nlohmann
+
+#endif // HIERO_TCK_CPP_CONTRACT_INFO_QUERY_PARAMS_H_

--- a/src/tck/include/contract/params/CreateContractParams.h
+++ b/src/tck/include/contract/params/CreateContractParams.h
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef HIERO_TCK_CPP_CREATE_CONTRACT_PARAMS_H_
+#define HIERO_TCK_CPP_CREATE_CONTRACT_PARAMS_H_
+
+#include "common/CommonTransactionParams.h"
+#include "json/JsonUtils.h"
+
+#include <cstdint>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+
+namespace Hiero::TCK::ContractService
+{
+/**
+ * Struct to hold the arguments for a `createContract` JSON-RPC method call.
+ */
+struct CreateContractParams
+{
+  /**
+   * ID of the file containing contract bytecode.
+   */
+  std::optional<std::string> mBytecodeFileId;
+
+  /**
+   * Gas limit for contract creation.
+   */
+  std::optional<int64_t> mGas;
+
+  /**
+   * Admin key controlling update/delete operations for the contract.
+   */
+  std::optional<std::string> mAdminKey;
+
+  /**
+   * ABI-encoded constructor parameters as hex-encoded bytes.
+   */
+  std::optional<std::string> mConstructorParameters;
+
+  /**
+   * Initial balance in tinybars.
+   */
+  std::optional<std::string> mInitialBalance;
+
+  /**
+   * Memo for the contract.
+   */
+  std::optional<std::string> mMemo;
+
+  /**
+   * Auto-renew account ID.
+   */
+  std::optional<std::string> mAutoRenewAccountId;
+
+  /**
+   * Auto-renew period in seconds.
+   */
+  std::optional<std::string> mAutoRenewPeriod;
+
+  /**
+   * ID of the account to stake to.
+   */
+  std::optional<std::string> mStakedAccountId;
+
+  /**
+   * ID of the node to stake to.
+   */
+  std::optional<std::string> mStakedNodeId;
+
+  /**
+   * Whether the contract should decline staking rewards.
+   */
+  std::optional<bool> mDeclineStakingReward;
+
+  /**
+   * Maximum number of automatic token associations.
+   */
+  std::optional<int32_t> mMaxAutomaticTokenAssociations;
+
+  /**
+   * Any parameters common to all transaction types.
+   */
+  std::optional<CommonTransactionParams> mCommonTxParams;
+};
+
+} // namespace Hiero::TCK::ContractService
+
+namespace nlohmann
+{
+/**
+ * JSON serializer template specialization required to convert CreateContractParams arguments properly.
+ */
+template<>
+struct [[maybe_unused]] adl_serializer<Hiero::TCK::ContractService::CreateContractParams>
+{
+  /**
+   * Convert a JSON object to a CreateContractParams.
+   *
+   * @param jsonFrom The JSON object with which to fill the CreateContractParams.
+   * @param params   The CreateContractParams to fill with the JSON object.
+   */
+  static void from_json(const json& jsonFrom, Hiero::TCK::ContractService::CreateContractParams& params)
+  {
+    params.mBytecodeFileId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "bytecodeFileId");
+    params.mGas = Hiero::TCK::getOptionalJsonParameter<int64_t>(jsonFrom, "gas");
+    params.mAdminKey = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "adminKey");
+    params.mConstructorParameters =
+      Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "constructorParameters");
+    params.mInitialBalance = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "initialBalance");
+    params.mMemo = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "memo");
+    params.mAutoRenewAccountId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "autoRenewAccountId");
+    params.mAutoRenewPeriod = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "autoRenewPeriod");
+    params.mStakedAccountId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "stakedAccountId");
+    params.mStakedNodeId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "stakedNodeId");
+    params.mDeclineStakingReward = Hiero::TCK::getOptionalJsonParameter<bool>(jsonFrom, "declineStakingReward");
+    params.mMaxAutomaticTokenAssociations =
+      Hiero::TCK::getOptionalJsonParameter<int32_t>(jsonFrom, "maxAutomaticTokenAssociations");
+    params.mCommonTxParams =
+      Hiero::TCK::getOptionalJsonParameter<Hiero::TCK::CommonTransactionParams>(jsonFrom, "commonTransactionParams");
+  }
+};
+
+} // namespace nlohmann
+
+#endif // HIERO_TCK_CPP_CREATE_CONTRACT_PARAMS_H_

--- a/src/tck/include/contract/params/DeleteContractParams.h
+++ b/src/tck/include/contract/params/DeleteContractParams.h
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef HIERO_TCK_CPP_DELETE_CONTRACT_PARAMS_H_
+#define HIERO_TCK_CPP_DELETE_CONTRACT_PARAMS_H_
+
+#include "common/CommonTransactionParams.h"
+#include "json/JsonUtils.h"
+
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+
+namespace Hiero::TCK::ContractService
+{
+/**
+ * Struct to hold the arguments for a `deleteContract` JSON-RPC method call.
+ */
+struct DeleteContractParams
+{
+  /**
+   * The ID of the contract to delete.
+   */
+  std::optional<std::string> mContractId;
+
+  /**
+   * The ID of the account to which to transfer remaining balances.
+   */
+  std::optional<std::string> mTransferAccountId;
+
+  /**
+   * The ID of the contract to which to transfer remaining balances.
+   */
+  std::optional<std::string> mTransferContractId;
+
+  /**
+   * Any parameters common to all transaction types.
+   */
+  std::optional<CommonTransactionParams> mCommonTxParams;
+
+  /**
+   * If set to true, marks this as a system-initiated permanent removal
+   * (should always fail for user transactions).
+   */
+  std::optional<bool> mPermanentRemoval;
+};
+
+} // namespace Hiero::TCK::ContractService
+
+namespace nlohmann
+{
+/**
+ * JSON serializer template specialization required to convert DeleteContractParams arguments properly.
+ */
+template<>
+struct [[maybe_unused]] adl_serializer<Hiero::TCK::ContractService::DeleteContractParams>
+{
+  /**
+   * Convert a JSON object to a DeleteContractParams.
+   *
+   * @param jsonFrom The JSON object with which to fill the DeleteContractParams.
+   * @param params   The DeleteContractParams to fill with the JSON object.
+   */
+  static void from_json(const json& jsonFrom, Hiero::TCK::ContractService::DeleteContractParams& params)
+  {
+    params.mContractId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "contractId");
+    params.mTransferAccountId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "transferAccountId");
+    params.mTransferContractId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "transferContractId");
+    params.mCommonTxParams =
+      Hiero::TCK::getOptionalJsonParameter<Hiero::TCK::CommonTransactionParams>(jsonFrom, "commonTransactionParams");
+    params.mPermanentRemoval = Hiero::TCK::getOptionalJsonParameter<bool>(jsonFrom, "permanentRemoval");
+  }
+};
+
+} // namespace nlohmann
+
+#endif // HIERO_TCK_CPP_DELETE_CONTRACT_PARAMS_H_

--- a/src/tck/src/TckServer.cc
+++ b/src/tck/src/TckServer.cc
@@ -12,6 +12,8 @@
 #include "account/params/GetAccountInfoParams.h"
 #include "account/params/TransferCryptoParams.h"
 #include "account/params/UpdateAccountParams.h"
+#include "contract/ContractService.h"
+#include "contract/params/DeleteContractParams.h"
 #include "file/FileService.h"
 #include "file/params/AppendFileParams.h"
 #include "file/params/CreateFileParams.h"
@@ -81,6 +83,8 @@ TckServer::TckServer(int port)
   mJsonRpcParser.addMethod("getAccountInfo", getHandle(AccountService::getAccountInfo));
   mJsonRpcParser.addMethod("transferCrypto", getHandle(AccountService::transferCrypto));
   mJsonRpcParser.addMethod("updateAccount", getHandle(AccountService::updateAccount));
+
+  mJsonRpcParser.addMethod("deleteContract", getHandle(ContractService::deleteContract));
 
   mJsonRpcParser.addMethod("airdropToken", getHandle(TokenService::airdropToken));
   mJsonRpcParser.addMethod("associateToken", getHandle(TokenService::associateToken));
@@ -184,6 +188,8 @@ template TckServer::MethodHandle TckServer::getHandle<AccountService::ApproveAll
   nlohmann::json (*method)(const AccountService::ApproveAllowanceParams&));
 template TckServer::MethodHandle TckServer::getHandle<AccountService::DeleteAllowanceParams>(
   nlohmann::json (*method)(const AccountService::DeleteAllowanceParams&));
+template TckServer::MethodHandle TckServer::getHandle<ContractService::DeleteContractParams>(
+  nlohmann::json (*method)(const ContractService::DeleteContractParams&));
 template TckServer::MethodHandle TckServer::getHandle<KeyService::GenerateKeyParams>(
   nlohmann::json (*method)(const KeyService::GenerateKeyParams&));
 template TckServer::MethodHandle TckServer::getHandle<TokenService::CreateTokenParams>(

--- a/src/tck/src/TckServer.cc
+++ b/src/tck/src/TckServer.cc
@@ -13,6 +13,10 @@
 #include "account/params/TransferCryptoParams.h"
 #include "account/params/UpdateAccountParams.h"
 #include "contract/ContractService.h"
+#include "contract/params/ContractByteCodeQueryParams.h"
+#include "contract/params/ContractCallQueryParams.h"
+#include "contract/params/ContractInfoQueryParams.h"
+#include "contract/params/CreateContractParams.h"
 #include "contract/params/DeleteContractParams.h"
 #include "file/FileService.h"
 #include "file/params/AppendFileParams.h"
@@ -84,8 +88,6 @@ TckServer::TckServer(int port)
   mJsonRpcParser.addMethod("transferCrypto", getHandle(AccountService::transferCrypto));
   mJsonRpcParser.addMethod("updateAccount", getHandle(AccountService::updateAccount));
 
-  mJsonRpcParser.addMethod("deleteContract", getHandle(ContractService::deleteContract));
-
   mJsonRpcParser.addMethod("airdropToken", getHandle(TokenService::airdropToken));
   mJsonRpcParser.addMethod("associateToken", getHandle(TokenService::associateToken));
   mJsonRpcParser.addMethod("burnToken", getHandle(TokenService::burnToken));
@@ -111,6 +113,13 @@ TckServer::TckServer(int port)
   mJsonRpcParser.addMethod("deleteTopic", getHandle(TopicService::deleteTopic));
   mJsonRpcParser.addMethod("getTopicInfo", getHandle(TopicService::getTopicInfo));
   mJsonRpcParser.addMethod("submitTopicMessage", getHandle(TopicService::submitTopicMessage));
+
+  // Contract Service
+  mJsonRpcParser.addMethod("createContract", getHandle(ContractService::createContract));
+  mJsonRpcParser.addMethod("contractByteCodeQuery", getHandle(ContractService::contractByteCodeQuery));
+  mJsonRpcParser.addMethod("contractCallQuery", getHandle(ContractService::contractCallQuery));
+  mJsonRpcParser.addMethod("contractInfoQuery", getHandle(ContractService::contractInfoQuery));
+  mJsonRpcParser.addMethod("deleteContract", getHandle(ContractService::deleteContract));
 
   // Add the FileService functions.
   mJsonRpcParser.addMethod("appendFile", getHandle(FileService::appendFile));
@@ -188,6 +197,14 @@ template TckServer::MethodHandle TckServer::getHandle<AccountService::ApproveAll
   nlohmann::json (*method)(const AccountService::ApproveAllowanceParams&));
 template TckServer::MethodHandle TckServer::getHandle<AccountService::DeleteAllowanceParams>(
   nlohmann::json (*method)(const AccountService::DeleteAllowanceParams&));
+template TckServer::MethodHandle TckServer::getHandle<ContractService::CreateContractParams>(
+  nlohmann::json (*method)(const ContractService::CreateContractParams&));
+template TckServer::MethodHandle TckServer::getHandle<ContractService::ContractByteCodeQueryParams>(
+  nlohmann::json (*method)(const ContractService::ContractByteCodeQueryParams&));
+template TckServer::MethodHandle TckServer::getHandle<ContractService::ContractCallQueryParams>(
+  nlohmann::json (*method)(const ContractService::ContractCallQueryParams&));
+template TckServer::MethodHandle TckServer::getHandle<ContractService::ContractInfoQueryParams>(
+  nlohmann::json (*method)(const ContractService::ContractInfoQueryParams&));
 template TckServer::MethodHandle TckServer::getHandle<ContractService::DeleteContractParams>(
   nlohmann::json (*method)(const ContractService::DeleteContractParams&));
 template TckServer::MethodHandle TckServer::getHandle<KeyService::GenerateKeyParams>(

--- a/src/tck/src/contract/ContractService.cc
+++ b/src/tck/src/contract/ContractService.cc
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "contract/ContractService.h"
+#include "common/CommonTransactionParams.h"
+#include "contract/params/DeleteContractParams.h"
+#include "sdk/SdkClient.h"
+
+#include <AccountId.h>
+#include <ContractDeleteTransaction.h>
+#include <ContractId.h>
+#include <Status.h>
+#include <TransactionReceipt.h>
+#include <TransactionResponse.h>
+
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace Hiero::TCK::ContractService
+{
+//-----
+nlohmann::json deleteContract(const DeleteContractParams& params)
+{
+  ContractDeleteTransaction contractDeleteTransaction;
+  contractDeleteTransaction.setGrpcDeadline(SdkClient::DEFAULT_TCK_REQUEST_TIMEOUT);
+
+  if (params.mContractId.has_value())
+  {
+    contractDeleteTransaction.setContractId(ContractId::fromString(params.mContractId.value()));
+  }
+
+  if (params.mTransferAccountId.has_value())
+  {
+    contractDeleteTransaction.setTransferAccountId(AccountId::fromString(params.mTransferAccountId.value()));
+  }
+
+  if (params.mTransferContractId.has_value())
+  {
+    contractDeleteTransaction.setTransferContractId(ContractId::fromString(params.mTransferContractId.value()));
+  }
+
+  if (params.mPermanentRemoval.has_value())
+  {
+    contractDeleteTransaction.setPermanentRemoval(params.mPermanentRemoval.value());
+  }
+
+  if (params.mCommonTxParams.has_value())
+  {
+    params.mCommonTxParams->fillOutTransaction(contractDeleteTransaction, SdkClient::getClient());
+  }
+
+  return {
+    {"status",
+     gStatusToString.at(
+        contractDeleteTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient()).mStatus)}
+  };
+}
+
+} // namespace Hiero::TCK::ContractService

--- a/src/tck/src/contract/ContractService.cc
+++ b/src/tck/src/contract/ContractService.cc
@@ -1,21 +1,138 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "contract/ContractService.h"
 #include "common/CommonTransactionParams.h"
+
+#include "contract/params/ContractByteCodeQueryParams.h"
+#include "contract/params/ContractCallQueryParams.h"
+#include "contract/params/ContractInfoQueryParams.h"
+#include "contract/params/CreateContractParams.h"
 #include "contract/params/DeleteContractParams.h"
+#include "key/KeyService.h"
 #include "sdk/SdkClient.h"
 
 #include <AccountId.h>
+#include <ContractByteCodeQuery.h>
+#include <ContractCallQuery.h>
+#include <ContractCreateTransaction.h>
 #include <ContractDeleteTransaction.h>
+#include <ContractFunctionResult.h>
 #include <ContractId.h>
+#include <ContractInfo.h>
+#include <ContractInfoQuery.h>
+#include <FileId.h>
+#include <Hbar.h>
+#include <PublicKey.h>
 #include <Status.h>
 #include <TransactionReceipt.h>
 #include <TransactionResponse.h>
+#include <impl/EntityIdHelper.h>
+#include <impl/HexConverter.h>
 
+#include <chrono>
+#include <cstdint>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <vector>
+
+namespace
+{
+std::string stripHexPrefix(std::string hex)
+{
+  if (hex.rfind("0x", 0) == 0 || hex.rfind("0X", 0) == 0)
+  {
+    hex = hex.substr(2);
+  }
+
+  return hex;
+}
+} // namespace
 
 namespace Hiero::TCK::ContractService
 {
+//-----
+nlohmann::json createContract(const CreateContractParams& params)
+{
+  ContractCreateTransaction contractCreateTransaction;
+  contractCreateTransaction.setGrpcDeadline(SdkClient::DEFAULT_TCK_REQUEST_TIMEOUT);
+
+  if (params.mBytecodeFileId.has_value())
+  {
+    contractCreateTransaction.setBytecodeFileId(FileId::fromString(params.mBytecodeFileId.value()));
+  }
+
+  if (params.mGas.has_value())
+  {
+    contractCreateTransaction.setGas(static_cast<uint64_t>(params.mGas.value()));
+  }
+
+  if (params.mAdminKey.has_value())
+  {
+    contractCreateTransaction.setAdminKey(KeyService::getHieroKey(params.mAdminKey.value()));
+  }
+
+  if (params.mConstructorParameters.has_value())
+  {
+    std::string constructorParameters = stripHexPrefix(params.mConstructorParameters.value());
+
+    contractCreateTransaction.setConstructorParameters(internal::HexConverter::hexToBytes(constructorParameters));
+  }
+
+  if (params.mInitialBalance.has_value())
+  {
+    contractCreateTransaction.setInitialBalance(
+      Hbar::fromTinybars(internal::EntityIdHelper::getNum<int64_t>(params.mInitialBalance.value())));
+  }
+
+  if (params.mMemo.has_value())
+  {
+    contractCreateTransaction.setMemo(params.mMemo.value());
+  }
+
+  if (params.mAutoRenewAccountId.has_value())
+  {
+    contractCreateTransaction.setAutoRenewAccountId(AccountId::fromString(params.mAutoRenewAccountId.value()));
+  }
+
+  if (params.mAutoRenewPeriod.has_value())
+  {
+    contractCreateTransaction.setAutoRenewPeriod(
+      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(params.mAutoRenewPeriod.value())));
+  }
+
+  if (params.mStakedAccountId.has_value())
+  {
+    contractCreateTransaction.setStakedAccountId(AccountId::fromString(params.mStakedAccountId.value()));
+  }
+
+  if (params.mStakedNodeId.has_value())
+  {
+    contractCreateTransaction.setStakedNodeId(internal::EntityIdHelper::getNum<uint64_t>(params.mStakedNodeId.value()));
+  }
+
+  if (params.mDeclineStakingReward.has_value())
+  {
+    contractCreateTransaction.setDeclineStakingReward(params.mDeclineStakingReward.value());
+  }
+
+  if (params.mMaxAutomaticTokenAssociations.has_value())
+  {
+    contractCreateTransaction.setMaxAutomaticTokenAssociations(params.mMaxAutomaticTokenAssociations.value());
+  }
+
+  if (params.mCommonTxParams.has_value())
+  {
+    params.mCommonTxParams->fillOutTransaction(contractCreateTransaction, SdkClient::getClient());
+  }
+
+  const TransactionReceipt txReceipt =
+    contractCreateTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient());
+
+  return {
+    {"contractId", txReceipt.mContractId.value().toString()},
+    { "status",    gStatusToString.at(txReceipt.mStatus)   }
+  };
+}
+
 //-----
 nlohmann::json deleteContract(const DeleteContractParams& params)
 {
@@ -52,6 +169,203 @@ nlohmann::json deleteContract(const DeleteContractParams& params)
      gStatusToString.at(
         contractDeleteTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient()).mStatus)}
   };
+}
+
+//-----
+nlohmann::json contractByteCodeQuery(const ContractByteCodeQueryParams& params)
+{
+  ContractByteCodeQuery contractByteCodeQuery;
+  contractByteCodeQuery.setGrpcDeadline(SdkClient::DEFAULT_TCK_REQUEST_TIMEOUT);
+
+  if (params.mContractId.has_value())
+  {
+    contractByteCodeQuery.setContractId(ContractId::fromString(params.mContractId.value()));
+  }
+
+  if (params.mQueryPayment.has_value())
+  {
+    contractByteCodeQuery.setQueryPayment(Hbar::fromTinybars(std::stoll(params.mQueryPayment.value())));
+  }
+
+  if (params.mMaxQueryPayment.has_value())
+  {
+    contractByteCodeQuery.setMaxQueryPayment(Hbar::fromTinybars(std::stoll(params.mMaxQueryPayment.value())));
+  }
+
+  const ContractByteCode byteCode = contractByteCodeQuery.execute(SdkClient::getClient());
+
+  return {
+    {"bytecode", internal::HexConverter::bytesToHex(byteCode)}
+  };
+}
+
+//-----
+nlohmann::json contractCallQuery(const ContractCallQueryParams& params)
+{
+  ContractCallQuery contractCallQuery;
+  contractCallQuery.setGrpcDeadline(SdkClient::DEFAULT_TCK_REQUEST_TIMEOUT);
+
+  if (params.mContractId.has_value())
+  {
+    contractCallQuery.setContractId(ContractId::fromString(params.mContractId.value()));
+  }
+
+  if (params.mGas.has_value())
+  {
+    contractCallQuery.setGas(static_cast<uint64_t>(params.mGas.value()));
+  }
+
+  if (params.mFunctionName.has_value())
+  {
+    contractCallQuery.setFunction(params.mFunctionName.value());
+
+    if (params.mFunctionParameters.has_value())
+    {
+      std::string functionParameters = stripHexPrefix(params.mFunctionParameters.value());
+
+      std::vector<std::byte> callData = contractCallQuery.getFunctionParameters();
+      std::vector<std::byte> encodedParameters = internal::HexConverter::hexToBytes(functionParameters);
+      callData.insert(callData.end(), encodedParameters.begin(), encodedParameters.end());
+
+      contractCallQuery.setFunctionParameters(callData);
+    }
+  }
+  else if (params.mFunctionParameters.has_value())
+  {
+    std::string functionParameters = stripHexPrefix(params.mFunctionParameters.value());
+
+    contractCallQuery.setFunctionParameters(internal::HexConverter::hexToBytes(functionParameters));
+  }
+
+  if (params.mQueryPayment.has_value())
+  {
+    contractCallQuery.setQueryPayment(Hbar::fromTinybars(std::stoll(params.mQueryPayment.value())));
+  }
+
+  if (params.mMaxQueryPayment.has_value())
+  {
+    contractCallQuery.setMaxQueryPayment(Hbar::fromTinybars(std::stoll(params.mMaxQueryPayment.value())));
+  }
+
+  const ContractFunctionResult result = contractCallQuery.execute(SdkClient::getClient());
+
+  nlohmann::json response = {
+    {"contractId",    result.mContractId.toString()                                 },
+    { "rawResult",    internal::HexConverter::bytesToHex(result.mContractCallResult)},
+    { "gasUsed",      std::to_string(result.mGasUsed)                               },
+    { "errorMessage", result.mErrorMessage                                          },
+    { "bloom",        internal::HexConverter::bytesToHex(result.mBloom)             },
+    { "gas",          std::to_string(result.mGas)                                   },
+    { "amount",       std::to_string(result.mHbarAmount.toTinybars())               }
+  };
+
+  try
+  {
+    response["address"] = result.getAddress(0);
+  }
+  catch (const std::exception&)
+  {
+    // result.getAddress(0) throws if the result contains no addresses; omit the field in that case
+  }
+
+  return response;
+}
+
+//-----
+nlohmann::json contractInfoQuery(const ContractInfoQueryParams& params)
+{
+  ContractInfoQuery contractInfoQuery;
+  contractInfoQuery.setGrpcDeadline(SdkClient::DEFAULT_TCK_REQUEST_TIMEOUT);
+
+  if (params.mContractId.has_value())
+  {
+    contractInfoQuery.setContractId(ContractId::fromString(params.mContractId.value()));
+  }
+
+  if (params.mQueryPayment.has_value())
+  {
+    contractInfoQuery.setQueryPayment(Hbar::fromTinybars(std::stoll(params.mQueryPayment.value())));
+  }
+
+  if (params.mMaxQueryPayment.has_value())
+  {
+    contractInfoQuery.setMaxQueryPayment(Hbar::fromTinybars(std::stoll(params.mMaxQueryPayment.value())));
+  }
+
+  const ContractInfo info = contractInfoQuery.execute(SdkClient::getClient());
+
+  nlohmann::json response;
+
+  response["contractId"] = info.mContractId.toString();
+  response["accountId"] = info.mAccountId.toString();
+  response["contractAccountId"] = info.mContractAccountId;
+
+  if (const auto* pubKey = dynamic_cast<const PublicKey*>(info.mAdminKey.get()))
+  {
+    response["adminKey"] = pubKey->toStringDer();
+  }
+  else if (info.mAdminKey)
+  {
+    response["adminKey"] = internal::HexConverter::bytesToHex(info.mAdminKey->toBytes());
+  }
+
+  const auto expirationTimeSeconds =
+    std::chrono::duration_cast<std::chrono::seconds>(info.mExpirationTime.time_since_epoch()).count();
+  response["expirationTime"] = std::to_string(expirationTimeSeconds);
+
+  const auto autoRenewPeriodSeconds = std::chrono::duration_cast<std::chrono::seconds>(info.mAutoRenewPeriod).count();
+  response["autoRenewPeriod"] = std::to_string(autoRenewPeriodSeconds);
+
+  if (info.mAutoRenewAccountId.has_value())
+  {
+    response["autoRenewAccountId"] = info.mAutoRenewAccountId->toString();
+  }
+
+  response["storage"] = std::to_string(info.mStorage);
+  response["contractMemo"] = info.mMemo;
+  response["balance"] = std::to_string(info.mBalance.toTinybars());
+  response["isDeleted"] = info.mIsDeleted;
+  response["maxAutomaticTokenAssociations"] = std::to_string(info.mMaxAutomaticTokenAssociations);
+  response["ledgerId"] = info.mLedgerId.toString();
+
+  nlohmann::json stakingInfo;
+  stakingInfo["declineStakingReward"] = info.mStakingInfo.mDeclineRewards;
+
+  if (info.mStakingInfo.mStakePeriodStart.has_value())
+  {
+    const auto stakePeriodStartSeconds =
+      std::chrono::duration_cast<std::chrono::seconds>(info.mStakingInfo.mStakePeriodStart->time_since_epoch()).count();
+    stakingInfo["stakePeriodStart"] = std::to_string(stakePeriodStartSeconds);
+  }
+  else
+  {
+    stakingInfo["stakePeriodStart"] = "0";
+  }
+
+  stakingInfo["pendingReward"] = std::to_string(info.mStakingInfo.mPendingReward.toTinybars());
+  stakingInfo["stakedToMe"] = std::to_string(info.mStakingInfo.mStakedToMe.toTinybars());
+
+  if (info.mStakingInfo.mStakedAccountId.has_value())
+  {
+    stakingInfo["stakedAccountId"] = info.mStakingInfo.mStakedAccountId->toString();
+  }
+  else
+  {
+    stakingInfo["stakedAccountId"] = nullptr;
+  }
+
+  if (info.mStakingInfo.mStakedNodeId.has_value())
+  {
+    stakingInfo["stakedNodeId"] = std::to_string(info.mStakingInfo.mStakedNodeId.value());
+  }
+  else
+  {
+    stakingInfo["stakedNodeId"] = nullptr;
+  }
+
+  response["stakingInfo"] = stakingInfo;
+
+  return response;
 }
 
 } // namespace Hiero::TCK::ContractService


### PR DESCRIPTION
Fixes #1430

Implement equality comparison operator for the FeeComponents class to enable direct comparison of two instances without manually comparing individual fields.

Changes:
- Add friend declaration for operator== in FeeComponents.h with attribute to encourage proper usage of the comparison result
- 
- Implement operator== in FeeComponents.cc comparing all 11 member fields:

- Add comprehensive unit test suite in FeeComponentsUnitTests.cc with 14 tests cases covering:
  * Default-constructed instances equality
  * Identically-constructed instances equality
  * Inequality verification for each of the 11 fields

- Register new test file in src/sdk/tests/unit/CMakeLists.txt

Implementation follows the established pattern from PendingAirdropId and uses friend function approach to access private member variables.
