### PR TITLE
fix: use assignment date as baseline for issue inactivity, not creation date

### DIFF
--- a/.github/scripts/bot-inactivity.js
+++ b/.github/scripts/bot-inactivity.js
@@ -156,6 +156,30 @@ async function getLastAuthorCommitDate(github, owner, repo, prNumber, authorLogi
 }
 
 /**
+ * Returns the timestamp (ms) of the most recent event matching predicate,
+ * or null if no matching event is found.
+ *
+ * @param {object} github
+ * @param {string} owner
+ * @param {string} repo
+ * @param {number} number
+ * @param {function} predicate - Called with each event object; return true to include.
+ * @returns {Promise<number|null>}
+ */
+async function getLastMatchingEventDate(github, owner, repo, number, predicate) {
+  const ctx = buildCtx(github, owner, repo, number);
+  const events = await fetchIssueEvents(ctx);
+
+  let latest = null;
+  for (const e of events) {
+    if (!predicate(e)) continue;
+    const t = new Date(e.created_at).getTime();
+    latest = latestOf(latest === null ? -Infinity : latest, t);
+  }
+  return latest === null || latest === -Infinity ? null : latest;
+}
+
+/**
  * Returns the timestamp (ms) of the most recent time "status: blocked" was
  * removed from the item, or null if it has never been unblocked.
  *
@@ -166,16 +190,23 @@ async function getLastAuthorCommitDate(github, owner, repo, prNumber, authorLogi
  * @returns {Promise<number|null>}
  */
 async function getLastUnblockedDate(github, owner, repo, number) {
-  const ctx = buildCtx(github, owner, repo, number);
-  const events = await fetchIssueEvents(ctx);
+  return getLastMatchingEventDate(github, owner, repo, number,
+    e => e.event === 'unlabeled' && e.label?.name === LABELS.BLOCKED);
+}
 
-  let latest = null;
-  for (const e of events) {
-    if (e.event !== 'unlabeled' || e.label?.name !== LABELS.BLOCKED) continue;
-    const t = new Date(e.created_at).getTime();
-    latest = latestOf(latest === null ? -Infinity : latest, t);
-  }
-  return latest === null || latest === -Infinity ? null : latest;
+/**
+ * Returns the timestamp (ms) of the most recent time the item was assigned,
+ * or null if no assigned event is found.
+ *
+ * @param {object} github
+ * @param {string} owner
+ * @param {string} repo
+ * @param {number} number
+ * @returns {Promise<number|null>}
+ */
+async function getLastAssignedDate(github, owner, repo, number) {
+  return getLastMatchingEventDate(github, owner, repo, number,
+    e => e.event === 'assigned');
 }
 
 // ─── Activity computation ────────────────────────────────────────────────────
@@ -223,7 +254,10 @@ async function computePRLastActivity(github, owner, repo, pr) {
  * @returns {Promise<number>}
  */
 async function computeIssueLastActivity(github, owner, repo, issue, linkedOpenPRs) {
-  let latest = new Date(issue.created_at).getTime();
+  const assignedAt = await getLastAssignedDate(github, owner, repo, issue.number);
+  if (assignedAt === null) return null;
+
+  let latest = assignedAt;
   const assigneeLogins = new Set((issue.assignees || []).map(a => a.login.toLowerCase()));
 
   if (assigneeLogins.size > 0) {
@@ -582,6 +616,10 @@ module.exports = async function ({ github, context, getNow = () => Date.now() })
 
     const linkedPRs = issueToOpenPRs.get(issue.number) || [];
     const lastActivity = await computeIssueLastActivity(github, owner, repo, issue, linkedPRs);
+    if (lastActivity === null) {
+      logger.log(`#${issue.number}: skipping (no assigned event found)`);
+      continue;
+    }
     await handleStaleItem(github, owner, repo, issue, lastActivity, 'issue', logger, nowMs);
   }
 

--- a/.github/scripts/tests/test-inactivity-bot.js
+++ b/.github/scripts/tests/test-inactivity-bot.js
@@ -185,6 +185,10 @@ function makeUnlabeledEvent(labelName, createdAt) {
   return { event: 'unlabeled', created_at: createdAt, label: { name: labelName } };
 }
 
+function makeAssignedEvent(createdAt) {
+  return { event: 'assigned', created_at: createdAt };
+}
+
 function makeComment(userLogin, createdAt, { isBot = false } = {}) {
   return {
     id: Math.floor(Math.random() * 100000),
@@ -236,6 +240,9 @@ const scenarios = [
       assignedIssues: [
         makeIssue(10, { createdAt: daysAgo(3), assignees: ['alice'], labels: [LABELS.IN_PROGRESS] }),
       ],
+      eventsByNumber: {
+        10: [makeAssignedEvent(daysAgo(3))],
+      },
     }),
     expect: {
       itemsClosed: [],
@@ -253,6 +260,9 @@ const scenarios = [
       assignedIssues: [
         makeIssue(20, { createdAt: daysAgo(6), assignees: ['alice'], labels: [LABELS.IN_PROGRESS] }),
       ],
+      eventsByNumber: {
+        20: [makeAssignedEvent(daysAgo(6))],
+      },
     }),
     expect: {
       itemsClosed: [],
@@ -271,6 +281,9 @@ const scenarios = [
       assignedIssues: [
         makeIssue(30, { createdAt: daysAgo(8), assignees: ['alice'], labels: [LABELS.IN_PROGRESS] }),
       ],
+      eventsByNumber: {
+        30: [makeAssignedEvent(daysAgo(8))],
+      },
     }),
     expect: {
       itemsClosed: [],
@@ -292,6 +305,9 @@ const scenarios = [
       commentsByNumber: {
         40: [makeComment('bob', daysAgo(2))],
       },
+      eventsByNumber: {
+        40: [makeAssignedEvent(daysAgo(8))],
+      },
     }),
     expect: {
       itemsClosed: [],
@@ -311,6 +327,9 @@ const scenarios = [
       ],
       commentsByNumber: {
         50: [makeComment('maintainer', daysAgo(1))],
+      },
+      eventsByNumber: {
+        50: [makeAssignedEvent(daysAgo(8))],
       },
     }),
     expect: {
@@ -359,6 +378,9 @@ const scenarios = [
       ],
       commitsByPRNumber: {
         71: [makeCommit('carol', daysAgo(1))],
+      },
+      eventsByNumber: {
+        70: [makeAssignedEvent(daysAgo(8))],
       },
     }),
     expect: {
@@ -506,7 +528,7 @@ const scenarios = [
         makeIssue(140, { createdAt: daysAgo(8), assignees: ['judy'], labels: [LABELS.IN_PROGRESS] }),
       ],
       eventsByNumber: {
-        140: [makeUnlabeledEvent(LABELS.BLOCKED, daysAgo(3))],
+        140: [makeAssignedEvent(daysAgo(8)), makeUnlabeledEvent(LABELS.BLOCKED, daysAgo(3))],
       },
     }),
     expect: {
@@ -526,7 +548,7 @@ const scenarios = [
         makeIssue(150, { createdAt: daysAgo(10), assignees: ['kate'], labels: [LABELS.IN_PROGRESS] }),
       ],
       eventsByNumber: {
-        150: [makeUnlabeledEvent(LABELS.BLOCKED, daysAgo(8))],
+        150: [makeAssignedEvent(daysAgo(10)), makeUnlabeledEvent(LABELS.BLOCKED, daysAgo(8))],
       },
     }),
     expect: {
@@ -632,6 +654,46 @@ const scenarios = [
     expect: {
       itemsClosed: [],
       checkinPostedOn: [190],
+      assigneesRemoved: 0,
+    },
+  },
+
+  // ── 21 ─────────────────────────────────────────────────────────────────────
+  {
+    name: 'Issue: created 30 days ago but assigned 2 days ago — no action',
+    description: 'The inactivity clock starts from the assignment date, not creation date.',
+    github: createMockGithub({
+      assignedIssues: [
+        makeIssue(200, { createdAt: daysAgo(30), assignees: ['pat'], labels: [LABELS.IN_PROGRESS] }),
+      ],
+      eventsByNumber: {
+        200: [makeAssignedEvent(daysAgo(2))],
+      },
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreated: 0,
+      labelsAdded: 0,
+      assigneesRemoved: 0,
+    },
+  },
+
+  // ── 22 ─────────────────────────────────────────────────────────────────────
+  {
+    name: 'Issue: no assigned event — skipped without error',
+    description: 'If the events API returns no assigned event, the issue is skipped entirely.',
+    github: createMockGithub({
+      assignedIssues: [
+        makeIssue(210, { createdAt: daysAgo(10), assignees: ['quinn'], labels: [LABELS.IN_PROGRESS] }),
+      ],
+      eventsByNumber: {
+        210: [],
+      },
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreated: 0,
+      labelsAdded: 0,
       assigneesRemoved: 0,
     },
   },


### PR DESCRIPTION
## Summary

The inactivity bot was using `issue.created_at` as the baseline when computing how long an assigned issue had been inactive. This caused long-open issues to be warned or closed almost immediately after assignment, since the 5-day clock had already elapsed. This PR fixes the baseline to be the most recent `assigned` event timestamp. If no `assigned` event is found, the issue is silently skipped.

As part of this fix, `getLastUnblockedDate` and the new `getLastAssignedDate` shared identical event-fetching logic, so a private `getLastMatchingEventDate` helper was extracted to eliminate the duplication.

Closes #1453.

## Changes

### 1. Extract `getLastMatchingEventDate` private helper

Both `getLastUnblockedDate` and the new `getLastAssignedDate` follow the same pattern: fetch issue events, filter by a predicate, return the most recent matching timestamp. The shared logic was extracted into a single helper to avoid duplication.

**File changed:** `.github/scripts/bot-inactivity.js`

### 2. Refactor `getLastUnblockedDate` onto the shared helper

The existing function was rewritten as a one-liner delegating to `getLastMatchingEventDate` with a predicate that matches `unlabeled` events for the `status: blocked` label. Behavior is unchanged.

**File changed:** `.github/scripts/bot-inactivity.js`

### 3. Add `getLastAssignedDate`

New helper that returns the timestamp of the most recent `assigned` event, or `null` if none is found. Implemented as a one-liner via `getLastMatchingEventDate`.

```js
async function getLastAssignedDate(github, owner, repo, number) {
  return getLastMatchingEventDate(github, owner, repo, number,
    e => e.event === 'assigned');
}
```

**File changed:** `.github/scripts/bot-inactivity.js`

### 4. Fix `computeIssueLastActivity` baseline

- Calls `getLastAssignedDate` first; returns `null` if no `assigned` event is found.
- Uses the assignment timestamp as the inactivity baseline instead of `issue.created_at`.

| Before | After |
|--------|-------|
| `let latest = new Date(issue.created_at).getTime()` | Fetch most recent `assigned` event; return `null` if absent |

**File changed:** `.github/scripts/bot-inactivity.js`

### 5. Skip issues with no `assigned` event in the main loop

The main issue-processing loop now checks the return value of `computeIssueLastActivity`. If `null`, the issue is logged and skipped — no inactivity action is taken.

**File changed:** `.github/scripts/bot-inactivity.js`

### 6. Update existing test scenarios to include `assigned` events

All existing issue scenarios in the test suite lacked `assigned` events in their mock data. Under the new logic these issues were silently skipped (coincidentally correct for "no action" tests, but incorrect for scenarios expecting a warning or reset). Each issue scenario now includes a `makeAssignedEvent` entry with a date matching the scenario's original intent.

**File changed:** `.github/scripts/tests/test-inactivity-bot.js`

### 7. Add `makeAssignedEvent` test helper

```js
function makeAssignedEvent(createdAt) {
  return { event: 'assigned', created_at: createdAt };
}
```

**File changed:** `.github/scripts/tests/test-inactivity-bot.js`

### 8. Add two new test scenarios

| # | Name | Verifies |
|---|------|----------|
| 21 | Issue created 30 days ago but assigned 2 days ago — no action | Assignment date is used as baseline, not creation date |
| 22 | Issue with no `assigned` event — skipped without error | Missing assignment event causes silent skip |

**File changed:** `.github/scripts/tests/test-inactivity-bot.js`

## Testing

```bash
node .github/scripts/tests/test-inactivity-bot.js
# Integration Tests: 22 total, 22 passed ✅
```

**Test plan:**
- [x] All 20 existing scenarios continue to pass
- [x] Scenario 21: issue created 30 days ago, assigned 2 days ago → no warning (assignment date used)
- [x] Scenario 22: issue with no `assigned` event → silently skipped, no crash

## Files Changed Summary

| File | Change |
|------|--------|
| `.github/scripts/bot-inactivity.js` | Add `getLastMatchingEventDate`, refactor `getLastUnblockedDate`, add `getLastAssignedDate`, fix `computeIssueLastActivity`, update main loop |
| `.github/scripts/tests/test-inactivity-bot.js` | Add `makeAssignedEvent` helper, add `assigned` events to 8 existing scenarios, add 2 new scenarios |

## Breaking Changes

**None.** No public APIs are changed. The fix only affects the inactivity bot's internal activity computation for issues.
