### PR TITLE
fix: exempt PRs with "status: needs review" from inactivity tracking

### DIFF
--- a/.github/scripts/bot-inactivity.js
+++ b/.github/scripts/bot-inactivity.js
@@ -604,9 +604,8 @@ module.exports = async function ({ github, context, getNow = () => Date.now() })
     let lastActivity;
     if (hasLabel(pr, LABELS.NEEDS_REVISION)) {
       const revisionLabeledAt = await getLastNeedsRevisionLabeledDate(github, owner, repo, pr.number);
-      lastActivity = revisionLabeledAt !== null
-        ? revisionLabeledAt
-        : await computePRLastActivity(github, owner, repo, pr);
+      const prActivity = await computePRLastActivity(github, owner, repo, pr);
+      lastActivity = latestOf(prActivity, revisionLabeledAt);
     } else {
       lastActivity = await computePRLastActivity(github, owner, repo, pr);
     }

--- a/.github/scripts/bot-inactivity.js
+++ b/.github/scripts/bot-inactivity.js
@@ -13,6 +13,10 @@
 //   - A commit pushed to a PR branch by the PR author
 //   - Removal of the "status: blocked" label (unblocking counts as activity)
 //
+// PR review state:
+//   - "status: needs review"   → skipped entirely (waiting on maintainers)
+//   - "status: needs revision" → clock starts from when label was last applied
+//
 // Blocked items ("status: blocked" label):
 //   - Exempt from the inactivity close/warn flow
 //   - Receive a friendly check-in comment every 30 days instead
@@ -192,6 +196,21 @@ async function getLastMatchingEventDate(github, owner, repo, number, predicate) 
 async function getLastUnblockedDate(github, owner, repo, number) {
   return getLastMatchingEventDate(github, owner, repo, number,
     e => e.event === 'unlabeled' && e.label?.name === LABELS.BLOCKED);
+}
+
+/**
+ * Returns the timestamp (ms) of the most recent time "status: needs revision"
+ * was applied to the item, or null if it has never been applied.
+ *
+ * @param {object} github
+ * @param {string} owner
+ * @param {string} repo
+ * @param {number} number
+ * @returns {Promise<number|null>}
+ */
+async function getLastNeedsRevisionLabeledDate(github, owner, repo, number) {
+  return getLastMatchingEventDate(github, owner, repo, number,
+    e => e.event === 'labeled' && e.label?.name === LABELS.NEEDS_REVISION);
 }
 
 /**
@@ -577,7 +596,21 @@ module.exports = async function ({ github, context, getNow = () => Date.now() })
       continue;
     }
 
-    const lastActivity = await computePRLastActivity(github, owner, repo, pr);
+    if (hasLabel(pr, LABELS.NEEDS_REVIEW)) {
+      logger.log(`#${pr.number} (PR): skipping (status: needs review)`);
+      continue;
+    }
+
+    let lastActivity;
+    if (hasLabel(pr, LABELS.NEEDS_REVISION)) {
+      const revisionLabeledAt = await getLastNeedsRevisionLabeledDate(github, owner, repo, pr.number);
+      lastActivity = revisionLabeledAt !== null
+        ? revisionLabeledAt
+        : await computePRLastActivity(github, owner, repo, pr);
+    } else {
+      lastActivity = await computePRLastActivity(github, owner, repo, pr);
+    }
+
     const result = await handleStaleItem(github, owner, repo, pr, lastActivity, 'PR', logger, nowMs);
 
     if (result === 'closed') {

--- a/.github/scripts/tests/test-inactivity-bot.js
+++ b/.github/scripts/tests/test-inactivity-bot.js
@@ -801,6 +801,34 @@ const scenarios = [
 
   // ── 27 ─────────────────────────────────────────────────────────────────────
   {
+    name: 'PR: status: needs revision labeled 8 days ago, author commented 2 days ago — no action',
+    description: 'Author activity after the label is applied resets the clock; the bot should not close an actively-engaged PR.',
+    github: createMockGithub({
+      openPRs: [
+        makePR(261, {
+          createdAt: daysAgo(10),
+          assignees: ['wren'],
+          authorLogin: 'wren',
+          labels: [LABELS.NEEDS_REVISION],
+        }),
+      ],
+      commentsByNumber: {
+        261: [makeComment('wren', daysAgo(2))],
+      },
+      eventsByNumber: {
+        261: [makeLabeledEvent(LABELS.NEEDS_REVISION, daysAgo(8))],
+      },
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreated: 0,
+      labelsAdded: 0,
+      assigneesRemoved: 0,
+    },
+  },
+
+  // ── 28 ─────────────────────────────────────────────────────────────────────
+  {
     name: 'PR: status: needs revision applied twice — clock uses most recent application',
     description: 'Back-and-forth review cycles must not penalize contributors; the clock resets on each new needs-revision application.',
     github: createMockGithub({

--- a/.github/scripts/tests/test-inactivity-bot.js
+++ b/.github/scripts/tests/test-inactivity-bot.js
@@ -185,6 +185,10 @@ function makeUnlabeledEvent(labelName, createdAt) {
   return { event: 'unlabeled', created_at: createdAt, label: { name: labelName } };
 }
 
+function makeLabeledEvent(labelName, createdAt) {
+  return { event: 'labeled', created_at: createdAt, label: { name: labelName } };
+}
+
 function makeAssignedEvent(createdAt) {
   return { event: 'assigned', created_at: createdAt };
 }
@@ -688,6 +692,134 @@ const scenarios = [
       ],
       eventsByNumber: {
         210: [],
+      },
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreated: 0,
+      labelsAdded: 0,
+      assigneesRemoved: 0,
+    },
+  },
+
+  // ── 23 ─────────────────────────────────────────────────────────────────────
+  {
+    name: 'PR: status: needs review — skipped entirely',
+    description: 'PRs waiting on maintainer review are exempt from inactivity tracking.',
+    github: createMockGithub({
+      openPRs: [
+        makePR(220, {
+          createdAt: daysAgo(8),
+          assignees: ['rose'],
+          authorLogin: 'rose',
+          labels: [LABELS.NEEDS_REVIEW],
+        }),
+      ],
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreated: 0,
+      labelsAdded: 0,
+      assigneesRemoved: 0,
+    },
+  },
+
+  // ── 24 ─────────────────────────────────────────────────────────────────────
+  {
+    name: 'PR: status: needs revision labeled 2 days ago — no action',
+    description: 'Inactivity clock starts from when needs-revision was last applied; 2 days is under threshold.',
+    github: createMockGithub({
+      openPRs: [
+        makePR(230, {
+          createdAt: daysAgo(10),
+          assignees: ['sam'],
+          authorLogin: 'sam',
+          labels: [LABELS.NEEDS_REVISION],
+        }),
+      ],
+      eventsByNumber: {
+        230: [makeLabeledEvent(LABELS.NEEDS_REVISION, daysAgo(2))],
+      },
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreated: 0,
+      labelsAdded: 0,
+      assigneesRemoved: 0,
+    },
+  },
+
+  // ── 25 ─────────────────────────────────────────────────────────────────────
+  {
+    name: 'PR: status: needs revision labeled 6 days ago — warning posted',
+    description: 'Six days since needs-revision was applied triggers the 5-day warning.',
+    github: createMockGithub({
+      openPRs: [
+        makePR(240, {
+          createdAt: daysAgo(10),
+          assignees: ['taylor'],
+          authorLogin: 'taylor',
+          labels: [LABELS.NEEDS_REVISION],
+        }),
+      ],
+      eventsByNumber: {
+        240: [makeLabeledEvent(LABELS.NEEDS_REVISION, daysAgo(6))],
+      },
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreatedCount: 1,
+      warningPostedOn: [240],
+      labelsAdded: 0,
+      assigneesRemoved: 0,
+    },
+  },
+
+  // ── 26 ─────────────────────────────────────────────────────────────────────
+  {
+    name: 'PR: status: needs revision labeled 8 days ago — closed and reset',
+    description: 'Eight days since needs-revision was applied exceeds the 7-day close threshold.',
+    github: createMockGithub({
+      openPRs: [
+        makePR(250, {
+          createdAt: daysAgo(10),
+          assignees: ['uri'],
+          authorLogin: 'uri',
+          labels: [LABELS.NEEDS_REVISION],
+        }),
+      ],
+      eventsByNumber: {
+        250: [makeLabeledEvent(LABELS.NEEDS_REVISION, daysAgo(8))],
+      },
+    }),
+    expect: {
+      itemsClosed: [250],
+      closureCommentOn: [250],
+      assigneesRemoved: [{ issue_number: 250, assignees: ['uri'] }],
+    },
+  },
+
+  // ── 27 ─────────────────────────────────────────────────────────────────────
+  {
+    name: 'PR: status: needs revision applied twice — clock uses most recent application',
+    description: 'Back-and-forth review cycles must not penalize contributors; the clock resets on each new needs-revision application.',
+    github: createMockGithub({
+      openPRs: [
+        makePR(260, {
+          createdAt: daysAgo(12),
+          assignees: ['vera'],
+          authorLogin: 'vera',
+          labels: [LABELS.NEEDS_REVISION],
+        }),
+      ],
+      eventsByNumber: {
+        260: [
+          makeLabeledEvent(LABELS.NEEDS_REVISION, daysAgo(10)),
+          makeUnlabeledEvent(LABELS.NEEDS_REVISION, daysAgo(8)),
+          makeLabeledEvent(LABELS.NEEDS_REVIEW, daysAgo(8)),
+          makeUnlabeledEvent(LABELS.NEEDS_REVIEW, daysAgo(2)),
+          makeLabeledEvent(LABELS.NEEDS_REVISION, daysAgo(2)),
+        ],
       },
     }),
     expect: {


### PR DESCRIPTION
## Summary

This PR refines the inactivity bot's PR handling to respect the review lifecycle. PRs labeled `status: needs review` are now skipped entirely — the inactivity clock should not tick while a contributor is waiting on a maintainer. For PRs labeled `status: needs revision`, the inactivity clock now starts from whichever is later: when the label was applied, or the most recent PR activity (e.g., an author comment).

**Key Changes:**
- Skip inactivity processing entirely for PRs with `status: needs review`
- Use `status: needs revision` label application time as the inactivity baseline for those PRs
- Take the later of the label timestamp vs. PR activity to avoid penalizing actively engaged contributors
- Add 6 new test scenarios covering the new behaviors

## Changes

### PR Review State Handling ([.github/scripts/bot-inactivity.js](.github/scripts/bot-inactivity.js))

**`status: needs review` — exempt from inactivity tracking**

PRs waiting on a maintainer review are now skipped before any activity computation. The inactivity clock should not run against the contributor when the ball is in the maintainers' court.

**`status: needs revision` — clock anchored to label application**

When a PR has `status: needs revision`, the bot now fetches the timestamp of the most recent time that label was applied and uses `latestOf(prActivity, revisionLabeledAt)` as the baseline. This means:
- If the contributor has commented/pushed more recently than the label was applied, their activity resets the clock.
- Back-and-forth review cycles reset the clock each time the label is re-applied, so contributors aren't penalized for a label that was applied and removed multiple times.

New helper function added:
- `getLastNeedsRevisionLabeledDate(github, owner, repo, number)` — returns the timestamp of the most recent `labeled` event for `status: needs revision`, or `null` if never applied.

**Files Changed:**
- `.github/scripts/bot-inactivity.js`

### Tests ([.github/scripts/tests/test-inactivity-bot.js](.github/scripts/tests/test-inactivity-bot.js))

Six new scenarios added:

| # | Name | Validates |
|---|------|-----------|
| 23 | PR: `status: needs review` — skipped entirely | Exempt from inactivity tracking when waiting on maintainers |
| 24 | PR: `status: needs revision` labeled 2 days ago — no action | Under warning threshold |
| 25 | PR: `status: needs revision` labeled 6 days ago — warning posted | Exceeds 5-day warning threshold |
| 26 | PR: `status: needs revision` labeled 8 days ago — closed and reset | Exceeds 7-day close threshold |
| 27 | PR: `status: needs revision` labeled 8 days ago, author commented 2 days ago — no action | Author activity after label resets the clock |
| 28 | PR: `status: needs revision` applied twice — clock uses most recent application | Re-labeling resets the clock |

Also added `makeLabeledEvent(labelName, createdAt)` helper to complement the existing `makeUnlabeledEvent`.

**Files Changed:**
- `.github/scripts/tests/test-inactivity-bot.js`

## Testing

```bash
node .github/scripts/tests/test-inactivity-bot.js
```

**Test Plan:**
- [x] All existing scenarios continue to pass
- [x] Scenario 23: `status: needs review` PR is skipped with no comments, labels, or closures
- [x] Scenario 24: `status: needs revision` applied 2 days ago — no action taken
- [x] Scenario 25: `status: needs revision` applied 6 days ago — warning comment posted
- [x] Scenario 26: `status: needs revision` applied 8 days ago — PR closed and assignee removed
- [x] Scenario 27: Label applied 8 days ago but author commented 2 days ago — no action (activity resets clock)
- [x] Scenario 28: Label applied twice; clock anchors to most recent application — no action

## Files Changed Summary

| Category | Files |
|----------|-------|
| Bot logic | `.github/scripts/bot-inactivity.js` |
| Tests | `.github/scripts/tests/test-inactivity-bot.js` |

## Breaking Changes

**None.** This change only affects which PRs the inactivity bot acts on, and in what direction (fewer false positives). No public APIs, workflows, or configurations are changed.
