### PR TITLE
fix: align recommendation logic with assignment eligibility 

### DIFF
--- a/.github/scripts/commands/assign-comments.js
+++ b/.github/scripts/commands/assign-comments.js
@@ -10,6 +10,7 @@ const {
   LABELS,
   ISSUE_STATE,
   SKILL_HIERARCHY,
+  SKILL_PREREQUISITES,
 } = require("../helpers");
 
 /**
@@ -25,42 +26,6 @@ const MAX_OPEN_ASSIGNMENTS = 2;
  * @type {number}
  */
 const MAX_GFI_COMPLETIONS = 5;
-
-/**
- * Skill-level prerequisite map. Each key is a LABELS skill-level constant.
- * - requiredLabel: the prerequisite skill label the user must have completed, or null if none.
- * - requiredCount: how many closed issues with requiredLabel the user needs.
- * - displayName: human-readable name for the current skill level.
- * - prerequisiteDisplayName: human-readable plural name for the prerequisite level (used in comments).
- *
- * Progression: Good First Issue (no prereqs) -> Beginner (2 GFI) -> Intermediate (3 Beginner) -> Advanced (3 Intermediate).
- * @type {Object<string, { requiredLabel: string|null, requiredCount: number, displayName: string, prerequisiteDisplayName?: string }>}
- */
-const SKILL_PREREQUISITES = {
-  [LABELS.GOOD_FIRST_ISSUE]: {
-    requiredLabel: null,
-    requiredCount: 0,
-    displayName: "Good First Issue",
-  },
-  [LABELS.BEGINNER]: {
-    requiredLabel: LABELS.GOOD_FIRST_ISSUE,
-    requiredCount: 2,
-    displayName: "Beginner",
-    prerequisiteDisplayName: "Good First Issues",
-  },
-  [LABELS.INTERMEDIATE]: {
-    requiredLabel: LABELS.BEGINNER,
-    requiredCount: 3,
-    displayName: "Intermediate",
-    prerequisiteDisplayName: "Beginner Issues",
-  },
-  [LABELS.ADVANCED]: {
-    requiredLabel: LABELS.INTERMEDIATE,
-    requiredCount: 3,
-    displayName: "Advanced",
-    prerequisiteDisplayName: "Intermediate Issues",
-  },
-};
 
 /**
  * Builds the welcome comment posted after a successful assignment. Returns a

--- a/.github/scripts/commands/assign.js
+++ b/.github/scripts/commands/assign.js
@@ -18,6 +18,7 @@ const {
   postComment,
   acknowledgeComment,
   getHighestIssueSkillLevel,
+  countIssuesByAssignee,
 } = require('../helpers');
 
 const {
@@ -47,132 +48,12 @@ const logger = createDelegatingLogger();
  * capped the value. If count reaches the short-circuit threshold, return an
  * "at least" style display (e.g. "3+") rather than implying an exact value.
  *
- * @param {number} count - Count returned by countAssignedIssues.
+ * @param {number} count - Count returned by countIssuesByAssignee.
  * @param {number} threshold - Threshold used for short-circuiting.
  * @returns {string} User-facing display string.
  */
 function formatThresholdedCount(count, threshold) {
   return count >= threshold ? `${threshold}+` : String(count);
-}
-
-/**
- * Fetches the number of issues assigned to a specific user that match a given
- * state and optional label using the GitHub REST API.
- *
- * Note: When state is OPEN and no label filter is provided, issues with the
- * "status: blocked" label are explicitly EXCLUDED from the count.
- * The search is constrained to the repo specified in the context.
- *
- * @param {object} github - Octokit GitHub API client (must support github.rest).
- * @param {string} owner - Repository owner (e.g. 'hiero-ledger').
- * @param {string} repo - Repository name (e.g. 'hiero-sdk-cpp').
- * @param {string} username - GitHub username to search for.
- * @param {string} state - Issue state filter: ISSUE_STATE.OPEN or ISSUE_STATE.CLOSED.
- * @param {string|null} [label=null] - Optional label filter (e.g. 'skill: good first issue').
- * @param {number|null} [threshold=null] - Optional threshold to short-circuit pagination.
- *   When provided, the function returns a capped count (the threshold value)
- *   once that threshold is reached.
- * @returns {Promise<number|null>} Matching issue count, or null if inputs are invalid or the API call fails.
- *   When threshold is provided and reached, returns the threshold value (capped),
- *   not necessarily the exact total.
- */
-async function countAssignedIssues(
-  github,
-  owner,
-  repo,
-  username,
-  state,
-  label = null,
-  threshold = null,
-) {
-  if (
-    !isSafeSearchToken(owner) ||
-    !isSafeSearchToken(repo) ||
-    !isSafeSearchToken(username)
-  ) {
-    logger.log("[assign] Invalid search inputs:", {
-      owner,
-      repo,
-      username,
-      label,
-    });
-    return null;
-  }
-  if (state !== ISSUE_STATE.OPEN && state !== ISSUE_STATE.CLOSED) {
-    logger.log("[assign] Invalid state:", { state });
-    return null;
-  }
-  if (
-    label &&
-    (typeof label !== "string" || !label.trim() || label.includes('"'))
-  ) {
-    logger.log("[assign] Invalid label parameter:", { label });
-    return null;
-  }
-
-  try {
-    let page = 1;
-    let matchingIssuesCount = 0;
-    const perPage = 100;
-
-    logger.log(`[assign] Fetching ${state} assigned issues via REST...`);
-    while (true) {
-      const params = {
-        owner,
-        repo,
-        state: state.toLowerCase(),
-        assignee: username,
-        per_page: perPage,
-        page,
-      };
-      if (label) params.labels = label;
-
-      const result = await github.rest.issues.listForRepo(params);
-      // Filter out Pull Requests (which are returned by the issues endpoint)
-      const actualIssues = result.data.filter((item) => !item.pull_request);
-
-      let pageMatchCount = 0;
-      if (state === ISSUE_STATE.OPEN && !label) {
-        pageMatchCount = actualIssues.filter(
-          (issue) =>
-            !issue.labels?.some((l) => (l.name || l) === LABELS.BLOCKED),
-        ).length;
-      } else {
-        pageMatchCount = actualIssues.length;
-      }
-
-      matchingIssuesCount += pageMatchCount;
-
-      if (threshold !== null && matchingIssuesCount >= threshold) {
-        logger.log(
-          `[assign] Reached threshold (${threshold}), short-circuiting fetch.`,
-        );
-        matchingIssuesCount = threshold; // Cap at threshold logically for callers
-        break;
-      }
-
-      // Pagination must evaluate the raw result size, not the filtered size.
-      if (result.data.length < perPage) break;
-      page++;
-    }
-
-    if (label) {
-      logger.log(
-        `[assign] ${state} assigned issues for ${username} with label ${label}: ${matchingIssuesCount}`,
-      );
-    } else {
-      logger.log(
-        `[assign] ${state} assigned issues for ${username}${state === ISSUE_STATE.OPEN ? " (excluding blocked)" : ""}: ${matchingIssuesCount}`,
-      );
-    }
-    return matchingIssuesCount;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger.log(
-      `[assign] Failed to count ${state} issues for ${username}: ${message}`,
-    );
-    return null;
-  }
 }
 
 /**
@@ -187,7 +68,7 @@ async function countAssignedIssues(
  * @returns {Promise<number>} The blocked-issue count (defaults to 0 on any error).
  */
 async function getBlockedCount(github, owner, repo, username) {
-  const count = await countAssignedIssues(
+  const count = await countIssuesByAssignee(
     github,
     owner,
     repo,
@@ -221,7 +102,7 @@ async function checkPrerequisites(botContext, skillLevel, requesterUsername) {
   if (skillIndex !== -1) {
     for (let i = skillIndex; i < SKILL_HIERARCHY.length; i++) {
       const checkCurrLevel = SKILL_HIERARCHY[i];
-      const countAtLevel = await countAssignedIssues(
+      const countAtLevel = await countIssuesByAssignee(
         botContext.github,
         botContext.owner,
         botContext.repo,
@@ -241,7 +122,7 @@ async function checkPrerequisites(botContext, skillLevel, requesterUsername) {
   }
 
   // Normal validation
-  const completedCount = await countAssignedIssues(
+  const completedCount = await countIssuesByAssignee(
     botContext.github,
     botContext.owner,
     botContext.repo,
@@ -322,7 +203,7 @@ async function enforceGfiCompletionLimit(
 ) {
   if (skillLevel !== LABELS.GOOD_FIRST_ISSUE) return true;
 
-  const completedCount = await countAssignedIssues(
+  const completedCount = await countIssuesByAssignee(
     botContext.github,
     botContext.owner,
     botContext.repo,
@@ -425,7 +306,7 @@ async function validateIssueState(botContext, requesterUsername) {
  * @returns {Promise<boolean>} True if within assignment limits; false otherwise.
  */
 async function enforceAssignmentLimit(botContext, requesterUsername) {
-  const openAssignmentCount = await countAssignedIssues(
+  const openAssignmentCount = await countIssuesByAssignee(
     botContext.github,
     botContext.owner,
     botContext.repo,

--- a/.github/scripts/commands/recommend-issues.js
+++ b/.github/scripts/commands/recommend-issues.js
@@ -25,32 +25,6 @@ const logger = {
 };
 
 /**
- * Returns the next difficulty level in the hierarchy.
- *
- * @param {string} currentLevel
- * @returns {string|null} Next level, same level if max, or null if invalid.
- */
-function getNextLevel(currentLevel) {
-    const index = SKILL_HIERARCHY.indexOf(currentLevel);
-    if (index === -1) return null;
-
-    return SKILL_HIERARCHY[index + 1] || currentLevel;
-}
-
-/**
- * Returns the previous (fallback) difficulty level.
- *
- * @param {string} currentLevel
- * @returns {string|null} Lower level or null if none.
- */
-function getFallbackLevel(currentLevel) {
-    const index = SKILL_HIERARCHY.indexOf(currentLevel);
-    if (index <= 0) return null;
-
-    return SKILL_HIERARCHY[index - 1];
-}
-
-/**
  * Groups issues by their matching difficulty level.
  *
  * Each issue is assigned to the first matching level in levelsPriority.
@@ -127,17 +101,34 @@ async function fetchIssuesBatch(github, owner, repo) {
 /**
  * Builds the success comment listing recommended issues.
  *
+ * When `unlockedLevel` is provided, a congratulatory block is prepended to
+ * acknowledge that this contribution crossed the threshold into a new skill
+ * level. The display name is sourced from SKILL_PREREQUISITES so it stays
+ * consistent with the rest of the bot.
+ *
  * @param {string} username
  * @param {Array<{ title: string, html_url: string }>} issues
+ * @param {string|null} unlockedLevel - LABELS constant for the newly unlocked
+ *   level, or null if no threshold was crossed.
  * @returns {string}
  */
-function buildRecommendationComment(username, issues) {
+function buildRecommendationComment(username, issues, unlockedLevel = null) {
     const list = issues.map(
         (issue) => `- [${issue.title}](${issue.html_url})`
     );
+
+    const congratsBlock = unlockedLevel
+        ? [
+            `🏆 Milestone unlocked: you've just reached **${SKILL_PREREQUISITES[unlockedLevel].displayName}** level!`,
+            `That's a big step — well done. 🎊`,
+            '',
+        ]
+        : [];
+
     return [
         `👋 Hi @${username}! Great work on your recent contribution! 🎉`,
         '',
+        ...congratsBlock,
         `Here are some issues you might want to explore next:`,
         '',
         ...list,
@@ -166,52 +157,99 @@ function buildRecommendationErrorComment(username) {
 
 /**
  * Determines the highest skill level a user is genuinely eligible for,
- * by walking the prerequisite chain upward from their current level and
- * verifying each step against their actual closed-issue history.
+ * mirroring the two-step eligibility check used by the assignment bot.
  *
- * Starts at currentLevel (trusted — the user just closed an issue at that
- * level) and attempts to advance upward. Stops at the first level whose
- * prerequisites are unmet or when a GitHub API call fails, returning the
- * highest level fully verified so far.
+ * Walks the hierarchy top-down (Advanced → … → Good First Issue), stopping
+ * at the first level where the contributor passes either check:
  *
- * Example progression check for a user at BEGINNER:
- *   BEGINNER   → no requiredLabel      → eligible by default, continue
- *   INTERMEDIATE → needs 3 Beginner   → count closed Beginner issues
- *     ≥ 3 → verifiedLevel = INTERMEDIATE, continue
- *     < 3 → stop, return BEGINNER
+ *   Bypass check  — contributor already has ≥ 1 closed issue at this level
+ *                   or higher. Prior demonstrated competence skips the normal
+ *                   prerequisite count entirely.
+ *
+ *   Normal check  — contributor has accumulated at least requiredCount closed
+ *                   issues at the prerequisite level defined in
+ *                   SKILL_PREREQUISITES.
+ *
+ * Levels with no requiredLabel (i.e. Good First Issue) are always eligible
+ * and act as the guaranteed floor — the walk always resolves to at least GFI.
+ *
+ * The walk is entirely history-based and ignores the triggering issue's label,
+ * so a contributor who completes a GFI after already having three closed
+ * Intermediate issues is correctly resolved to Intermediate, not GFI.
+ *
+ * API failures degrade gracefully: if countIssuesByAssignee returns null the
+ * candidate is skipped and the walk continues downward.
+ *
+ * Example (contributor has 2 closed GFIs, 0 Beginner):
+ *   ADVANCED     → bypass: 0 closed Advanced+ → fail
+ *                  normal: needs 3 Intermediate closed → 0 → fail → skip
+ *   INTERMEDIATE → bypass: 0 closed Intermediate+ → fail
+ *                  normal: needs 3 Beginner closed → 0 → fail → skip
+ *   BEGINNER     → bypass: 0 closed Beginner+ → fail
+ *                  normal: needs 2 GFI closed → 2 → pass ✓ → return BEGINNER
  *
  * @param {object} botContext
  * @param {string} username
- * @param {string} currentLevel - Skill label from the triggering PR/issue.
- * @returns {Promise<string>}   - Highest verified eligible level label.
+ * @returns {Promise<string>} The highest verified eligible level label.
  */
-async function resolveEligibleLevel(botContext, username, currentLevel) {
+async function resolveEligibleLevel(botContext, username) {
     const { github, owner, repo } = botContext;
-    let verifiedLevel = currentLevel;
 
-    // Slice the hierarchy at currentLevel so we only walk upward from
-    // where the user already is, skipping levels they've clearly passed.
-    const startIndex = SKILL_HIERARCHY.indexOf(currentLevel);
-    for (const candidate of SKILL_HIERARCHY.slice(startIndex)) {
+    // Walk from highest to lowest so we always return the best eligible level.
+    const topDown = [...SKILL_HIERARCHY].reverse();
+
+    for (const candidate of topDown) {
         const prereq = SKILL_PREREQUISITES[candidate];
 
-        // Guard against labels that exist in SKILL_HIERARCHY but have no
-        // corresponding entry in SKILL_PREREQUISITES (misconfiguration).
+        // Guard against misconfiguration — a label in the hierarchy with no
+        // corresponding prerequisites entry.
         if (!prereq) {
-            logger.log('resolveEligibleLevel: unknown candidate, stopping walk', { candidate });
-            break;
-        }
-
-        // Some levels (e.g. Good First Issue) have no prerequisite —
-        // the user is eligible just by reaching them.
-        if (!prereq.requiredLabel) {
-            verifiedLevel = candidate;
+            logger.log('resolveEligibleLevel: unknown candidate, skipping', { candidate });
             continue;
         }
 
-        // Count closed issues the user completed at the required prerequisite
-        // level. Pass requiredCount as the threshold so the API call
-        // short-circuits as soon as the bar is cleared — no over-fetching.
+        // Floor level — no prerequisites, always eligible.
+        // Reached only if every higher level failed both checks.
+        if (!prereq.requiredLabel) {
+            logger.log('resolveEligibleLevel: floor level reached, eligible by default', {
+                user: username, candidate,
+            });
+            return candidate;
+        }
+
+        // ── Bypass check ────────────────────────────────────────────────────
+        // A single closed issue at the candidate level or above proves the
+        // contributor can already handle this difficulty. Threshold: 1.
+        const candidateIndex = SKILL_HIERARCHY.indexOf(candidate);
+        const atOrAboveLabels = SKILL_HIERARCHY.slice(candidateIndex);
+
+        for (const bypassLabel of atOrAboveLabels) {
+            const bypassCount = await countIssuesByAssignee(
+                github, owner, repo, username,
+                'closed',
+                bypassLabel,
+                1,
+            );
+
+            if (bypassCount === null) {
+                logger.log('resolveEligibleLevel: bypass countIssuesByAssignee failed, skipping label', {
+                    candidate, bypassLabel, user: username,
+                });
+                continue;
+            }
+
+            if (bypassCount >= 1) {
+                logger.log('resolveEligibleLevel: bypass check passed', {
+                    user: username, candidate, bypassLabel, bypassCount,
+                });
+                return candidate;
+            }
+        }
+
+        // ── Normal check ────────────────────────────────────────────────────
+        // Contributor must have completed at least requiredCount closed issues
+        // at the prerequisite level. Pass requiredCount as the threshold so
+        // the API short-circuits as soon as the bar is cleared.
         const count = await countIssuesByAssignee(
             github, owner, repo, username,
             'closed',
@@ -220,67 +258,124 @@ async function resolveEligibleLevel(botContext, username, currentLevel) {
         );
 
         if (count === null) {
-            // API failure — degrade gracefully by keeping whatever level
-            // has been verified so far rather than crashing the whole walk.
-            logger.log('resolveEligibleLevel: countIssuesByAssignee failed, stopping walk', {
+            logger.log('resolveEligibleLevel: normal countIssuesByAssignee failed, skipping candidate', {
                 candidate, user: username,
             });
-            break;
+            continue;
         }
 
         if (count >= prereq.requiredCount) {
-            // Prerequisites met — promote and try the next level.
-            verifiedLevel = candidate;
-        } else {
-            // Prerequisites not met — the chain is strict, so no higher
-            // level can be eligible either. Stop here.
-            logger.log('resolveEligibleLevel: prerequisites not met, stopping walk', {
-                candidate, required: prereq.requiredCount, actual: count, user: username,
+            logger.log('resolveEligibleLevel: normal check passed', {
+                user: username, candidate, required: prereq.requiredCount, actual: count,
             });
-            break;
+            return candidate;
         }
-    }
 
-    if (verifiedLevel !== currentLevel) {
-        logger.log('resolveEligibleLevel: resolved to higher level', {
-            user: username, from: currentLevel, to: verifiedLevel,
+        logger.log('resolveEligibleLevel: both checks failed, trying lower level', {
+            candidate, required: prereq.requiredCount, actual: count, user: username,
         });
     }
 
-    return verifiedLevel;
+    // Should be unreachable — the floor level always returns above — but
+    // defend against an empty or misconfigured SKILL_HIERARCHY.
+    logger.log('resolveEligibleLevel: hierarchy exhausted, defaulting to GFI', { user: username });
+    return LABELS.GOOD_FIRST_ISSUE;
 }
 
 /**
- * Returns recommended issues based on priority: next → same → fallback.
+ * Checks whether the just-completed issue pushed the contributor over the
+ * threshold into the level directly above `currentLevel`.
  *
- * Uses a single batch API call for issues and filters locally.
- * The level anchor is now the user's *verified* eligible level (resolved via
- * closed-issue history) rather than the raw label on the triggering issue.
+ * The trigger condition (from the issue spec): after this PR merged, the
+ * contributor's closed-issue count at `currentLevel` equals exactly the
+ * requiredCount that unlocks the next level. That exact count means this was
+ * the contribution that crossed the line for the first time.
+ *
+ * Only inspects the single step immediately above `currentLevel` — higher
+ * promotions would have been earned in prior sessions and should not be
+ * re-announced.
+ *
+ * Returns null if:
+ *   - currentLevel is already the top of the hierarchy
+ *   - the level above has a different requiredLabel than currentLevel
+ *     (shouldn't occur with the current config, but guards against gaps)
+ *   - the count doesn't land exactly on the threshold
+ *   - the API call fails
  *
  * @param {object} botContext
  * @param {string} username
- * @param {string} skillLevel  - Level label from the closed PR/issue.
- * @returns {Promise<Array<{ title: string, html_url: string }>|null>}
+ * @param {string} currentLevel - Skill label from the triggering PR/issue.
+ * @returns {Promise<string|null>} The newly unlocked level label, or null.
  */
-async function getRecommendedIssues(botContext, username, skillLevel) {
-    // Resolve the user's actual eligible level via prerequisite history.
-    const eligibleLevel = await resolveEligibleLevel(botContext, username, skillLevel);
+async function detectUnlockedLevel(botContext, username, currentLevel) {
+    const { github, owner, repo } = botContext;
+    const currentIndex = SKILL_HIERARCHY.indexOf(currentLevel);
+    const immediateNextLevel = SKILL_HIERARCHY[currentIndex + 1] ?? null;
 
-    logger.log('getRecommendedIssues: using eligible level', {
+    if (!immediateNextLevel) return null;
+
+    const nextPrereq = SKILL_PREREQUISITES[immediateNextLevel];
+
+    // The next level's prerequisite must be the current level for this
+    // completion to be the relevant crossing event.
+    if (!nextPrereq?.requiredLabel || nextPrereq.requiredLabel !== currentLevel) return null;
+
+    const count = await countIssuesByAssignee(
+        github, owner, repo, username,
+        'closed',
+        currentLevel,
+        nextPrereq.requiredCount,
+    );
+
+    if (count === null) {
+        logger.log('detectUnlockedLevel: countIssuesByAssignee failed', {
+            user: username, currentLevel,
+        });
+        return null;
+    }
+
+    if (count === nextPrereq.requiredCount) {
+        logger.log('detectUnlockedLevel: threshold crossed', {
+            user: username, unlockedLevel: immediateNextLevel, count,
+        });
+        return immediateNextLevel;
+    }
+
+    return null;
+}
+
+/**
+ * Returns recommended issues for the contributor based on their true
+ * eligibility level, determined by a history-based top-down walk.
+ *
+ * Issues are fetched in a single batch and filtered locally. Recommendations
+ * target the contributor's resolved eligible level — the same level they would
+ * be permitted to self-assign via the assignment bot — so every suggestion is
+ * immediately actionable.
+ *
+ * Also runs a focused threshold check (detectUnlockedLevel) to determine
+ * whether this specific completion crossed a new level boundary, so the caller
+ * can include a congratulatory message when appropriate.
+ *
+ * @param {object} botContext
+ * @param {string} username
+ * @param {string} currentLevel - Skill label from the triggering PR/issue.
+ * @returns {Promise<{ issues: Array<{ title: string, html_url: string }>, unlockedLevel: string|null } | null>}
+ *   Returns null on API failure (error comment already posted).
+ */
+async function getRecommendedIssues(botContext, username, currentLevel) {
+    // Run both async operations concurrently — they're independent.
+    const [eligibleLevel, unlockedLevel] = await Promise.all([
+        resolveEligibleLevel(botContext, username),
+        detectUnlockedLevel(botContext, username, currentLevel),
+    ]);
+
+    logger.log('getRecommendedIssues: resolved', {
         user: username,
-        labelLevel: skillLevel,
+        currentLevel,
         eligibleLevel,
+        unlockedLevel,
     });
-
-    const fallback = getFallbackLevel(eligibleLevel);
-    const nextLevel = getNextLevel(eligibleLevel);
-
-    // Priority: next (if different) → current eligible → one step down (unless already beginner).
-    const levelsPriority = [
-        nextLevel !== eligibleLevel ? nextLevel : null,
-        eligibleLevel,
-        eligibleLevel !== LABELS.BEGINNER ? fallback : null,
-    ].filter(Boolean);
 
     const issues = await fetchIssuesBatch(
         botContext.github,
@@ -296,8 +391,13 @@ async function getRecommendedIssues(botContext, username, skillLevel) {
         return null;
     }
 
-    const grouped = groupIssuesByLevel(issues, levelsPriority);
-    return pickFirstAvailableLevel(grouped, levelsPriority);
+    // Target the contributor's resolved eligible level directly. No next/fallback
+    // priority list — every recommended issue should be one they can actually claim.
+    const grouped = groupIssuesByLevel(issues, [eligibleLevel]);
+    return {
+        issues: pickFirstAvailableLevel(grouped, [eligibleLevel]),
+        unlockedLevel,
+    };
 }
 
 /**
@@ -305,10 +405,11 @@ async function getRecommendedIssues(botContext, username, skillLevel) {
  *
  * - Determines skill level
  * - Fetches recommended issues
- * - Posts a comment if results exist
+ * - Posts a comment if results exist, with a congratulatory prefix when the
+ *   just-completed issue crossed a new level threshold
  *
  * Skips silently if context is incomplete or no results found.
- * Returns early on API failure .
+ * Returns early on API failure.
  *
  * @param {{
  *   github: object,
@@ -345,30 +446,33 @@ async function handleRecommendIssues(botContext) {
         issue: botContext.issue?.number,
     });
 
-    const issues = await getRecommendedIssues(
+    const result = await getRecommendedIssues(
         botContext,
         username,
         skillLevel,
     );
 
-    if (issues === null) return;
+    if (result === null) return;
+
+    const { issues, unlockedLevel } = result;
 
     if (issues.length === 0) {
         logger.log('recommendation.empty', { user: username });
         return;
     }
 
-    const comment = buildRecommendationComment(username, issues);
+    const comment = buildRecommendationComment(username, issues, unlockedLevel);
     logger.log('recommendation.postComment', {
         target: botContext.number,
         issueSource: botContext.issue?.number,
         recommendations: issues.length,
+        unlockedLevel,
     });
-    const result = await postComment(botContext, comment);
+    const postResult = await postComment(botContext, comment);
 
-    if (!result.success) {
+    if (!postResult.success) {
         logger.error('recommendation.postCommentFailed', {
-            error: result.error,
+            error: postResult.error,
         });
         return;
     }
@@ -378,8 +482,7 @@ async function handleRecommendIssues(botContext) {
 
 module.exports = { 
     handleRecommendIssues,
-    getNextLevel,
-    getFallbackLevel,
     getRecommendedIssues,
     resolveEligibleLevel,
+    detectUnlockedLevel,
 };

--- a/.github/scripts/commands/recommend-issues.js
+++ b/.github/scripts/commands/recommend-issues.js
@@ -11,6 +11,7 @@ const {
     LABELS,
     SKILL_HIERARCHY,
     SKILL_PREREQUISITES,
+    ISSUE_STATE,
     hasLabel,
     postComment,
     getLogger,
@@ -181,7 +182,7 @@ async function passesBypassCheck(github, owner, repo, username, candidate) {
     for (const label of atOrAboveLabels) {
         const count = await countIssuesByAssignee(
             github, owner, repo, username,
-            'closed',
+            ISSUE_STATE.CLOSED,
             label,
             1,
         );
@@ -215,7 +216,7 @@ async function passesBypassCheck(github, owner, repo, username, candidate) {
 async function passesNormalCheck(github, owner, repo, username, prereq) {
     const count = await countIssuesByAssignee(
         github, owner, repo, username,
-        'closed',
+        ISSUE_STATE.CLOSED,
         prereq.requiredLabel,
         prereq.requiredCount,
     );
@@ -318,7 +319,7 @@ async function detectUnlockedLevel(botContext, username, currentLevel) {
 
     const count = await countIssuesByAssignee(
         github, owner, repo, username,
-        'closed',
+        ISSUE_STATE.CLOSED,
         currentLevel,
         nextPrereq.requiredCount + 1,
     );

--- a/.github/scripts/commands/recommend-issues.js
+++ b/.github/scripts/commands/recommend-issues.js
@@ -156,131 +156,134 @@ function buildRecommendationErrorComment(username) {
 }
 
 /**
- * Determines the highest skill level a user is genuinely eligible for,
- * mirroring the two-step eligibility check used by the assignment bot.
+ * Checks whether a contributor qualifies for a level via bypass.
  *
- * Walks the hierarchy top-down (Advanced → … → Good First Issue), stopping
- * at the first level where the contributor passes either check:
+ * A contributor passes the bypass check if they have at least one closed
+ * issue at the candidate level or any higher level. This indicates prior
+ * experience at that difficulty, so prerequisite counts are not required.
  *
- *   Bypass check  — contributor already has ≥ 1 closed issue at this level
- *                   or higher. Prior demonstrated competence skips the normal
- *                   prerequisite count entirely.
+ * Iterates through all labels at or above the candidate level and stops
+ * as soon as a qualifying issue is found.
  *
- *   Normal check  — contributor has accumulated at least requiredCount closed
- *                   issues at the prerequisite level defined in
- *                   SKILL_PREREQUISITES.
+ * API failures are treated as non-qualifying and skipped.
  *
- * Levels with no requiredLabel (i.e. Good First Issue) are always eligible
- * and act as the guaranteed floor — the walk always resolves to at least GFI.
+ * @param {object} github
+ * @param {string} owner
+ * @param {string} repo
+ * @param {string} username
+ * @param {string} candidate - Skill level being evaluated
+ * @returns {Promise<boolean>} True if bypass condition is satisfied
+ */
+async function passesBypassCheck(github, owner, repo, username, candidate) {
+    const candidateIndex = SKILL_HIERARCHY.indexOf(candidate);
+    const atOrAboveLabels = SKILL_HIERARCHY.slice(candidateIndex);
+
+    for (const label of atOrAboveLabels) {
+        const count = await countIssuesByAssignee(
+            github, owner, repo, username,
+            'closed',
+            label,
+            1,
+        );
+        // Skip on API failure
+        if (count === null) continue;
+
+        if (count >= 1) return true;
+    }
+    return false;
+}
+
+/**
+ * Checks whether a contributor qualifies for a level via prerequisite count.
  *
- * The walk is entirely history-based and does not depend on the triggering
- * issue's label. Eligibility is determined solely from previously closed issues.
+ * A contributor passes the normal check if they have completed at least
+ * `requiredCount` issues at the prerequisite level.
  *
- * API failures degrade gracefully: if countIssuesByAssignee returns null the
- * candidate is skipped and the walk continues downward.
+ * The threshold is passed to countIssuesByAssignee so the query can stop
+ * early once the requirement is satisfied.
  *
- * Example (contributor has 2 closed GFIs, 0 Beginner):
- *   ADVANCED     → bypass: 0 closed Advanced+ → fail
- *                  normal: needs 3 Intermediate closed → 0 → fail → skip
- *   INTERMEDIATE → bypass: 0 closed Intermediate+ → fail
- *                  normal: needs 3 Beginner closed → 0 → fail → skip
- *   BEGINNER     → bypass: 0 closed Beginner+ → fail
- *                  normal: needs 2 GFI closed → 2 → pass ✓ → return BEGINNER
+ * @param {object} github
+ * @param {string} owner
+ * @param {string} repo
+ * @param {string} username
+ * @param {{ requiredLabel: string, requiredCount: number }} prereq
+ * @returns {Promise<boolean|null>}
+ *   - true  → requirement met
+ *   - false → requirement not met
+ *   - null  → API failure
+ */
+async function passesNormalCheck(github, owner, repo, username, prereq) {
+    const count = await countIssuesByAssignee(
+        github, owner, repo, username,
+        'closed',
+        prereq.requiredLabel,
+        prereq.requiredCount,
+    );
+
+    if (count === null) return null;
+
+    return count >= prereq.requiredCount;
+}
+
+/**
+ * Determines the highest skill level a contributor is eligible for
+ * based on their completed issues.
+ *
+ * The hierarchy is evaluated from highest to lowest level, returning
+ * the first level that satisfies either of the following:
+ *
+ *   - Bypass check:
+ *       The contributor has at least one closed issue at the candidate
+ *       level or any higher level. This indicates prior experience, so
+ *       prerequisite counts are not required.
+ *
+ *   - Normal check:
+ *       The contributor has completed at least `requiredCount` issues
+ *       at the prerequisite level defined in SKILL_PREREQUISITES.
+ *
+ * The two checks are delegated to helper functions:
+ *   - passesBypassCheck
+ *   - passesNormalCheck
+ *
+ * Levels without a prerequisite label (e.g. Good First Issue) act as
+ * the floor and are always considered eligible.
+ *
+ * If an API call fails during evaluation, that candidate level is skipped
+ * and the next lower level is considered.
  *
  * @param {object} botContext
  * @param {string} username
- * @returns {Promise<string>} The highest verified eligible level label.
+ * @returns {Promise<string>} The highest eligible skill level label
  */
 async function resolveEligibleLevel(botContext, username) {
     const { github, owner, repo } = botContext;
-
-    // Walk from highest to lowest so we always return the best eligible level.
     const topDown = [...SKILL_HIERARCHY].reverse();
 
     for (const candidate of topDown) {
         const prereq = SKILL_PREREQUISITES[candidate];
 
-        // Guard against misconfiguration — a label in the hierarchy with no
-        // corresponding prerequisites entry.
-        if (!prereq) {
-            logger.log('resolveEligibleLevel: unknown candidate, skipping', { candidate });
-            continue;
-        }
+        if (!prereq) continue;
 
-        // Floor level — no prerequisites, always eligible.
-        // Reached only if every higher level failed both checks.
-        if (!prereq.requiredLabel) {
-            logger.log('resolveEligibleLevel: floor level reached, eligible by default', {
-                user: username, candidate,
-            });
-            return candidate;
-        }
+        // Floor level
+        if (!prereq.requiredLabel) return candidate;
 
-        // ── Bypass check ────────────────────────────────────────────────────
-        // A single closed issue at the candidate level or above proves the
-        // contributor can already handle this difficulty. Threshold: 1.
-        const candidateIndex = SKILL_HIERARCHY.indexOf(candidate);
-        const atOrAboveLabels = SKILL_HIERARCHY.slice(candidateIndex);
+        // Bypass check
+        const bypass = await passesBypassCheck(
+            github, owner, repo, username, candidate
+        );
+        if (bypass) return candidate;
 
-        for (const bypassLabel of atOrAboveLabels) {
-            const bypassCount = await countIssuesByAssignee(
-                github, owner, repo, username,
-                'closed',
-                bypassLabel,
-                1,
-            );
-
-            if (bypassCount === null) {
-                logger.log('resolveEligibleLevel: bypass countIssuesByAssignee failed, skipping label', {
-                    candidate, bypassLabel, user: username,
-                });
-                continue;
-            }
-
-            if (bypassCount >= 1) {
-                logger.log('resolveEligibleLevel: bypass check passed', {
-                    user: username, candidate, bypassLabel, bypassCount,
-                });
-                return candidate;
-            }
-        }
-
-        // ── Normal check ────────────────────────────────────────────────────
-        // Contributor must have completed at least requiredCount closed issues
-        // at the prerequisite level.
-        //
-        // countIssuesByAssignee caps results at the provided threshold, so
-        // passing requiredCount allows early exit once eligibility is proven,
-        // avoiding unnecessary pagination.
-        const count = await countIssuesByAssignee(
-            github, owner, repo, username,
-            'closed',
-            prereq.requiredLabel,
-            prereq.requiredCount,
+        // Normal check
+        const normal = await passesNormalCheck(
+            github, owner, repo, username, prereq
         );
 
-        if (count === null) {
-            logger.log('resolveEligibleLevel: normal countIssuesByAssignee failed, skipping candidate', {
-                candidate, user: username,
-            });
-            continue;
-        }
+        // Skip candidate if API failed
+        if (normal === null) continue;
 
-        if (count >= prereq.requiredCount) {
-            logger.log('resolveEligibleLevel: normal check passed', {
-                user: username, candidate, required: prereq.requiredCount, actual: count,
-            });
-            return candidate;
-        }
-
-        logger.log('resolveEligibleLevel: both checks failed, trying lower level', {
-            candidate, required: prereq.requiredCount, actual: count, user: username,
-        });
+        if (normal) return candidate;
     }
 
-    // Should be unreachable — the floor level always returns above — but
-    // defend against an empty or misconfigured SKILL_HIERARCHY.
-    logger.log('resolveEligibleLevel: hierarchy exhausted, defaulting to GFI', { user: username });
     return LABELS.GOOD_FIRST_ISSUE;
 }
 

--- a/.github/scripts/commands/recommend-issues.js
+++ b/.github/scripts/commands/recommend-issues.js
@@ -10,10 +10,12 @@ const {
     MAINTAINER_TEAM,
     LABELS,
     SKILL_HIERARCHY,
+    SKILL_PREREQUISITES,
     hasLabel,
     postComment,
     getLogger,
     getHighestIssueSkillLevel,
+    countIssuesByAssignee,
 } = require('../helpers');
 
 // Logger delegation 
@@ -163,24 +165,121 @@ function buildRecommendationErrorComment(username) {
 }
 
 /**
- * Returns recommended issues based on priority:
- * next → same → fallback.
+ * Determines the highest skill level a user is genuinely eligible for,
+ * by walking the prerequisite chain upward from their current level and
+ * verifying each step against their actual closed-issue history.
  *
- * Uses a single API call and filters results locally.
+ * Starts at currentLevel (trusted — the user just closed an issue at that
+ * level) and attempts to advance upward. Stops at the first level whose
+ * prerequisites are unmet or when a GitHub API call fails, returning the
+ * highest level fully verified so far.
+ *
+ * Example progression check for a user at BEGINNER:
+ *   BEGINNER   → no requiredLabel      → eligible by default, continue
+ *   INTERMEDIATE → needs 3 Beginner   → count closed Beginner issues
+ *     ≥ 3 → verifiedLevel = INTERMEDIATE, continue
+ *     < 3 → stop, return BEGINNER
  *
  * @param {object} botContext
  * @param {string} username
- * @param {string} skillLevel
+ * @param {string} currentLevel - Skill label from the triggering PR/issue.
+ * @returns {Promise<string>}   - Highest verified eligible level label.
+ */
+async function resolveEligibleLevel(botContext, username, currentLevel) {
+    const { github, owner, repo } = botContext;
+    let verifiedLevel = currentLevel;
+
+    // Slice the hierarchy at currentLevel so we only walk upward from
+    // where the user already is, skipping levels they've clearly passed.
+    const startIndex = SKILL_HIERARCHY.indexOf(currentLevel);
+    for (const candidate of SKILL_HIERARCHY.slice(startIndex)) {
+        const prereq = SKILL_PREREQUISITES[candidate];
+
+        // Guard against labels that exist in SKILL_HIERARCHY but have no
+        // corresponding entry in SKILL_PREREQUISITES (misconfiguration).
+        if (!prereq) {
+            logger.log('resolveEligibleLevel: unknown candidate, stopping walk', { candidate });
+            break;
+        }
+
+        // Some levels (e.g. Good First Issue) have no prerequisite —
+        // the user is eligible just by reaching them.
+        if (!prereq.requiredLabel) {
+            verifiedLevel = candidate;
+            continue;
+        }
+
+        // Count closed issues the user completed at the required prerequisite
+        // level. Pass requiredCount as the threshold so the API call
+        // short-circuits as soon as the bar is cleared — no over-fetching.
+        const count = await countIssuesByAssignee(
+            github, owner, repo, username,
+            'closed',
+            prereq.requiredLabel,
+            prereq.requiredCount,
+        );
+
+        if (count === null) {
+            // API failure — degrade gracefully by keeping whatever level
+            // has been verified so far rather than crashing the whole walk.
+            logger.log('resolveEligibleLevel: countIssuesByAssignee failed, stopping walk', {
+                candidate, user: username,
+            });
+            break;
+        }
+
+        if (count >= prereq.requiredCount) {
+            // Prerequisites met — promote and try the next level.
+            verifiedLevel = candidate;
+        } else {
+            // Prerequisites not met — the chain is strict, so no higher
+            // level can be eligible either. Stop here.
+            logger.log('resolveEligibleLevel: prerequisites not met, stopping walk', {
+                candidate, required: prereq.requiredCount, actual: count, user: username,
+            });
+            break;
+        }
+    }
+
+    if (verifiedLevel !== currentLevel) {
+        logger.log('resolveEligibleLevel: resolved to higher level', {
+            user: username, from: currentLevel, to: verifiedLevel,
+        });
+    }
+
+    return verifiedLevel;
+}
+
+/**
+ * Returns recommended issues based on priority: next → same → fallback.
+ *
+ * Uses a single batch API call for issues and filters locally.
+ * The level anchor is now the user's *verified* eligible level (resolved via
+ * closed-issue history) rather than the raw label on the triggering issue.
+ *
+ * @param {object} botContext
+ * @param {string} username
+ * @param {string} skillLevel  - Level label from the closed PR/issue.
  * @returns {Promise<Array<{ title: string, html_url: string }>|null>}
  */
 async function getRecommendedIssues(botContext, username, skillLevel) {
-    const fallback = getFallbackLevel(skillLevel);
-    const nextLevel = getNextLevel(skillLevel);
+    // Resolve the user's actual eligible level via prerequisite history.
+    const eligibleLevel = await resolveEligibleLevel(botContext, username, skillLevel);
 
+    logger.log('getRecommendedIssues: using eligible level', {
+        user: username,
+        labelLevel: skillLevel,
+        eligibleLevel,
+    });
+
+    const fallback = getFallbackLevel(eligibleLevel);
+    const nextLevel = getNextLevel(eligibleLevel);
+
+    // Priority: next (if different) → current eligible → one step down (unless already beginner).
     const levelsPriority = [
-        nextLevel !== skillLevel ? nextLevel : null,
-        skillLevel,
-        skillLevel !== LABELS.BEGINNER ? fallback : null,
+        nextLevel !== eligibleLevel ? nextLevel : null,
+        eligibleLevel,
+        eligibleLevel !== LABELS.BEGINNER ? fallback : null,
     ].filter(Boolean);
 
     const issues = await fetchIssuesBatch(
@@ -282,4 +381,5 @@ module.exports = {
     getNextLevel,
     getFallbackLevel,
     getRecommendedIssues,
+    resolveEligibleLevel,
 };

--- a/.github/scripts/commands/recommend-issues.js
+++ b/.github/scripts/commands/recommend-issues.js
@@ -3,8 +3,8 @@
 // commands/recommend-issues.js
 //
 // Issue recommendation command: suggests relevant issues to contributors
-// after a PR is closed. Uses skill progression logic to recommend the next
-// suitable issues based on difficulty level.
+// after a PR is closed. Uses a history-based eligibility model to recommend issues strictly
+// at the highest level the contributor is currently allowed to claim.
 
 const {
     MAINTAINER_TEAM,
@@ -173,9 +173,8 @@ function buildRecommendationErrorComment(username) {
  * Levels with no requiredLabel (i.e. Good First Issue) are always eligible
  * and act as the guaranteed floor — the walk always resolves to at least GFI.
  *
- * The walk is entirely history-based and ignores the triggering issue's label,
- * so a contributor who completes a GFI after already having three closed
- * Intermediate issues is correctly resolved to Intermediate, not GFI.
+ * The walk is entirely history-based and does not depend on the triggering
+ * issue's label. Eligibility is determined solely from previously closed issues.
  *
  * API failures degrade gracefully: if countIssuesByAssignee returns null the
  * candidate is skipped and the walk continues downward.
@@ -248,8 +247,11 @@ async function resolveEligibleLevel(botContext, username) {
 
         // ── Normal check ────────────────────────────────────────────────────
         // Contributor must have completed at least requiredCount closed issues
-        // at the prerequisite level. Pass requiredCount as the threshold so
-        // the API short-circuits as soon as the bar is cleared.
+        // at the prerequisite level.
+        //
+        // countIssuesByAssignee caps results at the provided threshold, so
+        // passing requiredCount allows early exit once eligibility is proven,
+        // avoiding unnecessary pagination.
         const count = await countIssuesByAssignee(
             github, owner, repo, username,
             'closed',
@@ -283,29 +285,20 @@ async function resolveEligibleLevel(botContext, username) {
 }
 
 /**
- * Checks whether the just-completed issue pushed the contributor over the
- * threshold into the level directly above `currentLevel`.
+ * Checks whether the just-completed issue caused the contributor to reach
+ * the threshold required to unlock the level directly above `currentLevel`.
  *
- * The trigger condition (from the issue spec): after this PR merged, the
- * contributor's closed-issue count at `currentLevel` equals exactly the
- * requiredCount that unlocks the next level. That exact count means this was
- * the contribution that crossed the line for the first time.
+ * The count is evaluated using a capped query (threshold = requiredCount + 1),
+ * allowing the function to distinguish between:
+ *   - reaching the threshold exactly for the first time
+ *   - having already exceeded it earlier
  *
- * Only inspects the single step immediately above `currentLevel` — higher
- * promotions would have been earned in prior sessions and should not be
- * re-announced.
- *
- * Returns null if:
- *   - currentLevel is already the top of the hierarchy
- *   - the level above has a different requiredLabel than currentLevel
- *     (shouldn't occur with the current config, but guards against gaps)
- *   - the count doesn't land exactly on the threshold
- *   - the API call fails
+ * Only the immediate next level is considered.
  *
  * @param {object} botContext
  * @param {string} username
- * @param {string} currentLevel - Skill label from the triggering PR/issue.
- * @returns {Promise<string|null>} The newly unlocked level label, or null.
+ * @param {string} currentLevel
+ * @returns {Promise<string|null>}
  */
 async function detectUnlockedLevel(botContext, username, currentLevel) {
     const { github, owner, repo } = botContext;
@@ -324,7 +317,7 @@ async function detectUnlockedLevel(botContext, username, currentLevel) {
         github, owner, repo, username,
         'closed',
         currentLevel,
-        nextPrereq.requiredCount,
+        nextPrereq.requiredCount + 1,
     );
 
     if (count === null) {
@@ -348,10 +341,9 @@ async function detectUnlockedLevel(botContext, username, currentLevel) {
  * Returns recommended issues for the contributor based on their true
  * eligibility level, determined by a history-based top-down walk.
  *
- * Issues are fetched in a single batch and filtered locally. Recommendations
- * target the contributor's resolved eligible level — the same level they would
- * be permitted to self-assign via the assignment bot — so every suggestion is
- * immediately actionable.
+ * Issues are fetched in a single batch and filtered locally.
+ * Recommendations are restricted to the contributor's resolved eligible level,
+ * so all suggested issues are immediately assignable.
  *
  * Also runs a focused threshold check (detectUnlockedLevel) to determine
  * whether this specific completion crossed a new level boundary, so the caller
@@ -391,8 +383,7 @@ async function getRecommendedIssues(botContext, username, currentLevel) {
         return null;
     }
 
-    // Target the contributor's resolved eligible level directly. No next/fallback
-    // priority list — every recommended issue should be one they can actually claim.
+    // Filter issues to the resolved eligible level so all results are actionable.
     const grouped = groupIssuesByLevel(issues, [eligibleLevel]);
     return {
         issues: pickFirstAvailableLevel(grouped, [eligibleLevel]),

--- a/.github/scripts/helpers/api.js
+++ b/.github/scripts/helpers/api.js
@@ -13,7 +13,7 @@ const {
   requirePositiveInt,
   requireSafeUsername,
 } = require('./validation');
-const { LABELS, SKILL_HIERARCHY } = require('./constants');
+const { LABELS, SKILL_HIERARCHY, ISSUE_STATE } = require('./constants');
 const { checkDCO, checkGPG, checkMergeConflict, checkIssueLink } = require('./checks');
 const { buildBotComment } = require('./comments');
 
@@ -779,7 +779,7 @@ async function countIssuesByAssignee(
     !isSafeSearchToken(repo) ||
     !isSafeSearchToken(username)
   ) {
-    logger.log("[assign] Invalid search inputs:", {
+    getLogger().log("[assign] Invalid search inputs:", {
       owner,
       repo,
       username,
@@ -788,14 +788,14 @@ async function countIssuesByAssignee(
     return null;
   }
   if (state !== ISSUE_STATE.OPEN && state !== ISSUE_STATE.CLOSED) {
-    logger.log("[assign] Invalid state:", { state });
+    getLogger().log("[assign] Invalid state:", { state });
     return null;
   }
   if (
     label &&
     (typeof label !== "string" || !label.trim() || label.includes('"'))
   ) {
-    logger.log("[assign] Invalid label parameter:", { label });
+    getLogger().log("[assign] Invalid label parameter:", { label });
     return null;
   }
 
@@ -804,7 +804,7 @@ async function countIssuesByAssignee(
     let matchingIssuesCount = 0;
     const perPage = 100;
 
-    logger.log(`[assign] Fetching ${state} assigned issues via REST...`);
+    getLogger().log(`[assign] Fetching ${state} assigned issues via REST...`);
     while (true) {
       const params = {
         owner,
@@ -833,7 +833,7 @@ async function countIssuesByAssignee(
       matchingIssuesCount += pageMatchCount;
 
       if (threshold !== null && matchingIssuesCount >= threshold) {
-        logger.log(
+        getLogger().log(
           `[assign] Reached threshold (${threshold}), short-circuiting fetch.`,
         );
         matchingIssuesCount = threshold; // Cap at threshold logically for callers
@@ -846,18 +846,18 @@ async function countIssuesByAssignee(
     }
 
     if (label) {
-      logger.log(
+      getLogger().log(
         `[assign] ${state} assigned issues for ${username} with label ${label}: ${matchingIssuesCount}`,
       );
     } else {
-      logger.log(
+      getLogger().log(
         `[assign] ${state} assigned issues for ${username}${state === ISSUE_STATE.OPEN ? " (excluding blocked)" : ""}: ${matchingIssuesCount}`,
       );
     }
     return matchingIssuesCount;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    logger.log(
+    getLogger().log(
       `[assign] Failed to count ${state} issues for ${username}: ${message}`,
     );
     return null;

--- a/.github/scripts/helpers/api.js
+++ b/.github/scripts/helpers/api.js
@@ -744,6 +744,126 @@ function getHighestIssueSkillLevel(issue) {
   return null;
 }
 
+/**
+ * Fetches the number of issues assigned to a specific user that match a given
+ * state and optional label using the GitHub REST API.
+ *
+ * Note: When state is OPEN and no label filter is provided, issues with the
+ * "status: blocked" label are explicitly EXCLUDED from the count.
+ * The search is constrained to the repo specified in the context.
+ *
+ * @param {object} github - Octokit GitHub API client (must support github.rest).
+ * @param {string} owner - Repository owner (e.g. 'hiero-ledger').
+ * @param {string} repo - Repository name (e.g. 'hiero-sdk-cpp').
+ * @param {string} username - GitHub username to search for.
+ * @param {string} state - Issue state filter: ISSUE_STATE.OPEN or ISSUE_STATE.CLOSED.
+ * @param {string|null} [label=null] - Optional label filter (e.g. 'skill: good first issue').
+ * @param {number|null} [threshold=null] - Optional threshold to short-circuit pagination.
+ *   When provided, the function returns a capped count (the threshold value)
+ *   once that threshold is reached.
+ * @returns {Promise<number|null>} Matching issue count, or null if inputs are invalid or the API call fails.
+ *   When threshold is provided and reached, returns the threshold value (capped),
+ *   not necessarily the exact total.
+ */
+async function countIssuesByAssignee(
+  github,
+  owner,
+  repo,
+  username,
+  state,
+  label = null,
+  threshold = null,
+) {
+  if (
+    !isSafeSearchToken(owner) ||
+    !isSafeSearchToken(repo) ||
+    !isSafeSearchToken(username)
+  ) {
+    logger.log("[assign] Invalid search inputs:", {
+      owner,
+      repo,
+      username,
+      label,
+    });
+    return null;
+  }
+  if (state !== ISSUE_STATE.OPEN && state !== ISSUE_STATE.CLOSED) {
+    logger.log("[assign] Invalid state:", { state });
+    return null;
+  }
+  if (
+    label &&
+    (typeof label !== "string" || !label.trim() || label.includes('"'))
+  ) {
+    logger.log("[assign] Invalid label parameter:", { label });
+    return null;
+  }
+
+  try {
+    let page = 1;
+    let matchingIssuesCount = 0;
+    const perPage = 100;
+
+    logger.log(`[assign] Fetching ${state} assigned issues via REST...`);
+    while (true) {
+      const params = {
+        owner,
+        repo,
+        state: state.toLowerCase(),
+        assignee: username,
+        per_page: perPage,
+        page,
+      };
+      if (label) params.labels = label;
+
+      const result = await github.rest.issues.listForRepo(params);
+      // Filter out Pull Requests (which are returned by the issues endpoint)
+      const actualIssues = result.data.filter((item) => !item.pull_request);
+
+      let pageMatchCount = 0;
+      if (state === ISSUE_STATE.OPEN && !label) {
+        pageMatchCount = actualIssues.filter(
+          (issue) =>
+            !issue.labels?.some((l) => (l.name || l) === LABELS.BLOCKED),
+        ).length;
+      } else {
+        pageMatchCount = actualIssues.length;
+      }
+
+      matchingIssuesCount += pageMatchCount;
+
+      if (threshold !== null && matchingIssuesCount >= threshold) {
+        logger.log(
+          `[assign] Reached threshold (${threshold}), short-circuiting fetch.`,
+        );
+        matchingIssuesCount = threshold; // Cap at threshold logically for callers
+        break;
+      }
+
+      // Pagination must evaluate the raw result size, not the filtered size.
+      if (result.data.length < perPage) break;
+      page++;
+    }
+
+    if (label) {
+      logger.log(
+        `[assign] ${state} assigned issues for ${username} with label ${label}: ${matchingIssuesCount}`,
+      );
+    } else {
+      logger.log(
+        `[assign] ${state} assigned issues for ${username}${state === ISSUE_STATE.OPEN ? " (excluding blocked)" : ""}: ${matchingIssuesCount}`,
+      );
+    }
+    return matchingIssuesCount;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.log(
+      `[assign] Failed to count ${state} issues for ${username}: ${message}`,
+    );
+    return null;
+  }
+}
+
 module.exports = {
   buildBotContext,
   addLabels,
@@ -768,4 +888,5 @@ module.exports = {
   fetchIssueEvents,
   closeItem,
   getHighestIssueSkillLevel,
+  countIssuesByAssignee,
 };

--- a/.github/scripts/helpers/constants.js
+++ b/.github/scripts/helpers/constants.js
@@ -46,9 +46,46 @@ const ISSUE_STATE = Object.freeze({
   CLOSED: 'closed',
 });
 
+/**
+ * Skill-level prerequisite map. Each key is a LABELS skill-level constant.
+ * - requiredLabel: the prerequisite skill label the user must have completed, or null if none.
+ * - requiredCount: how many closed issues with requiredLabel the user needs.
+ * - displayName: human-readable name for the current skill level.
+ * - prerequisiteDisplayName: human-readable plural name for the prerequisite level (used in comments).
+ *
+ * Progression: Good First Issue (no prereqs) -> Beginner (2 GFI) -> Intermediate (3 Beginner) -> Advanced (3 Intermediate).
+ * @type {Object<string, { requiredLabel: string|null, requiredCount: number, displayName: string, prerequisiteDisplayName?: string }>}
+ */
+const SKILL_PREREQUISITES = {
+  [LABELS.GOOD_FIRST_ISSUE]: {
+    requiredLabel: null,
+    requiredCount: 0,
+    displayName: "Good First Issue",
+  },
+  [LABELS.BEGINNER]: {
+    requiredLabel: LABELS.GOOD_FIRST_ISSUE,
+    requiredCount: 2,
+    displayName: "Beginner",
+    prerequisiteDisplayName: "Good First Issues",
+  },
+  [LABELS.INTERMEDIATE]: {
+    requiredLabel: LABELS.BEGINNER,
+    requiredCount: 3,
+    displayName: "Intermediate",
+    prerequisiteDisplayName: "Beginner Issues",
+  },
+  [LABELS.ADVANCED]: {
+    requiredLabel: LABELS.INTERMEDIATE,
+    requiredCount: 3,
+    displayName: "Advanced",
+    prerequisiteDisplayName: "Intermediate Issues",
+  },
+};
+
 module.exports = {
   MAINTAINER_TEAM,
   LABELS,
   ISSUE_STATE,
   SKILL_HIERARCHY,
+  SKILL_PREREQUISITES,
 };

--- a/.github/scripts/tests/test-recommend-issues-bot.js
+++ b/.github/scripts/tests/test-recommend-issues-bot.js
@@ -12,6 +12,7 @@ const {
   getNextLevel,
   getFallbackLevel,
   getRecommendedIssues,
+  resolveEligibleLevel,
 } = require('../commands/recommend-issues');
 
 // =============================================================================

--- a/.github/scripts/tests/test-recommend-issues-bot.js
+++ b/.github/scripts/tests/test-recommend-issues-bot.js
@@ -200,6 +200,21 @@ const unitTests = [
     },
   },
   {
+    name: 'resolveEligibleLevel: API failure at top level → falls through to next eligible level',
+    test: async () => {
+      const midPrereq = SKILL_PREREQUISITES[MID];
+      const { botContext } = createMockBotContext({
+        closedCounts: {
+          // Simulate failure for the TOP-level check, pass for MID.
+          [`${TOP}:contributor`]: null,
+          [`${midPrereq.requiredLabel}:contributor`]: midPrereq.requiredCount,
+        },
+      });
+      const level = await resolveEligibleLevel(botContext, 'contributor');
+      return level === MID;
+    },
+  },
+  {
     name: 'resolveEligibleLevel: meets prereq for MID but not TOP → returns MID',
     test: async () => {
       const midPrereq = SKILL_PREREQUISITES[MID];

--- a/.github/scripts/tests/test-recommend-issues-bot.js
+++ b/.github/scripts/tests/test-recommend-issues-bot.js
@@ -6,13 +6,12 @@
 // Run with: node .github/scripts/tests/test-recommend-issues-bot.js
 
 const { runTestSuite } = require('./test-utils');
-const { LABELS, SKILL_HIERARCHY, MAINTAINER_TEAM } = require('../helpers/constants');
+const { LABELS, SKILL_HIERARCHY, SKILL_PREREQUISITES, MAINTAINER_TEAM } = require('../helpers/constants');
 const {
   handleRecommendIssues,
-  getNextLevel,
-  getFallbackLevel,
   getRecommendedIssues,
   resolveEligibleLevel,
+  detectUnlockedLevel,
 } = require('../commands/recommend-issues');
 
 // =============================================================================
@@ -22,10 +21,14 @@ const {
 function createMockBotContext(overrides = {}) {
   const calls = { comments: [] };
 
-  // searchItems: null  → simulate API failure
+  // searchItems: null  → simulate API failure for issue search
   // searchItems: []    → API succeeds, no results
   // searchItems: [...] → API succeeds with items
   const searchItems = overrides.searchItems !== undefined ? overrides.searchItems : [];
+
+  // closedCounts controls how many issues exist for each (label, user).
+  // null simulates API failure for all calls.
+  const closedCounts = overrides.closedCounts !== undefined ? overrides.closedCounts : {};
 
   return {
     botContext: {
@@ -35,6 +38,7 @@ function createMockBotContext(overrides = {}) {
             createComment: async (params) => {
               calls.comments.push(params.body);
             },
+            listForRepo: buildListForRepo(closedCounts),
           },
           search: {
             issuesAndPullRequests: async () => {
@@ -54,6 +58,65 @@ function createMockBotContext(overrides = {}) {
   };
 }
 
+/**
+
+ * Builds a mock of `github.rest.issues.listForRepo` used by
+ * countIssuesByAssignee.
+ *
+ * For a given (state, assignee, label), the mock returns a list of synthetic
+ * issues whose size is determined by `closedCounts["label:username"]`.
+ *
+ * Behavior:
+ *   - `closedCounts === null` → all calls throw (simulates API failure)
+ *   - `closedCounts[key] === null` → specific call throws
+ *   - otherwise → returns an array of matching issues
+ *
+ * The returned items mimic real API responses:
+ *   - include labels
+ *   - exclude pull_request field (so they count as issues)
+ *
+ * The number of returned items is capped by `per_page`, matching how the real
+ * function respects pagination limits.
+ */
+function buildListForRepo(closedCounts) {
+  return async ({ state, assignee, labels, per_page }) => {
+    // Simulate full API outage.
+    if (closedCounts === null) {
+      throw new Error('listForRepo API error');
+    }
+
+    // Only the closed + label path is modeled, which is what the eligibility
+    // and unlock logic rely on.
+    const label = labels ?? null;
+    const key = label ? `${label}:${assignee}` : null;
+
+    // Allow individual keys to signal failure.
+    if (key !== null && closedCounts[key] === null) {
+      throw new Error(`listForRepo API error for key ${key}`);
+    }
+
+    const count = (key !== null ? closedCounts[key] : 0) ?? 0;
+
+    // Build synthetic issue objects that pass the `!item.pull_request` filter
+    // and carry the requested label.
+    const items = Array.from({ length: count }, (_, i) => ({
+      number: i + 1,
+      title: `Issue ${i + 1}`,
+      html_url: `https://github.com/test/repo/issues/${i + 1}`,
+      pull_request: undefined,   // marks it as a real issue, not a PR
+      labels: label ? [{ name: label }] : [],
+    }));
+
+    // The real implementation paginates but the mock returns everything at
+    // once since counts are small. Mimic the `{ data }` envelope.
+    return { data: items.slice(0, per_page) };
+  };
+}
+
+/**
+ * Creates a minimal issue object with the given labels.
+ * Matches the structure expected by recommendation logic.
+ */
 function makeIssue(labels, number = 1) {
   return {
     number,
@@ -63,7 +126,7 @@ function makeIssue(labels, number = 1) {
   };
 }
 
-// Convenience: lowest and commonly used levels
+// Skill levels derived from hierarchy order
 const GFI      = SKILL_HIERARCHY[0]; // good first issue (or equivalent)
 const BEGINNER = SKILL_HIERARCHY[1];
 const MID      = SKILL_HIERARCHY[2];
@@ -76,121 +139,205 @@ const TOP      = SKILL_HIERARCHY[SKILL_HIERARCHY.length - 1];
 const unitTests = [
 
   // ---------------------------------------------------------------------------
-  // getNextLevel
+  // resolveEligibleLevel
   // ---------------------------------------------------------------------------
   {
-    name: 'getNextLevel: mid-hierarchy level → returns next level up',
-    test: () => {
-      return getNextLevel(BEGINNER) === MID;
-    },
-  },
-  {
-    name: 'getNextLevel: top-level → returns same level (no higher)',
-    test: () => {
-      return getNextLevel(TOP) === TOP;
-    },
-  },
-  {
-    name: 'getNextLevel: invalid level → returns null',
-    test: () => {
-      return getNextLevel('not-a-real-level') === null;
-    },
-  },
-  {
-    name: 'getNextLevel: lowest level → returns second level',
-    test: () => {
-      return getNextLevel(GFI) === BEGINNER;
-    },
-  },
-
-  // ---------------------------------------------------------------------------
-  // getFallbackLevel
-  // ---------------------------------------------------------------------------
-  {
-    name: 'getFallbackLevel: mid-hierarchy level → returns one level down',
-    test: () => {
-      return getFallbackLevel(BEGINNER) === GFI;
-    },
-  },
-  {
-    name: 'getFallbackLevel: lowest level (GFI) → returns null (no lower)',
-    test: () => {
-      return getFallbackLevel(GFI) === null;
-    },
-  },
-  {
-    name: 'getFallbackLevel: invalid level → returns null',
-    test: () => {
-      return getFallbackLevel('not-a-real-level') === null;
-    },
-  },
-  {
-    name: 'getFallbackLevel: top level → returns second-highest',
-    test: () => {
-      const secondTop = SKILL_HIERARCHY[SKILL_HIERARCHY.length - 2];
-      return getFallbackLevel(TOP) === secondTop;
-    },
-  },
-
-  // ---------------------------------------------------------------------------
-  // getRecommendedIssues — priority order
-  // ---------------------------------------------------------------------------
-  {
-    name: 'getRecommendedIssues: next-level issues exist → prefers next',
+    name: 'resolveEligibleLevel: no closed issues → defaults to GFI (floor level)',
     test: async () => {
       const { botContext } = createMockBotContext({
-        sender: { login: 'contributor' },
+        closedCounts: {},
+      });
+      const level = await resolveEligibleLevel(botContext, 'contributor');
+      return level === GFI;
+    },
+  },
+  {
+    name: 'resolveEligibleLevel: meets normal prereq for BEGINNER → returns BEGINNER',
+    test: async () => {
+      const prereq = SKILL_PREREQUISITES[BEGINNER];
+      // Enough closed GFIs to satisfy the normal check for BEGINNER.
+      const { botContext } = createMockBotContext({
+        closedCounts: {
+          [`${prereq.requiredLabel}:contributor`]: prereq.requiredCount,
+        },
+      });
+      const level = await resolveEligibleLevel(botContext, 'contributor');
+      return level === BEGINNER;
+    },
+  },
+  {
+    name: 'resolveEligibleLevel: has 1 closed BEGINNER issue → bypass check passes for BEGINNER',
+    test: async () => {
+      const { botContext } = createMockBotContext({
+        closedCounts: {
+          [`${BEGINNER}:contributor`]: 1,
+        },
+      });
+      const level = await resolveEligibleLevel(botContext, 'contributor');
+      return level === BEGINNER;
+    },
+  },
+  {
+    name: 'resolveEligibleLevel: has 1 closed MID issue → bypass check resolves to MID',
+    test: async () => {
+      const { botContext } = createMockBotContext({
+        closedCounts: {
+          [`${MID}:contributor`]: 1,
+        },
+      });
+      const level = await resolveEligibleLevel(botContext, 'contributor');
+      return level === MID;
+    },
+  },
+  {
+    name: 'resolveEligibleLevel: countIssuesByAssignee API failure → degrades to GFI',
+    test: async () => {
+      const { botContext } = createMockBotContext({
+        closedCounts: null, // signal all API calls fail
+      });
+      const level = await resolveEligibleLevel(botContext, 'contributor');
+      return level === GFI;
+    },
+  },
+  {
+    name: 'resolveEligibleLevel: meets prereq for MID but not TOP → returns MID',
+    test: async () => {
+      const midPrereq = SKILL_PREREQUISITES[MID];
+      const { botContext } = createMockBotContext({
+        closedCounts: {
+          [`${midPrereq.requiredLabel}:contributor`]: midPrereq.requiredCount,
+        },
+      });
+      const level = await resolveEligibleLevel(botContext, 'contributor');
+      return level === MID;
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // detectUnlockedLevel
+  // ---------------------------------------------------------------------------
+  {
+    name: 'detectUnlockedLevel: count exactly equals threshold → returns next level',
+    test: async () => {
+      const prereq = SKILL_PREREQUISITES[BEGINNER];
+      const { botContext } = createMockBotContext({
+        closedCounts: {
+          [`${GFI}:contributor`]: prereq.requiredCount,
+        },
+      });
+      const unlocked = await detectUnlockedLevel(botContext, 'contributor', GFI);
+      return unlocked === BEGINNER;
+    },
+  },
+  {
+    name: 'detectUnlockedLevel: count below threshold → returns null',
+    test: async () => {
+      const prereq = SKILL_PREREQUISITES[BEGINNER];
+      const { botContext } = createMockBotContext({
+        closedCounts: {
+          [`${GFI}:contributor`]: prereq.requiredCount - 1,
+        },
+      });
+      const unlocked = await detectUnlockedLevel(botContext, 'contributor', GFI);
+      return unlocked === null;
+    },
+  },
+  {
+    name: 'detectUnlockedLevel: count above threshold → returns null (already crossed before)',
+    test: async () => {
+      const prereq = SKILL_PREREQUISITES[BEGINNER];
+      const { botContext } = createMockBotContext({
+        closedCounts: {
+          // The mock returns raw counts, so values greater than requiredCount
+          // represent cases where the threshold was already exceeded.
+          [`${GFI}:contributor`]: prereq.requiredCount + 1,
+        },
+      });
+      const unlocked = await detectUnlockedLevel(botContext, 'contributor', GFI);
+      return unlocked === null;
+    },
+  },
+  {
+    name: 'detectUnlockedLevel: currentLevel is TOP → returns null (no higher level)',
+    test: async () => {
+      const { botContext } = createMockBotContext();
+      const unlocked = await detectUnlockedLevel(botContext, 'contributor', TOP);
+      return unlocked === null;
+    },
+  },
+  {
+    name: 'detectUnlockedLevel: API failure → returns null',
+    test: async () => {
+      const { botContext } = createMockBotContext({
+        closedCounts: null,
+      });
+      const unlocked = await detectUnlockedLevel(botContext, 'contributor', GFI);
+      return unlocked === null;
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // getRecommendedIssues — returns { issues, unlockedLevel }
+  // ---------------------------------------------------------------------------
+  {
+    name: 'getRecommendedIssues: eligible for BEGINNER, BEGINNER issues exist → returns them',
+    test: async () => {
+      const prereq = SKILL_PREREQUISITES[BEGINNER];
+      const { botContext } = createMockBotContext({
+        closedCounts: {
+          [`${prereq.requiredLabel}:contributor`]: prereq.requiredCount,
+        },
         searchItems: [
           makeIssue([BEGINNER, LABELS.READY_FOR_DEV], 1),
           makeIssue([MID,      LABELS.READY_FOR_DEV], 2),
         ],
       });
-      const result = await getRecommendedIssues(botContext, 'contributor', BEGINNER);
-      return result !== null && result.every(i => i.number === 2);
+      const result = await getRecommendedIssues(botContext, 'contributor', GFI);
+      return (
+        result !== null &&
+        result.issues.length === 1 &&
+        result.issues[0].number === 1
+      );
     },
   },
   {
-    name: 'getRecommendedIssues: no next-level issues → falls back to same level',
+    name: 'getRecommendedIssues: eligible for GFI → only GFI issues returned',
     test: async () => {
       const { botContext } = createMockBotContext({
+        closedCounts: {},
+        searchItems: [
+          makeIssue([GFI,      LABELS.READY_FOR_DEV], 3),
+          makeIssue([BEGINNER, LABELS.READY_FOR_DEV], 4),
+        ],
+      });
+      const result = await getRecommendedIssues(botContext, 'contributor', GFI);
+      return (
+        result !== null &&
+        result.issues.length === 1 &&
+        result.issues[0].number === 3
+      );
+    },
+  },
+  {
+    name: 'getRecommendedIssues: no issues at eligible level → returns empty array',
+    test: async () => {
+      const { botContext } = createMockBotContext({
+        closedCounts: {},
         searchItems: [
           makeIssue([BEGINNER, LABELS.READY_FOR_DEV], 5),
         ],
       });
-      const result = await getRecommendedIssues(botContext, 'contributor', BEGINNER);
-      return result !== null && result.length === 1 && result[0].number === 5;
+      const result = await getRecommendedIssues(botContext, 'contributor', GFI);
+      return result !== null && result.issues.length === 0;
     },
   },
   {
-    name: 'getRecommendedIssues: no next or same → falls back to lower level',
-    test: async () => {
-      const { botContext } = createMockBotContext({
-        searchItems: [
-          makeIssue([BEGINNER, LABELS.READY_FOR_DEV], 7),
-        ],
-      });
-      const result = await getRecommendedIssues(botContext, 'contributor', MID);
-      return result !== null && result.length === 1 && result[0].number === 7;
-    },
-  },
-  {
-    name: 'getRecommendedIssues: BEGINNER skill level → GFI not included in fallback',
-    test: async () => {
-      const { botContext } = createMockBotContext({
-        searchItems: [
-          makeIssue([GFI, LABELS.READY_FOR_DEV], 3), // only GFI available, should be ignored
-        ],
-      });
-      const result = await getRecommendedIssues(botContext, 'contributor', BEGINNER);
-      return result !== null && result.length === 0;
-    },
-  },
-  {
-    name: 'getRecommendedIssues: API failure → posts error comment, returns null',
+    name: 'getRecommendedIssues: API failure on issue search → posts error comment, returns null',
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         sender: { login: 'user' },
         issue: makeIssue([BEGINNER]),
+        closedCounts: {},
         searchItems: null,
       });
       const result = await getRecommendedIssues(botContext, 'user', BEGINNER);
@@ -213,13 +360,44 @@ const unitTests = [
   {
     name: 'getRecommendedIssues: caps results at 5',
     test: async () => {
+      const prereq = SKILL_PREREQUISITES[BEGINNER];
       const { botContext } = createMockBotContext({
+        closedCounts: {
+          [`${prereq.requiredLabel}:contributor`]: prereq.requiredCount,
+        },
         searchItems: Array.from({ length: 10 }, (_, i) =>
           makeIssue([BEGINNER, LABELS.READY_FOR_DEV], i + 1)
         ),
       });
-      const result = await getRecommendedIssues(botContext, 'contributor', BEGINNER);
-      return result !== null && result.length <= 5;
+      const result = await getRecommendedIssues(botContext, 'contributor', GFI);
+      return result !== null && result.issues.length <= 5;
+    },
+  },
+  {
+    name: 'getRecommendedIssues: threshold crossed → unlockedLevel is set',
+    test: async () => {
+      const prereq = SKILL_PREREQUISITES[BEGINNER];
+      const { botContext } = createMockBotContext({
+        closedCounts: {
+          // Exactly meets normal prereq for BEGINNER (resolveEligibleLevel) AND
+          // exactly equals threshold for detectUnlockedLevel.
+          [`${GFI}:contributor`]: prereq.requiredCount,
+        },
+        searchItems: [makeIssue([BEGINNER, LABELS.READY_FOR_DEV], 1)],
+      });
+      const result = await getRecommendedIssues(botContext, 'contributor', GFI);
+      return result !== null && result.unlockedLevel === BEGINNER;
+    },
+  },
+  {
+    name: 'getRecommendedIssues: threshold not crossed → unlockedLevel is null',
+    test: async () => {
+      const { botContext } = createMockBotContext({
+        closedCounts: {},
+        searchItems: [makeIssue([GFI, LABELS.READY_FOR_DEV], 1)],
+      });
+      const result = await getRecommendedIssues(botContext, 'contributor', GFI);
+      return result !== null && result.unlockedLevel === null;
     },
   },
 
@@ -253,10 +431,11 @@ const unitTests = [
     },
   },
   {
-    name: 'handleRecommendIssues: no matching issues at any level → no comment',
+    name: 'handleRecommendIssues: no matching issues at eligible level → no comment',
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         issue: makeIssue([BEGINNER, LABELS.READY_FOR_DEV]),
+        closedCounts: {},
         searchItems: [],
       });
       await handleRecommendIssues(botContext);
@@ -264,12 +443,13 @@ const unitTests = [
     },
   },
   {
-    name: 'handleRecommendIssues: valid context → posts recommendation comment',
+    name: 'handleRecommendIssues: valid context, no unlock → posts standard recommendation comment',
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         sender: { login: 'user' },
-        issue: makeIssue([BEGINNER, LABELS.READY_FOR_DEV]),
-        searchItems: [makeIssue([MID, LABELS.READY_FOR_DEV], 1)],
+        issue: makeIssue([GFI, LABELS.READY_FOR_DEV]),
+        closedCounts: {},
+        searchItems: [makeIssue([GFI, LABELS.READY_FOR_DEV], 1)],
       });
       await handleRecommendIssues(botContext);
       const expected = [
@@ -281,7 +461,27 @@ const unitTests = [
         '',
         'Happy coding! 🚀',
       ].join('\n');
-      return calls.comments[0] === expected;
+      return calls.comments.length === 1 && calls.comments[0] === expected;
+    },
+  },
+  {
+    name: 'handleRecommendIssues: level unlocked → comment includes congratulatory block',
+    test: async () => {
+      const prereq = SKILL_PREREQUISITES[BEGINNER];
+      const { botContext, calls } = createMockBotContext({
+        sender: { login: 'user' },
+        issue: makeIssue([GFI, LABELS.READY_FOR_DEV]),
+        closedCounts: {
+          [`${GFI}:user`]: prereq.requiredCount,
+        },
+        searchItems: [makeIssue([BEGINNER, LABELS.READY_FOR_DEV], 2)],
+      });
+      await handleRecommendIssues(botContext);
+      return (
+        calls.comments.length === 1 &&
+        calls.comments[0].includes('Milestone unlocked') &&
+        calls.comments[0].includes(SKILL_PREREQUISITES[BEGINNER].displayName)
+      );
     },
   },
 ];


### PR DESCRIPTION
**Summary**:
- Move SKILL_PREREQUISITES from assign-comments.js to helpers/constants.js to establish a single source of truth across bots
- Move countAssignedIssues from assign.js to helpers/api.js, export it, and rename to countIssuesByAssignee to better reflect its generalized usage
- Update helpers/api.js to import ISSUE_STATE from helpers/constants.js to use in countIssuesByAssignee
- Update assign.js to import countIssuesByAssignee from helpers/api.js instead of defining it locally
- Update assign-comments.js to import SKILL_PREREQUISITES from helpers/constants.js 
- Replace getNextLevel / getFallbackLevel logic in getRecommendedIssues with a history-based eligibility walk
- Aligned recommendation logic with assignment bot by applying:
   - Bypass check (≥1 closed issue at target level or higher)
   - Normal check (meets prerequisite thresholds)
- Ensured recommendations always target the highest level the contributor is eligible for
- Added threshold detection to identify when a contribution unlocks a new level
- Included a small congratulatory message when a milestone is reached


**Tests**:
- Updated tests/test-recommend-issues-bot.js to reflect new changes


**Related issue(s)**:
Fixes #1405 

