### PR TITLE
chore: update SDK version to v0.54.0 in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15...3.24)
-project(hiero-sdk-cpp VERSION 0.41.0 DESCRIPTION "Hiero SDK C++" LANGUAGES CXX)
+project(hiero-sdk-cpp VERSION 0.54.0 DESCRIPTION "Hiero SDK C++" LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
## Summary

Bumps the `VERSION` field in the root `CMakeLists.txt` from `0.41.0` to `0.54.0` in preparation for the v0.54.0 release. This is the single source of truth for the SDK version and drives the auto-generated `version.h` header at build time.

Closes #1435.

## Changes

### Version Bump

Updated the `project()` declaration on line 2 of `CMakeLists.txt`:

**Before:**
```cmake
project(hiero-sdk-cpp VERSION 0.41.0 DESCRIPTION "Hiero SDK C++" LANGUAGES CXX)
```

**After:**
```cmake
project(hiero-sdk-cpp VERSION 0.54.0 DESCRIPTION "Hiero SDK C++" LANGUAGES CXX)
```

## Testing

**Test Plan:**
- [x] Verify only `CMakeLists.txt` line 2 is modified
- [x] Confirm `VERSION` reads `0.54.0`
- [x] Confirm no other files are modified

## Files Changed Summary

| Category | Files |
|----------|-------|
| Build | `CMakeLists.txt` |

## Breaking Changes

**None.** This is a version string update only. No APIs, interfaces, or behaviors are changed.
