### PR TITLE
add operator== to FeeComponents with unit tests

### DIFF
--- a/src/sdk/main/include/FeeComponents.h
+++ b/src/sdk/main/include/FeeComponents.h
@@ -326,11 +326,11 @@ private:
   int64_t mResponseDiskByte = 0LL;
 
   /**
-   * Compare this FeeComponents to another FeeComponents and determine if they represent an equivalent set of fees.
+   * Compare to FeeComponents instances and determine if they represent an equivalent set of fees.
    *
    * @param lhs The left-hand side FeeComponents to compare.
    * @param rhs The right-hand side FeeComponents to compare.
-   * @return \c TRUE if this FeeComponents is the same as the input FeeComponents, otherwise \c FALSE.
+   * @return \c TRUE if \p lhs and \p rhs represent equivalent fee component values, otherwise \c FALSE.
    */
   [[nodiscard]] friend bool operator==(const FeeComponents& lhs, const FeeComponents& rhs);
 };

--- a/src/sdk/main/include/FeeComponents.h
+++ b/src/sdk/main/include/FeeComponents.h
@@ -324,6 +324,15 @@ private:
    * The price of bandwidth for data retrieved from disk for a response, measured in bytes.
    */
   int64_t mResponseDiskByte = 0LL;
+
+  /**
+   * Compare this FeeComponents to another FeeComponents and determine if they represent an equivalent set of fees.
+   *
+   * @param lhs The left-hand side FeeComponents to compare.
+   * @param rhs The right-hand side FeeComponents to compare.
+   * @return \c TRUE if this FeeComponents is the same as the input FeeComponents, otherwise \c FALSE.
+   */
+  [[nodiscard]] friend bool operator==(const FeeComponents& lhs, const FeeComponents& rhs);
 };
 
 } // namespace Hiero

--- a/src/sdk/main/include/FeeComponents.h
+++ b/src/sdk/main/include/FeeComponents.h
@@ -326,7 +326,7 @@ private:
   int64_t mResponseDiskByte = 0LL;
 
   /**
-   * Compare to FeeComponents instances and determine if they represent an equivalent set of fees.
+   * Compare two FeeComponents instances and determine if they represent an equivalent set of fees.
    *
    * @param lhs The left-hand side FeeComponents to compare.
    * @param rhs The right-hand side FeeComponents to compare.

--- a/src/sdk/main/src/FeeComponents.cc
+++ b/src/sdk/main/src/FeeComponents.cc
@@ -75,4 +75,17 @@ std::string FeeComponents::toString() const
   return json.dump();
 }
 
+//-----
+bool operator==(const FeeComponents& lhs, const FeeComponents& rhs)
+{
+  return (lhs.mMin == rhs.mMin) && (lhs.mMax == rhs.mMax) && (lhs.mConstant == rhs.mConstant) &&
+         (lhs.mTransactionBandwidthBytes == rhs.mTransactionBandwidthBytes) &&
+         (lhs.mTransactionVerification == rhs.mTransactionVerification) &&
+         (lhs.mTransactionRamByteHour == rhs.mTransactionRamByteHour) &&
+         (lhs.mTransactionStorageByteHour == rhs.mTransactionStorageByteHour) &&
+         (lhs.mContractTransactionGas == rhs.mContractTransactionGas) &&
+         (lhs.mTransferVolumeHbar == rhs.mTransferVolumeHbar) &&
+         (lhs.mResponseMemoryByte == rhs.mResponseMemoryByte) && (lhs.mResponseDiskByte == rhs.mResponseDiskByte);
+}
+
 } // namespace Hiero

--- a/src/sdk/main/src/FeeComponents.cc
+++ b/src/sdk/main/src/FeeComponents.cc
@@ -84,8 +84,8 @@ bool operator==(const FeeComponents& lhs, const FeeComponents& rhs)
          (lhs.mTransactionRamByteHour == rhs.mTransactionRamByteHour) &&
          (lhs.mTransactionStorageByteHour == rhs.mTransactionStorageByteHour) &&
          (lhs.mContractTransactionGas == rhs.mContractTransactionGas) &&
-         (lhs.mTransferVolumeHbar == rhs.mTransferVolumeHbar) &&
-         (lhs.mResponseMemoryByte == rhs.mResponseMemoryByte) && (lhs.mResponseDiskByte == rhs.mResponseDiskByte);
+         (lhs.mTransferVolumeHbar == rhs.mTransferVolumeHbar) && (lhs.mResponseMemoryByte == rhs.mResponseMemoryByte) &&
+         (lhs.mResponseDiskByte == rhs.mResponseDiskByte);
 }
 
 } // namespace Hiero

--- a/src/sdk/tests/unit/CMakeLists.txt
+++ b/src/sdk/tests/unit/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(${TEST_PROJECT_NAME}
         EvmHookSpecUnitTests.cc
         ExchangeRateUnitTests.cc
         FeeAssessmentMethodUnitTests.cc
+        FeeComponentsUnitTests.cc
         FileAppendTransactionUnitTests.cc
         FileContentsQueryUnitTests.cc
         FileCreateTransactionUnitTests.cc
@@ -123,6 +124,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenNftTransferUnitTests.cc
         TokenPauseTransactionUnitTests.cc
         TokenRejectTransactionUnitTests.cc
+        TokenRelationshipUnitTests.cc
         TokenRevokeKycTransactionUnitTests.cc
         TokenSupplyTypeUnitTests.cc
         TokenTransferHookUnitTests.cc

--- a/src/sdk/tests/unit/CMakeLists.txt
+++ b/src/sdk/tests/unit/CMakeLists.txt
@@ -124,7 +124,6 @@ add_executable(${TEST_PROJECT_NAME}
         TokenNftTransferUnitTests.cc
         TokenPauseTransactionUnitTests.cc
         TokenRejectTransactionUnitTests.cc
-        TokenRelationshipUnitTests.cc
         TokenRevokeKycTransactionUnitTests.cc
         TokenSupplyTypeUnitTests.cc
         TokenTransferHookUnitTests.cc

--- a/src/sdk/tests/unit/FeeComponentsUnitTests.cc
+++ b/src/sdk/tests/unit/FeeComponentsUnitTests.cc
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "FeeComponents.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hiero;
+
+class FeeComponentsUnitTests : public ::testing::Test
+{
+protected:
+  FeeComponents feeComponents;
+};
+
+//-----
+TEST_F(FeeComponentsUnitTests, DefaultConstructor)
+{
+  // Then
+  EXPECT_EQ(feeComponents.getMin(), 0LL);
+  EXPECT_EQ(feeComponents.getMax(), 0LL);
+  EXPECT_EQ(feeComponents.getConstant(), 0LL);
+  EXPECT_EQ(feeComponents.getTransactionBandwidthBytes(), 0LL);
+  EXPECT_EQ(feeComponents.getTransactionVerification(), 0LL);
+  EXPECT_EQ(feeComponents.getTransactionRamByteHour(), 0LL);
+  EXPECT_EQ(feeComponents.getTransactionStorageByteHour(), 0LL);
+  EXPECT_EQ(feeComponents.getContractTransactionGas(), 0LL);
+  EXPECT_EQ(feeComponents.getTransferVolumeHbar(), 0LL);
+  EXPECT_EQ(feeComponents.getResponseMemoryByte(), 0LL);
+  EXPECT_EQ(feeComponents.getResponseDiskByte(), 0LL);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorEqualsDefaultConstructed)
+{
+  // Given
+  FeeComponents lhs;
+  FeeComponents rhs;
+
+  // Then
+  EXPECT_TRUE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorEqualsIdentical)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setMin(1LL)
+    .setMax(2LL)
+    .setConstant(3LL)
+    .setTransactionBandwidthBytes(4LL)
+    .setTransactionVerification(5LL)
+    .setTransactionRamByteHour(6LL)
+    .setTransactionStorageByteHour(7LL)
+    .setContractTransactionGas(8LL)
+    .setTransferVolumeHbar(9LL)
+    .setResponseMemoryByte(10LL)
+    .setResponseDiskByte(11LL);
+
+  FeeComponents rhs;
+  rhs.setMin(1LL)
+    .setMax(2LL)
+    .setConstant(3LL)
+    .setTransactionBandwidthBytes(4LL)
+    .setTransactionVerification(5LL)
+    .setTransactionRamByteHour(6LL)
+    .setTransactionStorageByteHour(7LL)
+    .setContractTransactionGas(8LL)
+    .setTransferVolumeHbar(9LL)
+    .setResponseMemoryByte(10LL)
+    .setResponseDiskByte(11LL);
+
+  // Then
+  EXPECT_TRUE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentMin)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setMin(1LL);
+  FeeComponents rhs;
+  rhs.setMin(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentMax)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setMax(1LL);
+  FeeComponents rhs;
+  rhs.setMax(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentConstant)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setConstant(1LL);
+  FeeComponents rhs;
+  rhs.setConstant(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentTransactionBandwidthBytes)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setTransactionBandwidthBytes(1LL);
+  FeeComponents rhs;
+  rhs.setTransactionBandwidthBytes(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentTransactionVerification)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setTransactionVerification(1LL);
+  FeeComponents rhs;
+  rhs.setTransactionVerification(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentTransactionRamByteHour)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setTransactionRamByteHour(1LL);
+  FeeComponents rhs;
+  rhs.setTransactionRamByteHour(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentTransactionStorageByteHour)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setTransactionStorageByteHour(1LL);
+  FeeComponents rhs;
+  rhs.setTransactionStorageByteHour(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentContractTransactionGas)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setContractTransactionGas(1LL);
+  FeeComponents rhs;
+  rhs.setContractTransactionGas(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentTransferVolumeHbar)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setTransferVolumeHbar(1LL);
+  FeeComponents rhs;
+  rhs.setTransferVolumeHbar(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentResponseMemoryByte)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setResponseMemoryByte(1LL);
+  FeeComponents rhs;
+  rhs.setResponseMemoryByte(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(FeeComponentsUnitTests, OperatorNotEqualsDifferentResponseDiskByte)
+{
+  // Given
+  FeeComponents lhs;
+  lhs.setResponseDiskByte(1LL);
+  FeeComponents rhs;
+  rhs.setResponseDiskByte(2LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}


### PR DESCRIPTION
Fixes #1430

Implement equality comparison operator for the FeeComponents class to enable direct comparison of two instances without manually comparing individual fields.

Changes:
- Add friend declaration for operator== in FeeComponents.h with attribute to encourage proper usage of the comparison result
- 
- Implement operator== in FeeComponents.cc comparing all 11 member fields:

- Add comprehensive unit test suite in FeeComponentsUnitTests.cc with 14 tests cases covering:
  * Default-constructed instances equality
  * Identically-constructed instances equality
  * Inequality verification for each of the 11 fields

- Register new test file in src/sdk/tests/unit/CMakeLists.txt

Implementation follows the established pattern from PendingAirdropId and uses friend function approach to access private member variables.
