### PR TITLE
Fix inactivity warnings to repost after activity resets the clock

### DIFF
--- a/.github/scripts/bot-inactivity.js
+++ b/.github/scripts/bot-inactivity.js
@@ -21,8 +21,8 @@
 //   - Issues linked to open PRs with recent activity are not flagged.
 //   - When a PR is closed for inactivity, its linked issues are also reset.
 
-const { createLogger } = require('./helpers/logger');
-const { LABELS } = require('./helpers/constants');
+const { createLogger } = require("./helpers/logger");
+const { LABELS } = require("./helpers/constants");
 const {
   hasLabel,
   removeLabel,
@@ -34,17 +34,17 @@ const {
   fetchIssueEvents,
   fetchPRCommits,
   closeItem,
-} = require('./helpers/api');
-const { parseIssueNumbers } = require('./helpers/checks');
+} = require("./helpers/api");
+const { parseIssueNumbers } = require("./helpers/checks");
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
-const WARN_AFTER_MS           = 5 * 24 * 60 * 60 * 1000;  // 5 days
-const CLOSE_AFTER_MS          = 7 * 24 * 60 * 60 * 1000;  // 7 days
+const WARN_AFTER_MS = 5 * 24 * 60 * 60 * 1000; // 5 days
+const CLOSE_AFTER_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const BLOCKED_CHECKIN_AFTER_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
-const WARN_MARKER           = '<!-- bot:inactivity-warning -->';
-const BLOCKED_CHECKIN_MARKER = '<!-- bot:blocked-checkin -->';
+const WARN_MARKER = "<!-- bot:inactivity-warning -->";
+const BLOCKED_CHECKIN_MARKER = "<!-- bot:blocked-checkin -->";
 
 // ─── Context builder ─────────────────────────────────────────────────────────
 
@@ -81,7 +81,7 @@ function latestOf(current, candidate) {
  * @returns {Set<string>}
  */
 function collectParticipants(item) {
-  const logins = (item.assignees || []).map(a => a.login.toLowerCase());
+  const logins = (item.assignees || []).map((a) => a.login.toLowerCase());
   if (item.user?.login) logins.push(item.user.login.toLowerCase());
   return new Set(logins);
 }
@@ -116,13 +116,19 @@ function extractCommitDate(commit) {
  * @param {Set<string>} relevantLogins - Lowercased usernames to consider.
  * @returns {Promise<number|null>}
  */
-async function getLastRelevantCommentDate(github, owner, repo, number, relevantLogins) {
+async function getLastRelevantCommentDate(
+  github,
+  owner,
+  repo,
+  number,
+  relevantLogins,
+) {
   const ctx = buildCtx(github, owner, repo, number);
   const comments = await fetchComments(ctx);
 
   let latest = null;
   for (const c of comments) {
-    if (!c.user || c.user.type === 'Bot') continue;
+    if (!c.user || c.user.type === "Bot") continue;
     if (!relevantLogins.has(c.user.login.toLowerCase())) continue;
     const t = new Date(c.created_at).getTime();
     latest = latestOf(latest === null ? -Infinity : latest, t);
@@ -141,7 +147,13 @@ async function getLastRelevantCommentDate(github, owner, repo, number, relevantL
  * @param {string} authorLogin
  * @returns {Promise<number|null>}
  */
-async function getLastAuthorCommitDate(github, owner, repo, prNumber, authorLogin) {
+async function getLastAuthorCommitDate(
+  github,
+  owner,
+  repo,
+  prNumber,
+  authorLogin,
+) {
   const ctx = buildCtx(github, owner, repo, prNumber);
   const commits = await fetchPRCommits(ctx);
   const login = authorLogin.toLowerCase();
@@ -150,7 +162,10 @@ async function getLastAuthorCommitDate(github, owner, repo, prNumber, authorLogi
   for (const c of commits) {
     if (!isAuthorLogin(c, login)) continue;
     const dateStr = extractCommitDate(c);
-    latest = latestOf(latest === null ? -Infinity : latest, dateStr ? new Date(dateStr).getTime() : -Infinity);
+    latest = latestOf(
+      latest === null ? -Infinity : latest,
+      dateStr ? new Date(dateStr).getTime() : -Infinity,
+    );
   }
   return latest === null || latest === -Infinity ? null : latest;
 }
@@ -166,7 +181,13 @@ async function getLastAuthorCommitDate(github, owner, repo, prNumber, authorLogi
  * @param {function} predicate - Called with each event object; return true to include.
  * @returns {Promise<number|null>}
  */
-async function getLastMatchingEventDate(github, owner, repo, number, predicate) {
+async function getLastMatchingEventDate(
+  github,
+  owner,
+  repo,
+  number,
+  predicate,
+) {
   const ctx = buildCtx(github, owner, repo, number);
   const events = await fetchIssueEvents(ctx);
 
@@ -190,8 +211,13 @@ async function getLastMatchingEventDate(github, owner, repo, number, predicate) 
  * @returns {Promise<number|null>}
  */
 async function getLastUnblockedDate(github, owner, repo, number) {
-  return getLastMatchingEventDate(github, owner, repo, number,
-    e => e.event === 'unlabeled' && e.label?.name === LABELS.BLOCKED);
+  return getLastMatchingEventDate(
+    github,
+    owner,
+    repo,
+    number,
+    (e) => e.event === "unlabeled" && e.label?.name === LABELS.BLOCKED,
+  );
 }
 
 /**
@@ -205,8 +231,13 @@ async function getLastUnblockedDate(github, owner, repo, number) {
  * @returns {Promise<number|null>}
  */
 async function getLastAssignedDate(github, owner, repo, number) {
-  return getLastMatchingEventDate(github, owner, repo, number,
-    e => e.event === 'assigned');
+  return getLastMatchingEventDate(
+    github,
+    owner,
+    repo,
+    number,
+    (e) => e.event === "assigned",
+  );
 }
 
 // ─── Activity computation ────────────────────────────────────────────────────
@@ -229,16 +260,31 @@ async function computePRLastActivity(github, owner, repo, pr) {
   const participants = collectParticipants(pr);
 
   if (participants.size > 0) {
-    const d = await getLastRelevantCommentDate(github, owner, repo, pr.number, participants);
+    const d = await getLastRelevantCommentDate(
+      github,
+      owner,
+      repo,
+      pr.number,
+      participants,
+    );
     latest = latestOf(latest, d);
   }
 
   if (pr.user?.login) {
-    const d = await getLastAuthorCommitDate(github, owner, repo, pr.number, pr.user.login);
+    const d = await getLastAuthorCommitDate(
+      github,
+      owner,
+      repo,
+      pr.number,
+      pr.user.login,
+    );
     latest = latestOf(latest, d);
   }
 
-  return latestOf(latest, await getLastUnblockedDate(github, owner, repo, pr.number));
+  return latestOf(
+    latest,
+    await getLastUnblockedDate(github, owner, repo, pr.number),
+  );
 }
 
 /**
@@ -253,22 +299,47 @@ async function computePRLastActivity(github, owner, repo, pr) {
  * @param {object[]} linkedOpenPRs - Open PR objects whose bodies reference this issue.
  * @returns {Promise<number>}
  */
-async function computeIssueLastActivity(github, owner, repo, issue, linkedOpenPRs) {
-  const assignedAt = await getLastAssignedDate(github, owner, repo, issue.number);
+async function computeIssueLastActivity(
+  github,
+  owner,
+  repo,
+  issue,
+  linkedOpenPRs,
+) {
+  const assignedAt = await getLastAssignedDate(
+    github,
+    owner,
+    repo,
+    issue.number,
+  );
   if (assignedAt === null) return null;
 
   let latest = assignedAt;
-  const assigneeLogins = new Set((issue.assignees || []).map(a => a.login.toLowerCase()));
+  const assigneeLogins = new Set(
+    (issue.assignees || []).map((a) => a.login.toLowerCase()),
+  );
 
   if (assigneeLogins.size > 0) {
-    const d = await getLastRelevantCommentDate(github, owner, repo, issue.number, assigneeLogins);
+    const d = await getLastRelevantCommentDate(
+      github,
+      owner,
+      repo,
+      issue.number,
+      assigneeLogins,
+    );
     latest = latestOf(latest, d);
   }
 
-  latest = latestOf(latest, await getLastUnblockedDate(github, owner, repo, issue.number));
+  latest = latestOf(
+    latest,
+    await getLastUnblockedDate(github, owner, repo, issue.number),
+  );
 
   for (const pr of linkedOpenPRs) {
-    latest = latestOf(latest, await computePRLastActivity(github, owner, repo, pr));
+    latest = latestOf(
+      latest,
+      await computePRLastActivity(github, owner, repo, pr),
+    );
   }
 
   return latest;
@@ -283,18 +354,19 @@ async function computeIssueLastActivity(github, owner, repo, issue, linkedOpenPR
  * @returns {string}
  */
 function buildWarningComment(assigneeLogins, itemType) {
-  const mentions = assigneeLogins.length > 0
-    ? assigneeLogins.map(l => `@${l}`).join(', ')
-    : 'there';
+  const mentions =
+    assigneeLogins.length > 0
+      ? assigneeLogins.map((l) => `@${l}`).join(", ")
+      : "there";
 
   return [
     WARN_MARKER,
     `👋 Hey ${mentions}! This ${itemType} has been inactive for 5 days.`,
-    '',
-    'Are you still working on this? We will close this in 2 days if we see no further activity.',
-    '',
+    "",
+    "Are you still working on this? We will close this in 2 days if we see no further activity.",
+    "",
     "If you're still on it, leave a comment to let us know! If you'd like to step down, comment `/unassign`.",
-  ].join('\n');
+  ].join("\n");
 }
 
 /**
@@ -303,20 +375,20 @@ function buildWarningComment(assigneeLogins, itemType) {
  * @returns {string}
  */
 function buildClosureComment(itemType) {
-  if (itemType === 'issue') {
+  if (itemType === "issue") {
     return [
-      '⏱️ This issue has been unassigned and reset to `status: ready for dev` due to 7 days of inactivity.',
-      '',
+      "⏱️ This issue has been unassigned and reset to `status: ready for dev` due to 7 days of inactivity.",
+      "",
       "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
-    ].join('\n');
+    ].join("\n");
   }
   return [
-    '⏱️ This PR has been closed due to 7 days of inactivity.',
-    '',
-    'It has been unassigned and reset to `status: ready for dev` so another contributor can pick it up.',
-    '',
+    "⏱️ This PR has been closed due to 7 days of inactivity.",
+    "",
+    "It has been unassigned and reset to `status: ready for dev` so another contributor can pick it up.",
+    "",
     "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
-  ].join('\n');
+  ].join("\n");
 }
 
 /**
@@ -325,12 +397,12 @@ function buildClosureComment(itemType) {
  */
 function buildLinkedPRClosedComment() {
   return [
-    '🔗 The pull request linked to this issue was closed due to inactivity.',
-    '',
-    'This issue has been unassigned and reset to `status: ready for dev`.',
-    '',
+    "🔗 The pull request linked to this issue was closed due to inactivity.",
+    "",
+    "This issue has been unassigned and reset to `status: ready for dev`.",
+    "",
     "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
-  ].join('\n');
+  ].join("\n");
 }
 
 /**
@@ -340,20 +412,21 @@ function buildLinkedPRClosedComment() {
  * @returns {string}
  */
 function buildBlockedCheckinComment(assigneeLogins, itemType) {
-  const mentions = assigneeLogins.length > 0
-    ? assigneeLogins.map(l => `@${l}`).join(', ')
-    : 'there';
+  const mentions =
+    assigneeLogins.length > 0
+      ? assigneeLogins.map((l) => `@${l}`).join(", ")
+      : "there";
 
   return [
     BLOCKED_CHECKIN_MARKER,
     `👋 Hey ${mentions}, just checking in! Is this ${itemType} still blocked?`,
-    '',
-    'If it has been unblocked, please remove the `status: blocked` label so we can track progress.',
-  ].join('\n');
+    "",
+    "If it has been unblocked, please remove the `status: blocked` label so we can track progress.",
+  ].join("\n");
 }
 
 /**
- * Returns the most recently created bot comment that starts with marker.
+ * Returns the most recently created bot-authored comment that starts with marker.
  *
  * @param {object[]} comments
  * @param {string} marker
@@ -361,7 +434,9 @@ function buildBlockedCheckinComment(assigneeLogins, itemType) {
  */
 function getLatestBotMarkerComment(comments, marker) {
   const matching = comments
-    .filter(c => c.body && c.body.startsWith(marker))
+    .filter(
+      (c) => c.user?.type === "Bot" && c.body && c.body.startsWith(marker),
+    )
     .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
 
   return matching[0] || null;
@@ -381,7 +456,7 @@ function getLatestBotMarkerComment(comments, marker) {
  */
 async function resetItem(github, owner, repo, item) {
   const ctx = buildCtx(github, owner, repo, item.number);
-  const assigneeLogins = (item.assignees || []).map(a => a.login);
+  const assigneeLogins = (item.assignees || []).map((a) => a.login);
 
   if (assigneeLogins.length > 0) {
     await removeAssignees(ctx, assigneeLogins);
@@ -410,22 +485,35 @@ async function resetItem(github, owner, repo, item) {
  * @param {number} nowMs - Current time in ms (injectable for testing).
  * @returns {Promise<'closed'|'warned'|'none'>}
  */
-async function handleStaleItem(github, owner, repo, item, lastActivityMs, itemType, logger, nowMs) {
+async function handleStaleItem(
+  github,
+  owner,
+  repo,
+  item,
+  lastActivityMs,
+  itemType,
+  logger,
+  nowMs,
+) {
   const ctx = buildCtx(github, owner, repo, item.number);
   const elapsed = nowMs - lastActivityMs;
   const days = Math.floor(elapsed / (24 * 60 * 60 * 1000));
-  const assigneeLogins = (item.assignees || []).map(a => a.login);
+  const assigneeLogins = (item.assignees || []).map((a) => a.login);
 
   if (elapsed >= CLOSE_AFTER_MS) {
-    if (itemType === 'issue') {
-      logger.log(`#${item.number} (${itemType}): resetting after ${days} days inactive`);
+    if (itemType === "issue") {
+      logger.log(
+        `#${item.number} (${itemType}): resetting after ${days} days inactive`,
+      );
     } else {
-      logger.log(`#${item.number} (${itemType}): closing after ${days} days inactive`);
+      logger.log(
+        `#${item.number} (${itemType}): closing after ${days} days inactive`,
+      );
       await closeItem(ctx);
     }
     await resetItem(github, owner, repo, item);
     await postComment(ctx, buildClosureComment(itemType));
-    return 'closed';
+    return "closed";
   }
 
   if (elapsed >= WARN_AFTER_MS) {
@@ -435,23 +523,27 @@ async function handleStaleItem(github, owner, repo, item, lastActivityMs, itemTy
     // Post a fresh warning only when no prior warning exists, or when there
     // has been meaningful activity since the last warning was posted.
     if (!latestWarning) {
-      logger.log(`#${item.number} (${itemType}): warning after ${days} days inactive`);
+      logger.log(
+        `#${item.number} (${itemType}): warning after ${days} days inactive`,
+      );
       await postComment(ctx, buildWarningComment(assigneeLogins, itemType));
-      return 'warned';
+      return "warned";
     }
 
     const warningCreatedMs = new Date(latestWarning.created_at).getTime();
     if (lastActivityMs > warningCreatedMs) {
-      logger.log(`#${item.number} (${itemType}): warning re-posted after activity reset`);
+      logger.log(
+        `#${item.number} (${itemType}): warning re-posted after activity reset`,
+      );
       await postComment(ctx, buildWarningComment(assigneeLogins, itemType));
-      return 'warned';
+      return "warned";
     }
 
     logger.log(`#${item.number} (${itemType}): existing warning still valid`);
-    return 'none';
+    return "none";
   }
 
-  return 'none';
+  return "none";
 }
 
 /**
@@ -467,23 +559,42 @@ async function handleStaleItem(github, owner, repo, item, lastActivityMs, itemTy
  * @param {object} logger
  * @returns {Promise<void>}
  */
-async function handleBlockedItem(github, owner, repo, item, itemType, nowMs, logger) {
+async function handleBlockedItem(
+  github,
+  owner,
+  repo,
+  item,
+  itemType,
+  nowMs,
+  logger,
+) {
   const ctx = buildCtx(github, owner, repo, item.number);
   const comments = await fetchComments(ctx);
 
   // Find the most recently updated check-in comment (there should be at most one).
   const checkinComment = comments
-    .filter(c => c.body && c.body.startsWith(BLOCKED_CHECKIN_MARKER))
-    .sort((a, b) => new Date(b.updated_at || b.created_at) - new Date(a.updated_at || a.created_at))[0];
+    .filter((c) => c.body && c.body.startsWith(BLOCKED_CHECKIN_MARKER))
+    .sort(
+      (a, b) =>
+        new Date(b.updated_at || b.created_at) -
+        new Date(a.updated_at || a.created_at),
+    )[0];
 
   const lastCheckinMs = checkinComment
     ? new Date(checkinComment.updated_at || checkinComment.created_at).getTime()
     : null;
 
-  if (lastCheckinMs === null || (nowMs - lastCheckinMs) >= BLOCKED_CHECKIN_AFTER_MS) {
+  if (
+    lastCheckinMs === null ||
+    nowMs - lastCheckinMs >= BLOCKED_CHECKIN_AFTER_MS
+  ) {
     logger.log(`#${item.number} (${itemType}): posting blocked check-in`);
-    const assigneeLogins = (item.assignees || []).map(a => a.login);
-    await postOrUpdateComment(ctx, BLOCKED_CHECKIN_MARKER, buildBlockedCheckinComment(assigneeLogins, itemType));
+    const assigneeLogins = (item.assignees || []).map((a) => a.login);
+    await postOrUpdateComment(
+      ctx,
+      BLOCKED_CHECKIN_MARKER,
+      buildBlockedCheckinComment(assigneeLogins, itemType),
+    );
   } else {
     logger.log(`#${item.number} (${itemType}): blocked check-in not due yet`);
   }
@@ -509,13 +620,13 @@ async function fetchAssignedIssues(github, owner, repo) {
     const { data } = await github.rest.issues.listForRepo({
       owner,
       repo,
-      state: 'open',
-      assignee: '*',
+      state: "open",
+      assignee: "*",
       per_page: perPage,
       page,
     });
     // issues.listForRepo returns both issues and PRs — filter to issues only
-    items.push(...data.filter(item => !item.pull_request));
+    items.push(...data.filter((item) => !item.pull_request));
     if (data.length < perPage) break;
     page++;
   }
@@ -540,7 +651,7 @@ async function fetchOpenPRs(github, owner, repo) {
     const { data } = await github.rest.pulls.list({
       owner,
       repo,
-      state: 'open',
+      state: "open",
       per_page: perPage,
       page,
     });
@@ -562,7 +673,7 @@ async function fetchOpenPRs(github, owner, repo) {
 function buildIssueToPRsMap(openPRs) {
   const map = new Map();
   for (const pr of openPRs) {
-    const issueNums = parseIssueNumbers(pr.body || '');
+    const issueNums = parseIssueNumbers(pr.body || "");
     for (const num of issueNums) {
       if (!map.has(num)) map.set(num, []);
       map.get(num).push(pr);
@@ -579,12 +690,18 @@ function buildIssueToPRsMap(openPRs) {
  * @param {{ github: object, context: object, getNow?: () => number }} args
  *   - getNow is injectable for testing; defaults to Date.now.
  */
-module.exports = async function ({ github, context, getNow = () => Date.now() }) {
-  const logger = createLogger('[inactivity-bot]');
+module.exports = async function ({
+  github,
+  context,
+  getNow = () => Date.now(),
+}) {
+  const logger = createLogger("[inactivity-bot]");
   const { owner, repo } = context.repo;
   const nowMs = getNow();
 
-  logger.log(`Starting inactivity check (now=${new Date(nowMs).toISOString()})`);
+  logger.log(
+    `Starting inactivity check (now=${new Date(nowMs).toISOString()})`,
+  );
 
   // ── Fetch data ────────────────────────────────────────────────────────────
 
@@ -593,41 +710,61 @@ module.exports = async function ({ github, context, getNow = () => Date.now() })
     fetchOpenPRs(github, owner, repo),
   ]);
 
-  const assignedOpenPRs = allOpenPRs.filter(pr => (pr.assignees || []).length > 0);
-  const issueToOpenPRs  = buildIssueToPRsMap(allOpenPRs);
+  const assignedOpenPRs = allOpenPRs.filter(
+    (pr) => (pr.assignees || []).length > 0,
+  );
+  const issueToOpenPRs = buildIssueToPRsMap(allOpenPRs);
 
   logger.log(
     `Found ${assignedIssues.length} assigned issues, ` +
-    `${assignedOpenPRs.length} assigned open PRs`
+      `${assignedOpenPRs.length} assigned open PRs`,
   );
 
   // ── Process assigned PRs ──────────────────────────────────────────────────
 
   for (const pr of assignedOpenPRs) {
     if (hasLabel(pr, LABELS.BLOCKED)) {
-      await handleBlockedItem(github, owner, repo, pr, 'PR', nowMs, logger);
+      await handleBlockedItem(github, owner, repo, pr, "PR", nowMs, logger);
       continue;
     }
 
     const lastActivity = await computePRLastActivity(github, owner, repo, pr);
-    const result = await handleStaleItem(github, owner, repo, pr, lastActivity, 'PR', logger, nowMs);
+    const result = await handleStaleItem(
+      github,
+      owner,
+      repo,
+      pr,
+      lastActivity,
+      "PR",
+      logger,
+      nowMs,
+    );
 
-    if (result === 'closed') {
+    if (result === "closed") {
       // Clean up issues linked to this PR immediately
-      const linkedIssueNums = parseIssueNumbers(pr.body || '');
+      const linkedIssueNums = parseIssueNumbers(pr.body || "");
       for (const issueNum of linkedIssueNums) {
         try {
           const { data: linkedIssue } = await github.rest.issues.get({
-            owner, repo, issue_number: issueNum,
+            owner,
+            repo,
+            issue_number: issueNum,
           });
-          if (linkedIssue.state === 'open' && (linkedIssue.assignees || []).length > 0) {
-            logger.log(`Cleaning up linked issue #${issueNum} (PR #${pr.number} closed for inactivity)`);
+          if (
+            linkedIssue.state === "open" &&
+            (linkedIssue.assignees || []).length > 0
+          ) {
+            logger.log(
+              `Cleaning up linked issue #${issueNum} (PR #${pr.number} closed for inactivity)`,
+            );
             await resetItem(github, owner, repo, linkedIssue);
             const ctx = buildCtx(github, owner, repo, issueNum);
             await postComment(ctx, buildLinkedPRClosedComment());
           }
         } catch (err) {
-          logger.error(`Could not clean up linked issue #${issueNum}: ${err.message}`);
+          logger.error(
+            `Could not clean up linked issue #${issueNum}: ${err.message}`,
+          );
         }
       }
     }
@@ -637,23 +774,48 @@ module.exports = async function ({ github, context, getNow = () => Date.now() })
 
   for (const issue of assignedIssues) {
     if (hasLabel(issue, LABELS.BLOCKED)) {
-      await handleBlockedItem(github, owner, repo, issue, 'issue', nowMs, logger);
+      await handleBlockedItem(
+        github,
+        owner,
+        repo,
+        issue,
+        "issue",
+        nowMs,
+        logger,
+      );
       continue;
     }
 
     if (!hasLabel(issue, LABELS.IN_PROGRESS)) {
-      logger.log(`#${issue.number}: skipping (no in-progress or blocked label)`);
+      logger.log(
+        `#${issue.number}: skipping (no in-progress or blocked label)`,
+      );
       continue;
     }
 
     const linkedPRs = issueToOpenPRs.get(issue.number) || [];
-    const lastActivity = await computeIssueLastActivity(github, owner, repo, issue, linkedPRs);
+    const lastActivity = await computeIssueLastActivity(
+      github,
+      owner,
+      repo,
+      issue,
+      linkedPRs,
+    );
     if (lastActivity === null) {
       logger.log(`#${issue.number}: skipping (no assigned event found)`);
       continue;
     }
-    await handleStaleItem(github, owner, repo, issue, lastActivity, 'issue', logger, nowMs);
+    await handleStaleItem(
+      github,
+      owner,
+      repo,
+      issue,
+      lastActivity,
+      "issue",
+      logger,
+      nowMs,
+    );
   }
 
-  logger.log('Inactivity check complete');
+  logger.log("Inactivity check complete");
 };

--- a/.github/scripts/bot-inactivity.js
+++ b/.github/scripts/bot-inactivity.js
@@ -21,8 +21,8 @@
 //   - Issues linked to open PRs with recent activity are not flagged.
 //   - When a PR is closed for inactivity, its linked issues are also reset.
 
-const { createLogger } = require("./helpers/logger");
-const { LABELS } = require("./helpers/constants");
+const { createLogger } = require('./helpers/logger');
+const { LABELS } = require('./helpers/constants');
 const {
   hasLabel,
   removeLabel,
@@ -34,17 +34,17 @@ const {
   fetchIssueEvents,
   fetchPRCommits,
   closeItem,
-} = require("./helpers/api");
-const { parseIssueNumbers } = require("./helpers/checks");
+} = require('./helpers/api');
+const { parseIssueNumbers } = require('./helpers/checks');
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
-const WARN_AFTER_MS = 5 * 24 * 60 * 60 * 1000; // 5 days
-const CLOSE_AFTER_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const WARN_AFTER_MS           = 5 * 24 * 60 * 60 * 1000;  // 5 days
+const CLOSE_AFTER_MS          = 7 * 24 * 60 * 60 * 1000;  // 7 days
 const BLOCKED_CHECKIN_AFTER_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
-const WARN_MARKER = "<!-- bot:inactivity-warning -->";
-const BLOCKED_CHECKIN_MARKER = "<!-- bot:blocked-checkin -->";
+const WARN_MARKER           = '<!-- bot:inactivity-warning -->';
+const BLOCKED_CHECKIN_MARKER = '<!-- bot:blocked-checkin -->';
 
 // ─── Context builder ─────────────────────────────────────────────────────────
 
@@ -81,7 +81,7 @@ function latestOf(current, candidate) {
  * @returns {Set<string>}
  */
 function collectParticipants(item) {
-  const logins = (item.assignees || []).map((a) => a.login.toLowerCase());
+  const logins = (item.assignees || []).map(a => a.login.toLowerCase());
   if (item.user?.login) logins.push(item.user.login.toLowerCase());
   return new Set(logins);
 }
@@ -116,19 +116,13 @@ function extractCommitDate(commit) {
  * @param {Set<string>} relevantLogins - Lowercased usernames to consider.
  * @returns {Promise<number|null>}
  */
-async function getLastRelevantCommentDate(
-  github,
-  owner,
-  repo,
-  number,
-  relevantLogins,
-) {
+async function getLastRelevantCommentDate(github, owner, repo, number, relevantLogins) {
   const ctx = buildCtx(github, owner, repo, number);
   const comments = await fetchComments(ctx);
 
   let latest = null;
   for (const c of comments) {
-    if (!c.user || c.user.type === "Bot") continue;
+    if (!c.user || c.user.type === 'Bot') continue;
     if (!relevantLogins.has(c.user.login.toLowerCase())) continue;
     const t = new Date(c.created_at).getTime();
     latest = latestOf(latest === null ? -Infinity : latest, t);
@@ -147,13 +141,7 @@ async function getLastRelevantCommentDate(
  * @param {string} authorLogin
  * @returns {Promise<number|null>}
  */
-async function getLastAuthorCommitDate(
-  github,
-  owner,
-  repo,
-  prNumber,
-  authorLogin,
-) {
+async function getLastAuthorCommitDate(github, owner, repo, prNumber, authorLogin) {
   const ctx = buildCtx(github, owner, repo, prNumber);
   const commits = await fetchPRCommits(ctx);
   const login = authorLogin.toLowerCase();
@@ -162,10 +150,7 @@ async function getLastAuthorCommitDate(
   for (const c of commits) {
     if (!isAuthorLogin(c, login)) continue;
     const dateStr = extractCommitDate(c);
-    latest = latestOf(
-      latest === null ? -Infinity : latest,
-      dateStr ? new Date(dateStr).getTime() : -Infinity,
-    );
+    latest = latestOf(latest === null ? -Infinity : latest, dateStr ? new Date(dateStr).getTime() : -Infinity);
   }
   return latest === null || latest === -Infinity ? null : latest;
 }
@@ -181,13 +166,7 @@ async function getLastAuthorCommitDate(
  * @param {function} predicate - Called with each event object; return true to include.
  * @returns {Promise<number|null>}
  */
-async function getLastMatchingEventDate(
-  github,
-  owner,
-  repo,
-  number,
-  predicate,
-) {
+async function getLastMatchingEventDate(github, owner, repo, number, predicate) {
   const ctx = buildCtx(github, owner, repo, number);
   const events = await fetchIssueEvents(ctx);
 
@@ -211,13 +190,8 @@ async function getLastMatchingEventDate(
  * @returns {Promise<number|null>}
  */
 async function getLastUnblockedDate(github, owner, repo, number) {
-  return getLastMatchingEventDate(
-    github,
-    owner,
-    repo,
-    number,
-    (e) => e.event === "unlabeled" && e.label?.name === LABELS.BLOCKED,
-  );
+  return getLastMatchingEventDate(github, owner, repo, number,
+    e => e.event === 'unlabeled' && e.label?.name === LABELS.BLOCKED);
 }
 
 /**
@@ -231,13 +205,8 @@ async function getLastUnblockedDate(github, owner, repo, number) {
  * @returns {Promise<number|null>}
  */
 async function getLastAssignedDate(github, owner, repo, number) {
-  return getLastMatchingEventDate(
-    github,
-    owner,
-    repo,
-    number,
-    (e) => e.event === "assigned",
-  );
+  return getLastMatchingEventDate(github, owner, repo, number,
+    e => e.event === 'assigned');
 }
 
 // ─── Activity computation ────────────────────────────────────────────────────
@@ -260,31 +229,16 @@ async function computePRLastActivity(github, owner, repo, pr) {
   const participants = collectParticipants(pr);
 
   if (participants.size > 0) {
-    const d = await getLastRelevantCommentDate(
-      github,
-      owner,
-      repo,
-      pr.number,
-      participants,
-    );
+    const d = await getLastRelevantCommentDate(github, owner, repo, pr.number, participants);
     latest = latestOf(latest, d);
   }
 
   if (pr.user?.login) {
-    const d = await getLastAuthorCommitDate(
-      github,
-      owner,
-      repo,
-      pr.number,
-      pr.user.login,
-    );
+    const d = await getLastAuthorCommitDate(github, owner, repo, pr.number, pr.user.login);
     latest = latestOf(latest, d);
   }
 
-  return latestOf(
-    latest,
-    await getLastUnblockedDate(github, owner, repo, pr.number),
-  );
+  return latestOf(latest, await getLastUnblockedDate(github, owner, repo, pr.number));
 }
 
 /**
@@ -299,47 +253,22 @@ async function computePRLastActivity(github, owner, repo, pr) {
  * @param {object[]} linkedOpenPRs - Open PR objects whose bodies reference this issue.
  * @returns {Promise<number>}
  */
-async function computeIssueLastActivity(
-  github,
-  owner,
-  repo,
-  issue,
-  linkedOpenPRs,
-) {
-  const assignedAt = await getLastAssignedDate(
-    github,
-    owner,
-    repo,
-    issue.number,
-  );
+async function computeIssueLastActivity(github, owner, repo, issue, linkedOpenPRs) {
+  const assignedAt = await getLastAssignedDate(github, owner, repo, issue.number);
   if (assignedAt === null) return null;
 
   let latest = assignedAt;
-  const assigneeLogins = new Set(
-    (issue.assignees || []).map((a) => a.login.toLowerCase()),
-  );
+  const assigneeLogins = new Set((issue.assignees || []).map(a => a.login.toLowerCase()));
 
   if (assigneeLogins.size > 0) {
-    const d = await getLastRelevantCommentDate(
-      github,
-      owner,
-      repo,
-      issue.number,
-      assigneeLogins,
-    );
+    const d = await getLastRelevantCommentDate(github, owner, repo, issue.number, assigneeLogins);
     latest = latestOf(latest, d);
   }
 
-  latest = latestOf(
-    latest,
-    await getLastUnblockedDate(github, owner, repo, issue.number),
-  );
+  latest = latestOf(latest, await getLastUnblockedDate(github, owner, repo, issue.number));
 
   for (const pr of linkedOpenPRs) {
-    latest = latestOf(
-      latest,
-      await computePRLastActivity(github, owner, repo, pr),
-    );
+    latest = latestOf(latest, await computePRLastActivity(github, owner, repo, pr));
   }
 
   return latest;
@@ -354,19 +283,18 @@ async function computeIssueLastActivity(
  * @returns {string}
  */
 function buildWarningComment(assigneeLogins, itemType) {
-  const mentions =
-    assigneeLogins.length > 0
-      ? assigneeLogins.map((l) => `@${l}`).join(", ")
-      : "there";
+  const mentions = assigneeLogins.length > 0
+    ? assigneeLogins.map(l => `@${l}`).join(', ')
+    : 'there';
 
   return [
     WARN_MARKER,
     `👋 Hey ${mentions}! This ${itemType} has been inactive for 5 days.`,
-    "",
-    "Are you still working on this? We will close this in 2 days if we see no further activity.",
-    "",
+    '',
+    'Are you still working on this? We will close this in 2 days if we see no further activity.',
+    '',
     "If you're still on it, leave a comment to let us know! If you'd like to step down, comment `/unassign`.",
-  ].join("\n");
+  ].join('\n');
 }
 
 /**
@@ -375,20 +303,20 @@ function buildWarningComment(assigneeLogins, itemType) {
  * @returns {string}
  */
 function buildClosureComment(itemType) {
-  if (itemType === "issue") {
+  if (itemType === 'issue') {
     return [
-      "⏱️ This issue has been unassigned and reset to `status: ready for dev` due to 7 days of inactivity.",
-      "",
+      '⏱️ This issue has been unassigned and reset to `status: ready for dev` due to 7 days of inactivity.',
+      '',
       "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
-    ].join("\n");
+    ].join('\n');
   }
   return [
-    "⏱️ This PR has been closed due to 7 days of inactivity.",
-    "",
-    "It has been unassigned and reset to `status: ready for dev` so another contributor can pick it up.",
-    "",
+    '⏱️ This PR has been closed due to 7 days of inactivity.',
+    '',
+    'It has been unassigned and reset to `status: ready for dev` so another contributor can pick it up.',
+    '',
     "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
-  ].join("\n");
+  ].join('\n');
 }
 
 /**
@@ -397,12 +325,12 @@ function buildClosureComment(itemType) {
  */
 function buildLinkedPRClosedComment() {
   return [
-    "🔗 The pull request linked to this issue was closed due to inactivity.",
-    "",
-    "This issue has been unassigned and reset to `status: ready for dev`.",
-    "",
+    '🔗 The pull request linked to this issue was closed due to inactivity.',
+    '',
+    'This issue has been unassigned and reset to `status: ready for dev`.',
+    '',
     "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
-  ].join("\n");
+  ].join('\n');
 }
 
 /**
@@ -412,47 +340,31 @@ function buildLinkedPRClosedComment() {
  * @returns {string}
  */
 function buildBlockedCheckinComment(assigneeLogins, itemType) {
-  const mentions =
-    assigneeLogins.length > 0
-      ? assigneeLogins.map((l) => `@${l}`).join(", ")
-      : "there";
+  const mentions = assigneeLogins.length > 0
+    ? assigneeLogins.map(l => `@${l}`).join(', ')
+    : 'there';
 
   return [
     BLOCKED_CHECKIN_MARKER,
     `👋 Hey ${mentions}, just checking in! Is this ${itemType} still blocked?`,
-    "",
-    "If it has been unblocked, please remove the `status: blocked` label so we can track progress.",
-  ].join("\n");
+    '',
+    'If it has been unblocked, please remove the `status: blocked` label so we can track progress.',
+  ].join('\n');
 }
 
 /**
- * Returns the most recently created bot-authored comment that starts with marker.
+ * Returns the most recently created bot comment that starts with marker.
  *
  * @param {object[]} comments
  * @param {string} marker
  * @returns {object|null}
  */
 function getLatestBotMarkerComment(comments, marker) {
-  let latestComment = null;
-  let latestCreatedAt = -Infinity;
+  const matching = comments
+    .filter(c => c.user?.type === 'Bot' && c.body && c.body.startsWith(marker))
+    .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
 
-  for (const comment of comments) {
-    if (
-      comment.user?.type !== "Bot" ||
-      !comment.body ||
-      !comment.body.startsWith(marker)
-    ) {
-      continue;
-    }
-
-    const createdAt = Date.parse(comment.created_at);
-    if (createdAt > latestCreatedAt) {
-      latestCreatedAt = createdAt;
-      latestComment = comment;
-    }
-  }
-
-  return latestComment;
+  return matching[0] || null;
 }
 
 // ─── State mutation ───────────────────────────────────────────────────────────
@@ -469,7 +381,7 @@ function getLatestBotMarkerComment(comments, marker) {
  */
 async function resetItem(github, owner, repo, item) {
   const ctx = buildCtx(github, owner, repo, item.number);
-  const assigneeLogins = (item.assignees || []).map((a) => a.login);
+  const assigneeLogins = (item.assignees || []).map(a => a.login);
 
   if (assigneeLogins.length > 0) {
     await removeAssignees(ctx, assigneeLogins);
@@ -498,35 +410,22 @@ async function resetItem(github, owner, repo, item) {
  * @param {number} nowMs - Current time in ms (injectable for testing).
  * @returns {Promise<'closed'|'warned'|'none'>}
  */
-async function handleStaleItem(
-  github,
-  owner,
-  repo,
-  item,
-  lastActivityMs,
-  itemType,
-  logger,
-  nowMs,
-) {
+async function handleStaleItem(github, owner, repo, item, lastActivityMs, itemType, logger, nowMs) {
   const ctx = buildCtx(github, owner, repo, item.number);
   const elapsed = nowMs - lastActivityMs;
   const days = Math.floor(elapsed / (24 * 60 * 60 * 1000));
-  const assigneeLogins = (item.assignees || []).map((a) => a.login);
+  const assigneeLogins = (item.assignees || []).map(a => a.login);
 
   if (elapsed >= CLOSE_AFTER_MS) {
-    if (itemType === "issue") {
-      logger.log(
-        `#${item.number} (${itemType}): resetting after ${days} days inactive`,
-      );
+    if (itemType === 'issue') {
+      logger.log(`#${item.number} (${itemType}): resetting after ${days} days inactive`);
     } else {
-      logger.log(
-        `#${item.number} (${itemType}): closing after ${days} days inactive`,
-      );
+      logger.log(`#${item.number} (${itemType}): closing after ${days} days inactive`);
       await closeItem(ctx);
     }
     await resetItem(github, owner, repo, item);
     await postComment(ctx, buildClosureComment(itemType));
-    return "closed";
+    return 'closed';
   }
 
   if (elapsed >= WARN_AFTER_MS) {
@@ -536,27 +435,23 @@ async function handleStaleItem(
     // Post a fresh warning only when no prior warning exists, or when there
     // has been meaningful activity since the last warning was posted.
     if (!latestWarning) {
-      logger.log(
-        `#${item.number} (${itemType}): warning after ${days} days inactive`,
-      );
+      logger.log(`#${item.number} (${itemType}): warning after ${days} days inactive`);
       await postComment(ctx, buildWarningComment(assigneeLogins, itemType));
-      return "warned";
+      return 'warned';
     }
 
     const warningCreatedMs = new Date(latestWarning.created_at).getTime();
     if (lastActivityMs > warningCreatedMs) {
-      logger.log(
-        `#${item.number} (${itemType}): warning re-posted after activity reset`,
-      );
+      logger.log(`#${item.number} (${itemType}): warning re-posted after activity reset`);
       await postComment(ctx, buildWarningComment(assigneeLogins, itemType));
-      return "warned";
+      return 'warned';
     }
 
     logger.log(`#${item.number} (${itemType}): existing warning still valid`);
-    return "none";
+    return 'none';
   }
 
-  return "none";
+  return 'none';
 }
 
 /**
@@ -572,42 +467,23 @@ async function handleStaleItem(
  * @param {object} logger
  * @returns {Promise<void>}
  */
-async function handleBlockedItem(
-  github,
-  owner,
-  repo,
-  item,
-  itemType,
-  nowMs,
-  logger,
-) {
+async function handleBlockedItem(github, owner, repo, item, itemType, nowMs, logger) {
   const ctx = buildCtx(github, owner, repo, item.number);
   const comments = await fetchComments(ctx);
 
   // Find the most recently updated check-in comment (there should be at most one).
   const checkinComment = comments
-    .filter((c) => c.body && c.body.startsWith(BLOCKED_CHECKIN_MARKER))
-    .sort(
-      (a, b) =>
-        new Date(b.updated_at || b.created_at) -
-        new Date(a.updated_at || a.created_at),
-    )[0];
+    .filter(c => c.body && c.body.startsWith(BLOCKED_CHECKIN_MARKER))
+    .sort((a, b) => new Date(b.updated_at || b.created_at) - new Date(a.updated_at || a.created_at))[0];
 
   const lastCheckinMs = checkinComment
     ? new Date(checkinComment.updated_at || checkinComment.created_at).getTime()
     : null;
 
-  if (
-    lastCheckinMs === null ||
-    nowMs - lastCheckinMs >= BLOCKED_CHECKIN_AFTER_MS
-  ) {
+  if (lastCheckinMs === null || (nowMs - lastCheckinMs) >= BLOCKED_CHECKIN_AFTER_MS) {
     logger.log(`#${item.number} (${itemType}): posting blocked check-in`);
-    const assigneeLogins = (item.assignees || []).map((a) => a.login);
-    await postOrUpdateComment(
-      ctx,
-      BLOCKED_CHECKIN_MARKER,
-      buildBlockedCheckinComment(assigneeLogins, itemType),
-    );
+    const assigneeLogins = (item.assignees || []).map(a => a.login);
+    await postOrUpdateComment(ctx, BLOCKED_CHECKIN_MARKER, buildBlockedCheckinComment(assigneeLogins, itemType));
   } else {
     logger.log(`#${item.number} (${itemType}): blocked check-in not due yet`);
   }
@@ -633,13 +509,13 @@ async function fetchAssignedIssues(github, owner, repo) {
     const { data } = await github.rest.issues.listForRepo({
       owner,
       repo,
-      state: "open",
-      assignee: "*",
+      state: 'open',
+      assignee: '*',
       per_page: perPage,
       page,
     });
     // issues.listForRepo returns both issues and PRs — filter to issues only
-    items.push(...data.filter((item) => !item.pull_request));
+    items.push(...data.filter(item => !item.pull_request));
     if (data.length < perPage) break;
     page++;
   }
@@ -664,7 +540,7 @@ async function fetchOpenPRs(github, owner, repo) {
     const { data } = await github.rest.pulls.list({
       owner,
       repo,
-      state: "open",
+      state: 'open',
       per_page: perPage,
       page,
     });
@@ -686,7 +562,7 @@ async function fetchOpenPRs(github, owner, repo) {
 function buildIssueToPRsMap(openPRs) {
   const map = new Map();
   for (const pr of openPRs) {
-    const issueNums = parseIssueNumbers(pr.body || "");
+    const issueNums = parseIssueNumbers(pr.body || '');
     for (const num of issueNums) {
       if (!map.has(num)) map.set(num, []);
       map.get(num).push(pr);
@@ -703,18 +579,12 @@ function buildIssueToPRsMap(openPRs) {
  * @param {{ github: object, context: object, getNow?: () => number }} args
  *   - getNow is injectable for testing; defaults to Date.now.
  */
-module.exports = async function ({
-  github,
-  context,
-  getNow = () => Date.now(),
-}) {
-  const logger = createLogger("[inactivity-bot]");
+module.exports = async function ({ github, context, getNow = () => Date.now() }) {
+  const logger = createLogger('[inactivity-bot]');
   const { owner, repo } = context.repo;
   const nowMs = getNow();
 
-  logger.log(
-    `Starting inactivity check (now=${new Date(nowMs).toISOString()})`,
-  );
+  logger.log(`Starting inactivity check (now=${new Date(nowMs).toISOString()})`);
 
   // ── Fetch data ────────────────────────────────────────────────────────────
 
@@ -723,61 +593,41 @@ module.exports = async function ({
     fetchOpenPRs(github, owner, repo),
   ]);
 
-  const assignedOpenPRs = allOpenPRs.filter(
-    (pr) => (pr.assignees || []).length > 0,
-  );
-  const issueToOpenPRs = buildIssueToPRsMap(allOpenPRs);
+  const assignedOpenPRs = allOpenPRs.filter(pr => (pr.assignees || []).length > 0);
+  const issueToOpenPRs  = buildIssueToPRsMap(allOpenPRs);
 
   logger.log(
     `Found ${assignedIssues.length} assigned issues, ` +
-      `${assignedOpenPRs.length} assigned open PRs`,
+    `${assignedOpenPRs.length} assigned open PRs`
   );
 
   // ── Process assigned PRs ──────────────────────────────────────────────────
 
   for (const pr of assignedOpenPRs) {
     if (hasLabel(pr, LABELS.BLOCKED)) {
-      await handleBlockedItem(github, owner, repo, pr, "PR", nowMs, logger);
+      await handleBlockedItem(github, owner, repo, pr, 'PR', nowMs, logger);
       continue;
     }
 
     const lastActivity = await computePRLastActivity(github, owner, repo, pr);
-    const result = await handleStaleItem(
-      github,
-      owner,
-      repo,
-      pr,
-      lastActivity,
-      "PR",
-      logger,
-      nowMs,
-    );
+    const result = await handleStaleItem(github, owner, repo, pr, lastActivity, 'PR', logger, nowMs);
 
-    if (result === "closed") {
+    if (result === 'closed') {
       // Clean up issues linked to this PR immediately
-      const linkedIssueNums = parseIssueNumbers(pr.body || "");
+      const linkedIssueNums = parseIssueNumbers(pr.body || '');
       for (const issueNum of linkedIssueNums) {
         try {
           const { data: linkedIssue } = await github.rest.issues.get({
-            owner,
-            repo,
-            issue_number: issueNum,
+            owner, repo, issue_number: issueNum,
           });
-          if (
-            linkedIssue.state === "open" &&
-            (linkedIssue.assignees || []).length > 0
-          ) {
-            logger.log(
-              `Cleaning up linked issue #${issueNum} (PR #${pr.number} closed for inactivity)`,
-            );
+          if (linkedIssue.state === 'open' && (linkedIssue.assignees || []).length > 0) {
+            logger.log(`Cleaning up linked issue #${issueNum} (PR #${pr.number} closed for inactivity)`);
             await resetItem(github, owner, repo, linkedIssue);
             const ctx = buildCtx(github, owner, repo, issueNum);
             await postComment(ctx, buildLinkedPRClosedComment());
           }
         } catch (err) {
-          logger.error(
-            `Could not clean up linked issue #${issueNum}: ${err.message}`,
-          );
+          logger.error(`Could not clean up linked issue #${issueNum}: ${err.message}`);
         }
       }
     }
@@ -787,48 +637,23 @@ module.exports = async function ({
 
   for (const issue of assignedIssues) {
     if (hasLabel(issue, LABELS.BLOCKED)) {
-      await handleBlockedItem(
-        github,
-        owner,
-        repo,
-        issue,
-        "issue",
-        nowMs,
-        logger,
-      );
+      await handleBlockedItem(github, owner, repo, issue, 'issue', nowMs, logger);
       continue;
     }
 
     if (!hasLabel(issue, LABELS.IN_PROGRESS)) {
-      logger.log(
-        `#${issue.number}: skipping (no in-progress or blocked label)`,
-      );
+      logger.log(`#${issue.number}: skipping (no in-progress or blocked label)`);
       continue;
     }
 
     const linkedPRs = issueToOpenPRs.get(issue.number) || [];
-    const lastActivity = await computeIssueLastActivity(
-      github,
-      owner,
-      repo,
-      issue,
-      linkedPRs,
-    );
+    const lastActivity = await computeIssueLastActivity(github, owner, repo, issue, linkedPRs);
     if (lastActivity === null) {
       logger.log(`#${issue.number}: skipping (no assigned event found)`);
       continue;
     }
-    await handleStaleItem(
-      github,
-      owner,
-      repo,
-      issue,
-      lastActivity,
-      "issue",
-      logger,
-      nowMs,
-    );
+    await handleStaleItem(github, owner, repo, issue, lastActivity, 'issue', logger, nowMs);
   }
 
-  logger.log("Inactivity check complete");
+  logger.log('Inactivity check complete');
 };

--- a/.github/scripts/bot-inactivity.js
+++ b/.github/scripts/bot-inactivity.js
@@ -433,13 +433,26 @@ function buildBlockedCheckinComment(assigneeLogins, itemType) {
  * @returns {object|null}
  */
 function getLatestBotMarkerComment(comments, marker) {
-  const matching = comments
-    .filter(
-      (c) => c.user?.type === "Bot" && c.body && c.body.startsWith(marker),
-    )
-    .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+  let latestComment = null;
+  let latestCreatedAt = -Infinity;
 
-  return matching[0] || null;
+  for (const comment of comments) {
+    if (
+      comment.user?.type !== "Bot" ||
+      !comment.body ||
+      !comment.body.startsWith(marker)
+    ) {
+      continue;
+    }
+
+    const createdAt = Date.parse(comment.created_at);
+    if (createdAt > latestCreatedAt) {
+      latestCreatedAt = createdAt;
+      latestComment = comment;
+    }
+  }
+
+  return latestComment;
 }
 
 // ─── State mutation ───────────────────────────────────────────────────────────

--- a/.github/scripts/bot-inactivity.js
+++ b/.github/scripts/bot-inactivity.js
@@ -352,6 +352,21 @@ function buildBlockedCheckinComment(assigneeLogins, itemType) {
   ].join('\n');
 }
 
+/**
+ * Returns the most recently created bot comment that starts with marker.
+ *
+ * @param {object[]} comments
+ * @param {string} marker
+ * @returns {object|null}
+ */
+function getLatestBotMarkerComment(comments, marker) {
+  const matching = comments
+    .filter(c => c.body && c.body.startsWith(marker))
+    .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+  return matching[0] || null;
+}
+
 // ─── State mutation ───────────────────────────────────────────────────────────
 
 /**
@@ -414,9 +429,26 @@ async function handleStaleItem(github, owner, repo, item, lastActivityMs, itemTy
   }
 
   if (elapsed >= WARN_AFTER_MS) {
-    logger.log(`#${item.number} (${itemType}): warning after ${days} days inactive`);
-    await postOrUpdateComment(ctx, WARN_MARKER, buildWarningComment(assigneeLogins, itemType));
-    return 'warned';
+    const comments = await fetchComments(ctx);
+    const latestWarning = getLatestBotMarkerComment(comments, WARN_MARKER);
+
+    // Post a fresh warning only when no prior warning exists, or when there
+    // has been meaningful activity since the last warning was posted.
+    if (!latestWarning) {
+      logger.log(`#${item.number} (${itemType}): warning after ${days} days inactive`);
+      await postComment(ctx, buildWarningComment(assigneeLogins, itemType));
+      return 'warned';
+    }
+
+    const warningCreatedMs = new Date(latestWarning.created_at).getTime();
+    if (lastActivityMs > warningCreatedMs) {
+      logger.log(`#${item.number} (${itemType}): warning re-posted after activity reset`);
+      await postComment(ctx, buildWarningComment(assigneeLogins, itemType));
+      return 'warned';
+    }
+
+    logger.log(`#${item.number} (${itemType}): existing warning still valid`);
+    return 'none';
   }
 
   return 'none';

--- a/.github/scripts/helpers/api.js
+++ b/.github/scripts/helpers/api.js
@@ -5,17 +5,22 @@
 // Bot context builder and GitHub API wrappers (labels, assignees, comments,
 // commit/issue fetching, and label swap helpers).
 
-const { getLogger } = require('./logger');
+const { getLogger } = require("./logger");
 const {
   isSafeSearchToken,
   requireObject,
   requireNonEmptyString,
   requirePositiveInt,
   requireSafeUsername,
-} = require('./validation');
-const { LABELS, SKILL_HIERARCHY } = require('./constants');
-const { checkDCO, checkGPG, checkMergeConflict, checkIssueLink } = require('./checks');
-const { buildBotComment } = require('./comments');
+} = require("./validation");
+const { LABELS, SKILL_HIERARCHY } = require("./constants");
+const {
+  checkDCO,
+  checkGPG,
+  checkMergeConflict,
+  checkIssueLink,
+} = require("./checks");
+const { buildBotComment } = require("./comments");
 
 /**
  * Builds the bot context for any bot. Validates github, context, and payload; throws if invalid.
@@ -29,38 +34,42 @@ const { buildBotComment } = require('./comments');
  * @throws {Error} If input is invalid or event type is unsupported.
  */
 function buildBotContext({ github, context }) {
-  requireObject(github, 'github');
-  requireObject(context, 'context');
-  requireObject(context.repo, 'context.repo');
-  requireObject(context.payload, 'context.payload');
+  requireObject(github, "github");
+  requireObject(context, "context");
+  requireObject(context.repo, "context.repo");
+  requireObject(context.payload, "context.payload");
 
   const owner = context.repo.owner;
   const repo = context.repo.repo;
-  requireNonEmptyString(owner, 'context.repo.owner');
-  requireNonEmptyString(repo, 'context.repo.repo');
+  requireNonEmptyString(owner, "context.repo.owner");
+  requireNonEmptyString(repo, "context.repo.repo");
   if (!isSafeSearchToken(owner) || !isSafeSearchToken(repo)) {
-    throw new Error('Bot context invalid: owner or repo contains invalid characters');
+    throw new Error(
+      "Bot context invalid: owner or repo contains invalid characters",
+    );
   }
 
   const base = { github, owner, repo };
 
-  requireNonEmptyString(context.eventName, 'context.eventName');
+  requireNonEmptyString(context.eventName, "context.eventName");
   const eventType = context.eventName;
 
   const { payload } = context;
   let payloadPart;
   switch (eventType) {
-    case 'pull_request':
-    case 'pull_request_target':
-    case 'pull_request_review': {
+    case "pull_request":
+    case "pull_request_target":
+    case "pull_request_review": {
       const pr = payload.pull_request;
-      requireObject(pr, 'context.payload.pull_request');
-      requirePositiveInt(pr.number, 'pull_request.number');
+      requireObject(pr, "context.payload.pull_request");
+      requirePositiveInt(pr.number, "pull_request.number");
 
       if (pr.user) {
-        requireNonEmptyString(pr.user.login, 'pull_request.user.login');
+        requireNonEmptyString(pr.user.login, "pull_request.user.login");
         if (!isSafeSearchToken(pr.user.login)) {
-          throw new Error('Bot context invalid: pull_request.user.login contains invalid characters');
+          throw new Error(
+            "Bot context invalid: pull_request.user.login contains invalid characters",
+          );
         }
       }
 
@@ -68,35 +77,42 @@ function buildBotContext({ github, context }) {
       break;
     }
 
-    case 'issues':
-    case 'issue_comment': {
+    case "issues":
+    case "issue_comment": {
       const issue = payload.issue;
-      requireObject(issue, 'context.payload.issue');
-      requirePositiveInt(issue.number, 'issue.number');
+      requireObject(issue, "context.payload.issue");
+      requirePositiveInt(issue.number, "issue.number");
       payloadPart = { number: issue.number, issue };
 
-      if (eventType === 'issue_comment') {
+      if (eventType === "issue_comment") {
         const comment = payload.comment;
-        requireObject(comment, 'context.payload.comment');
-        requireObject(comment.user, 'context.payload.comment.user');
-        requireNonEmptyString(comment.user.login, 'context.payload.comment.user.login');
+        requireObject(comment, "context.payload.comment");
+        requireObject(comment.user, "context.payload.comment.user");
+        requireNonEmptyString(
+          comment.user.login,
+          "context.payload.comment.user.login",
+        );
 
         // Flag bot users early so callers can skip processing without
         // hitting the stricter username validation below.
-        const isBot = comment.user.type === 'Bot';
+        const isBot = comment.user.type === "Bot";
         if (!isBot && !isSafeSearchToken(comment.user.login)) {
-          throw new Error('Bot context invalid: comment.user.login contains invalid characters');
+          throw new Error(
+            "Bot context invalid: comment.user.login contains invalid characters",
+          );
         }
-        if (typeof comment.body !== 'string') {
-          throw new Error('Bot context invalid: comment.body must be a string');
+        if (typeof comment.body !== "string") {
+          throw new Error("Bot context invalid: comment.body must be a string");
         }
-        
+
         payloadPart = { ...payloadPart, comment, isBot };
       }
       break;
     }
     default:
-      throw new Error(`Bot context invalid: unsupported event type "${eventType}"`);
+      throw new Error(
+        `Bot context invalid: unsupported event type "${eventType}"`,
+      );
   }
   return { ...base, eventType, ...payloadPart };
 }
@@ -109,9 +125,9 @@ function buildBotContext({ github, context }) {
  */
 async function addLabels(botContext, labels) {
   if (!Array.isArray(labels)) {
-    return { success: false, error: 'labels must be an array' };
+    return { success: false, error: "labels must be an array" };
   }
-  
+
   try {
     for (let i = 0; i < labels.length; i++) {
       requireNonEmptyString(labels[i], `labels[${i}]`);
@@ -124,10 +140,12 @@ async function addLabels(botContext, labels) {
       labels,
     });
 
-    getLogger().log(`Added labels: ${labels.join(', ')}`);
+    getLogger().log(`Added labels: ${labels.join(", ")}`);
     return { success: true };
   } catch (error) {
-    getLogger().error(`Could not add labels "${labels.join(', ')}": ${error.message}`);
+    getLogger().error(
+      `Could not add labels "${labels.join(", ")}": ${error.message}`,
+    );
     return { success: false, error: error.message };
   }
 }
@@ -140,7 +158,7 @@ async function addLabels(botContext, labels) {
  */
 async function removeLabel(botContext, labelName) {
   try {
-    requireNonEmptyString(labelName, 'labelName');
+    requireNonEmptyString(labelName, "labelName");
 
     await botContext.github.rest.issues.removeLabel({
       owner: botContext.owner,
@@ -152,7 +170,9 @@ async function removeLabel(botContext, labelName) {
     getLogger().log(`Removed label: ${labelName}`);
     return { success: true };
   } catch (error) {
-    getLogger().error(`Could not remove label "${labelName}": ${error.message}`);
+    getLogger().error(
+      `Could not remove label "${labelName}": ${error.message}`,
+    );
     return { success: false, error: error.message };
   }
 }
@@ -165,7 +185,7 @@ async function removeLabel(botContext, labelName) {
  */
 async function addAssignees(botContext, assignees) {
   if (!Array.isArray(assignees)) {
-    return { success: false, error: 'assignees must be an array' };
+    return { success: false, error: "assignees must be an array" };
   }
 
   try {
@@ -180,10 +200,12 @@ async function addAssignees(botContext, assignees) {
       assignees,
     });
 
-    getLogger().log(`Added assignees: ${assignees.join(', ')}`);
+    getLogger().log(`Added assignees: ${assignees.join(", ")}`);
     return { success: true };
   } catch (error) {
-    getLogger().error(`Could not add assignees "${assignees.join(', ')}": ${error.message}`);
+    getLogger().error(
+      `Could not add assignees "${assignees.join(", ")}": ${error.message}`,
+    );
     return { success: false, error: error.message };
   }
 }
@@ -196,7 +218,7 @@ async function addAssignees(botContext, assignees) {
  */
 async function removeAssignees(botContext, assignees) {
   if (!Array.isArray(assignees)) {
-    return { success: false, error: 'assignees must be an array' };
+    return { success: false, error: "assignees must be an array" };
   }
 
   try {
@@ -211,10 +233,12 @@ async function removeAssignees(botContext, assignees) {
       assignees,
     });
 
-    getLogger().log(`Removed assignees: ${assignees.join(', ')}`);
+    getLogger().log(`Removed assignees: ${assignees.join(", ")}`);
     return { success: true };
   } catch (error) {
-    getLogger().error(`Could not remove assignees "${assignees.join(', ')}": ${error.message}`);
+    getLogger().error(
+      `Could not remove assignees "${assignees.join(", ")}": ${error.message}`,
+    );
     return { success: false, error: error.message };
   }
 }
@@ -227,7 +251,7 @@ async function removeAssignees(botContext, assignees) {
  */
 async function postComment(botContext, body) {
   try {
-    requireNonEmptyString(body, 'comment body');
+    requireNonEmptyString(body, "comment body");
 
     await botContext.github.rest.issues.createComment({
       owner: botContext.owner,
@@ -235,7 +259,7 @@ async function postComment(botContext, body) {
       issue_number: botContext.number,
       body,
     });
-    getLogger().log('Posted comment');
+    getLogger().log("Posted comment");
     return { success: true };
   } catch (error) {
     getLogger().error(`Could not post comment: ${error.message}`);
@@ -255,8 +279,10 @@ function hasLabel(issueOrPr, labelName) {
   }
 
   return issueOrPr.labels.some((label) => {
-    const name = typeof label === 'string' ? label : label?.name;
-    return typeof name === 'string' && name.toLowerCase() === labelName.toLowerCase();
+    const name = typeof label === "string" ? label : label?.name;
+    return (
+      typeof name === "string" && name.toLowerCase() === labelName.toLowerCase()
+    );
   });
 }
 
@@ -270,7 +296,7 @@ function hasLabel(issueOrPr, labelName) {
  */
 function getLabelsByPrefix(issueOrPr, prefix) {
   return (issueOrPr.labels || [])
-    .map((l) => (typeof l === 'string' ? l : l?.name || ''))
+    .map((l) => (typeof l === "string" ? l : l?.name || ""))
     .filter((name) => name.toLowerCase().startsWith(prefix.toLowerCase()));
 }
 
@@ -296,11 +322,11 @@ async function swapLabels(botContext, fromLabel, toLabel) {
     errors.push(`Failed to add '${toLabel}': ${addResult.error}`);
   }
 
-  return { success: errors.length === 0, errorDetails: errors.join('; ') };
+  return { success: errors.length === 0, errorDetails: errors.join("; ") };
 }
 
 /**
- * Fetches an existing comment identified by an HTML marker.
+ * Fetches an existing bot-authored comment identified by an HTML marker.
  * Paginates through all comments to find a match.
  * @param {object} botContext
  * @param {string} marker - HTML comment marker (e.g. '<!-- bot:pr-helper -->').
@@ -311,16 +337,18 @@ async function getBotComment(botContext, marker) {
   const perPage = 100;
 
   while (true) {
-    const { data: comments } = await botContext.github.rest.issues.listComments({
-      owner: botContext.owner,
-      repo: botContext.repo,
-      issue_number: botContext.number,
-      per_page: perPage,
-      page,
-    });
+    const { data: comments } = await botContext.github.rest.issues.listComments(
+      {
+        owner: botContext.owner,
+        repo: botContext.repo,
+        issue_number: botContext.number,
+        per_page: perPage,
+        page,
+      },
+    );
 
     for (const c of comments) {
-      if (c.body && c.body.startsWith(marker)) {
+      if (c.user?.type === "Bot" && c.body && c.body.startsWith(marker)) {
         return c;
       }
     }
@@ -342,14 +370,14 @@ async function getBotComment(botContext, marker) {
  */
 async function postOrUpdateComment(botContext, marker, body) {
   try {
-    requireNonEmptyString(marker, 'marker');
-    requireNonEmptyString(body, 'comment body');
+    requireNonEmptyString(marker, "marker");
+    requireNonEmptyString(body, "comment body");
 
     const existingComment = await getBotComment(botContext, marker);
 
     if (existingComment) {
       if (existingComment.body.trim() === body.trim()) {
-        getLogger().log('Existing bot comment is up-to-date');
+        getLogger().log("Existing bot comment is up-to-date");
       } else {
         await botContext.github.rest.issues.updateComment({
           owner: botContext.owner,
@@ -357,7 +385,7 @@ async function postOrUpdateComment(botContext, marker, body) {
           comment_id: existingComment.id,
           body,
         });
-        getLogger().log('Updated existing bot comment');
+        getLogger().log("Updated existing bot comment");
       }
     } else {
       await botContext.github.rest.issues.createComment({
@@ -366,7 +394,7 @@ async function postOrUpdateComment(botContext, marker, body) {
         issue_number: botContext.number,
         body,
       });
-      getLogger().log('Created new bot comment');
+      getLogger().log("Created new bot comment");
     }
     return { success: true };
   } catch (error) {
@@ -400,7 +428,9 @@ async function fetchPRCommits(botContext) {
     page++;
   }
 
-  getLogger().log(`Fetched ${commits.length} commits for PR #${botContext.number}`);
+  getLogger().log(
+    `Fetched ${commits.length} commits for PR #${botContext.number}`,
+  );
   return commits;
 }
 
@@ -418,7 +448,7 @@ async function fetchOpenPRs(botContext) {
     const response = await botContext.github.rest.pulls.list({
       owner: botContext.owner,
       repo: botContext.repo,
-      state: 'open',
+      state: "open",
       per_page: perPage,
       page,
     });
@@ -469,10 +499,13 @@ async function fetchClosingIssueNumbers(botContext) {
       repo: botContext.repo,
       number: botContext.number,
     });
-    const nodes = result.repository.pullRequest.closingIssuesReferences.nodes || [];
-    return nodes.map(n => n.number);
+    const nodes =
+      result.repository.pullRequest.closingIssuesReferences.nodes || [];
+    return nodes.map((n) => n.number);
   } catch (error) {
-    getLogger().error(`GraphQL closingIssuesReferences failed: ${error.message}`);
+    getLogger().error(
+      `GraphQL closingIssuesReferences failed: ${error.message}`,
+    );
     return [];
   }
 }
@@ -520,12 +553,12 @@ async function acknowledgeComment(botContext, commentId) {
       owner: botContext.owner,
       repo: botContext.repo,
       comment_id: commentId,
-      content: '+1',
+      content: "+1",
     });
-    getLogger().log('Added thumbs-up reaction to comment');
+    getLogger().log("Added thumbs-up reaction to comment");
     return { success: true };
   } catch (error) {
-    getLogger().log('Could not add reaction:', error.message);
+    getLogger().log("Could not add reaction:", error.message);
     return { success: false };
   }
 }
@@ -544,33 +577,54 @@ async function runAllChecksAndComment(botContext, precomputed = {}) {
   try {
     commits = await fetchPRCommits(botContext);
   } catch (e) {
-    getLogger().error('Failed to fetch PR commits:', e.message);
+    getLogger().error("Failed to fetch PR commits:", e.message);
     dco = { error: true, errorMessage: e.message };
     gpg = { error: true, errorMessage: e.message };
   }
 
   if (!dco) {
-    try { dco = checkDCO(commits); }
-    catch (e) { dco = { error: true, errorMessage: e.message }; }
+    try {
+      dco = checkDCO(commits);
+    } catch (e) {
+      dco = { error: true, errorMessage: e.message };
+    }
   }
 
   if (!gpg) {
-    try { gpg = checkGPG(commits); }
-    catch (e) { gpg = { error: true, errorMessage: e.message }; }
+    try {
+      gpg = checkGPG(commits);
+    } catch (e) {
+      gpg = { error: true, errorMessage: e.message };
+    }
   }
 
   if (!merge) {
-    try { merge = await checkMergeConflict(botContext); }
-    catch (e) { merge = { error: true, errorMessage: e.message }; }
+    try {
+      merge = await checkMergeConflict(botContext);
+    } catch (e) {
+      merge = { error: true, errorMessage: e.message };
+    }
   }
 
   if (!issueLink) {
-    try { issueLink = await checkIssueLink(botContext, { fetchIssue, fetchClosingIssueNumbers }); }
-    catch (e) { issueLink = { error: true, errorMessage: e.message }; }
+    try {
+      issueLink = await checkIssueLink(botContext, {
+        fetchIssue,
+        fetchClosingIssueNumbers,
+      });
+    } catch (e) {
+      issueLink = { error: true, errorMessage: e.message };
+    }
   }
 
   const prAuthor = botContext.pr?.user?.login;
-  const { marker, body, allPassed } = buildBotComment({ prAuthor, dco, gpg, merge, issueLink });
+  const { marker, body, allPassed } = buildBotComment({
+    prAuthor,
+    dco,
+    gpg,
+    merge,
+    issueLink,
+  });
   await postOrUpdateComment(botContext, marker, body);
 
   return { allPassed };
@@ -631,7 +685,9 @@ async function fetchComments(botContext) {
     page++;
   }
 
-  getLogger().log(`Fetched ${comments.length} comments for #${botContext.number}`);
+  getLogger().log(
+    `Fetched ${comments.length} comments for #${botContext.number}`,
+  );
   return comments;
 }
 
@@ -646,13 +702,15 @@ async function closeItem(botContext) {
       owner: botContext.owner,
       repo: botContext.repo,
       issue_number: botContext.number,
-      state: 'closed',
+      state: "closed",
     });
 
     getLogger().log(`Closed #${botContext.number}`);
     return { success: true };
   } catch (error) {
-    getLogger().error(`Could not close #${botContext.number}: ${error.message}`);
+    getLogger().error(
+      `Could not close #${botContext.number}: ${error.message}`,
+    );
     return { success: false, error: error.message };
   }
 }
@@ -673,60 +731,72 @@ async function closeItem(botContext) {
  * @returns {Promise<object|null>}
  */
 async function resolveLinkedIssue(botContext) {
-    try {
-        const issueNumbers = await fetchClosingIssueNumbers(botContext);
+  try {
+    const issueNumbers = await fetchClosingIssueNumbers(botContext);
 
-        if (!issueNumbers.length) {
-            getLogger().log('No linked issue found', {
-                prNumber: botContext.number,
-            });
-            return null;
-        }
+    if (!issueNumbers.length) {
+      getLogger().log("No linked issue found", {
+        prNumber: botContext.number,
+      });
+      return null;
+    }
 
-        if (issueNumbers.length === 1) {
-            const issue = await fetchIssue(botContext, issueNumbers[0]);
-            if (!issue || SKILL_HIERARCHY.findIndex(level => hasLabel(issue, level)) === -1) {
-                getLogger().log('Single linked issue has no skill label', { issueNumber: issueNumbers[0] });
-                return null;
-            }
-            return issue;
-        }
-
-        const issues = await Promise.all(
-            issueNumbers.map(n => fetchIssue(botContext, n))
-        );
-        const valid = issues.filter(Boolean);
-
-        if (!valid.length) {
-            getLogger().log('All linked issue fetches returned empty', { issueNumbers });
-            return null;
-        }
-
-        const selected = valid.reduce((best, issue) => {
-            const bestIndex = SKILL_HIERARCHY.findIndex(level => hasLabel(best, level));
-            const currIndex = SKILL_HIERARCHY.findIndex(level => hasLabel(issue, level));
-            return currIndex > bestIndex ? issue : best;
-        });
-
-        const selectedIndex = SKILL_HIERARCHY.findIndex(level => hasLabel(selected, level));
-        if (selectedIndex === -1) {
-            getLogger().log('No linked issues have a skill label', { issueNumbers });
-            return null;
-        }
-
-        getLogger().log('Multiple linked issues found (using highest level)', {
-            issueNumbers,
-            selected: selected.number,
-        });
-
-        return selected;
-
-    } catch (error) {
-        getLogger().error('Failed to resolve linked issue:', {
-            message: error.message,
+    if (issueNumbers.length === 1) {
+      const issue = await fetchIssue(botContext, issueNumbers[0]);
+      if (
+        !issue ||
+        SKILL_HIERARCHY.findIndex((level) => hasLabel(issue, level)) === -1
+      ) {
+        getLogger().log("Single linked issue has no skill label", {
+          issueNumber: issueNumbers[0],
         });
         return null;
+      }
+      return issue;
     }
+
+    const issues = await Promise.all(
+      issueNumbers.map((n) => fetchIssue(botContext, n)),
+    );
+    const valid = issues.filter(Boolean);
+
+    if (!valid.length) {
+      getLogger().log("All linked issue fetches returned empty", {
+        issueNumbers,
+      });
+      return null;
+    }
+
+    const selected = valid.reduce((best, issue) => {
+      const bestIndex = SKILL_HIERARCHY.findIndex((level) =>
+        hasLabel(best, level),
+      );
+      const currIndex = SKILL_HIERARCHY.findIndex((level) =>
+        hasLabel(issue, level),
+      );
+      return currIndex > bestIndex ? issue : best;
+    });
+
+    const selectedIndex = SKILL_HIERARCHY.findIndex((level) =>
+      hasLabel(selected, level),
+    );
+    if (selectedIndex === -1) {
+      getLogger().log("No linked issues have a skill label", { issueNumbers });
+      return null;
+    }
+
+    getLogger().log("Multiple linked issues found (using highest level)", {
+      issueNumbers,
+      selected: selected.number,
+    });
+
+    return selected;
+  } catch (error) {
+    getLogger().error("Failed to resolve linked issue:", {
+      message: error.message,
+    });
+    return null;
+  }
 }
 
 /**

--- a/.github/scripts/helpers/api.js
+++ b/.github/scripts/helpers/api.js
@@ -5,22 +5,17 @@
 // Bot context builder and GitHub API wrappers (labels, assignees, comments,
 // commit/issue fetching, and label swap helpers).
 
-const { getLogger } = require("./logger");
+const { getLogger } = require('./logger');
 const {
   isSafeSearchToken,
   requireObject,
   requireNonEmptyString,
   requirePositiveInt,
   requireSafeUsername,
-} = require("./validation");
-const { LABELS, SKILL_HIERARCHY } = require("./constants");
-const {
-  checkDCO,
-  checkGPG,
-  checkMergeConflict,
-  checkIssueLink,
-} = require("./checks");
-const { buildBotComment } = require("./comments");
+} = require('./validation');
+const { LABELS, SKILL_HIERARCHY } = require('./constants');
+const { checkDCO, checkGPG, checkMergeConflict, checkIssueLink } = require('./checks');
+const { buildBotComment } = require('./comments');
 
 /**
  * Builds the bot context for any bot. Validates github, context, and payload; throws if invalid.
@@ -34,42 +29,38 @@ const { buildBotComment } = require("./comments");
  * @throws {Error} If input is invalid or event type is unsupported.
  */
 function buildBotContext({ github, context }) {
-  requireObject(github, "github");
-  requireObject(context, "context");
-  requireObject(context.repo, "context.repo");
-  requireObject(context.payload, "context.payload");
+  requireObject(github, 'github');
+  requireObject(context, 'context');
+  requireObject(context.repo, 'context.repo');
+  requireObject(context.payload, 'context.payload');
 
   const owner = context.repo.owner;
   const repo = context.repo.repo;
-  requireNonEmptyString(owner, "context.repo.owner");
-  requireNonEmptyString(repo, "context.repo.repo");
+  requireNonEmptyString(owner, 'context.repo.owner');
+  requireNonEmptyString(repo, 'context.repo.repo');
   if (!isSafeSearchToken(owner) || !isSafeSearchToken(repo)) {
-    throw new Error(
-      "Bot context invalid: owner or repo contains invalid characters",
-    );
+    throw new Error('Bot context invalid: owner or repo contains invalid characters');
   }
 
   const base = { github, owner, repo };
 
-  requireNonEmptyString(context.eventName, "context.eventName");
+  requireNonEmptyString(context.eventName, 'context.eventName');
   const eventType = context.eventName;
 
   const { payload } = context;
   let payloadPart;
   switch (eventType) {
-    case "pull_request":
-    case "pull_request_target":
-    case "pull_request_review": {
+    case 'pull_request':
+    case 'pull_request_target':
+    case 'pull_request_review': {
       const pr = payload.pull_request;
-      requireObject(pr, "context.payload.pull_request");
-      requirePositiveInt(pr.number, "pull_request.number");
+      requireObject(pr, 'context.payload.pull_request');
+      requirePositiveInt(pr.number, 'pull_request.number');
 
       if (pr.user) {
-        requireNonEmptyString(pr.user.login, "pull_request.user.login");
+        requireNonEmptyString(pr.user.login, 'pull_request.user.login');
         if (!isSafeSearchToken(pr.user.login)) {
-          throw new Error(
-            "Bot context invalid: pull_request.user.login contains invalid characters",
-          );
+          throw new Error('Bot context invalid: pull_request.user.login contains invalid characters');
         }
       }
 
@@ -77,42 +68,35 @@ function buildBotContext({ github, context }) {
       break;
     }
 
-    case "issues":
-    case "issue_comment": {
+    case 'issues':
+    case 'issue_comment': {
       const issue = payload.issue;
-      requireObject(issue, "context.payload.issue");
-      requirePositiveInt(issue.number, "issue.number");
+      requireObject(issue, 'context.payload.issue');
+      requirePositiveInt(issue.number, 'issue.number');
       payloadPart = { number: issue.number, issue };
 
-      if (eventType === "issue_comment") {
+      if (eventType === 'issue_comment') {
         const comment = payload.comment;
-        requireObject(comment, "context.payload.comment");
-        requireObject(comment.user, "context.payload.comment.user");
-        requireNonEmptyString(
-          comment.user.login,
-          "context.payload.comment.user.login",
-        );
+        requireObject(comment, 'context.payload.comment');
+        requireObject(comment.user, 'context.payload.comment.user');
+        requireNonEmptyString(comment.user.login, 'context.payload.comment.user.login');
 
         // Flag bot users early so callers can skip processing without
         // hitting the stricter username validation below.
-        const isBot = comment.user.type === "Bot";
+        const isBot = comment.user.type === 'Bot';
         if (!isBot && !isSafeSearchToken(comment.user.login)) {
-          throw new Error(
-            "Bot context invalid: comment.user.login contains invalid characters",
-          );
+          throw new Error('Bot context invalid: comment.user.login contains invalid characters');
         }
-        if (typeof comment.body !== "string") {
-          throw new Error("Bot context invalid: comment.body must be a string");
+        if (typeof comment.body !== 'string') {
+          throw new Error('Bot context invalid: comment.body must be a string');
         }
-
+        
         payloadPart = { ...payloadPart, comment, isBot };
       }
       break;
     }
     default:
-      throw new Error(
-        `Bot context invalid: unsupported event type "${eventType}"`,
-      );
+      throw new Error(`Bot context invalid: unsupported event type "${eventType}"`);
   }
   return { ...base, eventType, ...payloadPart };
 }
@@ -125,9 +109,9 @@ function buildBotContext({ github, context }) {
  */
 async function addLabels(botContext, labels) {
   if (!Array.isArray(labels)) {
-    return { success: false, error: "labels must be an array" };
+    return { success: false, error: 'labels must be an array' };
   }
-
+  
   try {
     for (let i = 0; i < labels.length; i++) {
       requireNonEmptyString(labels[i], `labels[${i}]`);
@@ -140,12 +124,10 @@ async function addLabels(botContext, labels) {
       labels,
     });
 
-    getLogger().log(`Added labels: ${labels.join(", ")}`);
+    getLogger().log(`Added labels: ${labels.join(', ')}`);
     return { success: true };
   } catch (error) {
-    getLogger().error(
-      `Could not add labels "${labels.join(", ")}": ${error.message}`,
-    );
+    getLogger().error(`Could not add labels "${labels.join(', ')}": ${error.message}`);
     return { success: false, error: error.message };
   }
 }
@@ -158,7 +140,7 @@ async function addLabels(botContext, labels) {
  */
 async function removeLabel(botContext, labelName) {
   try {
-    requireNonEmptyString(labelName, "labelName");
+    requireNonEmptyString(labelName, 'labelName');
 
     await botContext.github.rest.issues.removeLabel({
       owner: botContext.owner,
@@ -170,9 +152,7 @@ async function removeLabel(botContext, labelName) {
     getLogger().log(`Removed label: ${labelName}`);
     return { success: true };
   } catch (error) {
-    getLogger().error(
-      `Could not remove label "${labelName}": ${error.message}`,
-    );
+    getLogger().error(`Could not remove label "${labelName}": ${error.message}`);
     return { success: false, error: error.message };
   }
 }
@@ -185,7 +165,7 @@ async function removeLabel(botContext, labelName) {
  */
 async function addAssignees(botContext, assignees) {
   if (!Array.isArray(assignees)) {
-    return { success: false, error: "assignees must be an array" };
+    return { success: false, error: 'assignees must be an array' };
   }
 
   try {
@@ -200,12 +180,10 @@ async function addAssignees(botContext, assignees) {
       assignees,
     });
 
-    getLogger().log(`Added assignees: ${assignees.join(", ")}`);
+    getLogger().log(`Added assignees: ${assignees.join(', ')}`);
     return { success: true };
   } catch (error) {
-    getLogger().error(
-      `Could not add assignees "${assignees.join(", ")}": ${error.message}`,
-    );
+    getLogger().error(`Could not add assignees "${assignees.join(', ')}": ${error.message}`);
     return { success: false, error: error.message };
   }
 }
@@ -218,7 +196,7 @@ async function addAssignees(botContext, assignees) {
  */
 async function removeAssignees(botContext, assignees) {
   if (!Array.isArray(assignees)) {
-    return { success: false, error: "assignees must be an array" };
+    return { success: false, error: 'assignees must be an array' };
   }
 
   try {
@@ -233,12 +211,10 @@ async function removeAssignees(botContext, assignees) {
       assignees,
     });
 
-    getLogger().log(`Removed assignees: ${assignees.join(", ")}`);
+    getLogger().log(`Removed assignees: ${assignees.join(', ')}`);
     return { success: true };
   } catch (error) {
-    getLogger().error(
-      `Could not remove assignees "${assignees.join(", ")}": ${error.message}`,
-    );
+    getLogger().error(`Could not remove assignees "${assignees.join(', ')}": ${error.message}`);
     return { success: false, error: error.message };
   }
 }
@@ -251,7 +227,7 @@ async function removeAssignees(botContext, assignees) {
  */
 async function postComment(botContext, body) {
   try {
-    requireNonEmptyString(body, "comment body");
+    requireNonEmptyString(body, 'comment body');
 
     await botContext.github.rest.issues.createComment({
       owner: botContext.owner,
@@ -259,7 +235,7 @@ async function postComment(botContext, body) {
       issue_number: botContext.number,
       body,
     });
-    getLogger().log("Posted comment");
+    getLogger().log('Posted comment');
     return { success: true };
   } catch (error) {
     getLogger().error(`Could not post comment: ${error.message}`);
@@ -279,10 +255,8 @@ function hasLabel(issueOrPr, labelName) {
   }
 
   return issueOrPr.labels.some((label) => {
-    const name = typeof label === "string" ? label : label?.name;
-    return (
-      typeof name === "string" && name.toLowerCase() === labelName.toLowerCase()
-    );
+    const name = typeof label === 'string' ? label : label?.name;
+    return typeof name === 'string' && name.toLowerCase() === labelName.toLowerCase();
   });
 }
 
@@ -296,7 +270,7 @@ function hasLabel(issueOrPr, labelName) {
  */
 function getLabelsByPrefix(issueOrPr, prefix) {
   return (issueOrPr.labels || [])
-    .map((l) => (typeof l === "string" ? l : l?.name || ""))
+    .map((l) => (typeof l === 'string' ? l : l?.name || ''))
     .filter((name) => name.toLowerCase().startsWith(prefix.toLowerCase()));
 }
 
@@ -322,7 +296,7 @@ async function swapLabels(botContext, fromLabel, toLabel) {
     errors.push(`Failed to add '${toLabel}': ${addResult.error}`);
   }
 
-  return { success: errors.length === 0, errorDetails: errors.join("; ") };
+  return { success: errors.length === 0, errorDetails: errors.join('; ') };
 }
 
 /**
@@ -337,18 +311,16 @@ async function getBotComment(botContext, marker) {
   const perPage = 100;
 
   while (true) {
-    const { data: comments } = await botContext.github.rest.issues.listComments(
-      {
-        owner: botContext.owner,
-        repo: botContext.repo,
-        issue_number: botContext.number,
-        per_page: perPage,
-        page,
-      },
-    );
+    const { data: comments } = await botContext.github.rest.issues.listComments({
+      owner: botContext.owner,
+      repo: botContext.repo,
+      issue_number: botContext.number,
+      per_page: perPage,
+      page,
+    });
 
     for (const c of comments) {
-      if (c.user?.type === "Bot" && c.body && c.body.startsWith(marker)) {
+      if (c.user?.type === 'Bot' && c.body && c.body.startsWith(marker)) {
         return c;
       }
     }
@@ -370,14 +342,14 @@ async function getBotComment(botContext, marker) {
  */
 async function postOrUpdateComment(botContext, marker, body) {
   try {
-    requireNonEmptyString(marker, "marker");
-    requireNonEmptyString(body, "comment body");
+    requireNonEmptyString(marker, 'marker');
+    requireNonEmptyString(body, 'comment body');
 
     const existingComment = await getBotComment(botContext, marker);
 
     if (existingComment) {
       if (existingComment.body.trim() === body.trim()) {
-        getLogger().log("Existing bot comment is up-to-date");
+        getLogger().log('Existing bot comment is up-to-date');
       } else {
         await botContext.github.rest.issues.updateComment({
           owner: botContext.owner,
@@ -385,7 +357,7 @@ async function postOrUpdateComment(botContext, marker, body) {
           comment_id: existingComment.id,
           body,
         });
-        getLogger().log("Updated existing bot comment");
+        getLogger().log('Updated existing bot comment');
       }
     } else {
       await botContext.github.rest.issues.createComment({
@@ -394,7 +366,7 @@ async function postOrUpdateComment(botContext, marker, body) {
         issue_number: botContext.number,
         body,
       });
-      getLogger().log("Created new bot comment");
+      getLogger().log('Created new bot comment');
     }
     return { success: true };
   } catch (error) {
@@ -428,9 +400,7 @@ async function fetchPRCommits(botContext) {
     page++;
   }
 
-  getLogger().log(
-    `Fetched ${commits.length} commits for PR #${botContext.number}`,
-  );
+  getLogger().log(`Fetched ${commits.length} commits for PR #${botContext.number}`);
   return commits;
 }
 
@@ -448,7 +418,7 @@ async function fetchOpenPRs(botContext) {
     const response = await botContext.github.rest.pulls.list({
       owner: botContext.owner,
       repo: botContext.repo,
-      state: "open",
+      state: 'open',
       per_page: perPage,
       page,
     });
@@ -499,13 +469,10 @@ async function fetchClosingIssueNumbers(botContext) {
       repo: botContext.repo,
       number: botContext.number,
     });
-    const nodes =
-      result.repository.pullRequest.closingIssuesReferences.nodes || [];
-    return nodes.map((n) => n.number);
+    const nodes = result.repository.pullRequest.closingIssuesReferences.nodes || [];
+    return nodes.map(n => n.number);
   } catch (error) {
-    getLogger().error(
-      `GraphQL closingIssuesReferences failed: ${error.message}`,
-    );
+    getLogger().error(`GraphQL closingIssuesReferences failed: ${error.message}`);
     return [];
   }
 }
@@ -553,12 +520,12 @@ async function acknowledgeComment(botContext, commentId) {
       owner: botContext.owner,
       repo: botContext.repo,
       comment_id: commentId,
-      content: "+1",
+      content: '+1',
     });
-    getLogger().log("Added thumbs-up reaction to comment");
+    getLogger().log('Added thumbs-up reaction to comment');
     return { success: true };
   } catch (error) {
-    getLogger().log("Could not add reaction:", error.message);
+    getLogger().log('Could not add reaction:', error.message);
     return { success: false };
   }
 }
@@ -577,54 +544,33 @@ async function runAllChecksAndComment(botContext, precomputed = {}) {
   try {
     commits = await fetchPRCommits(botContext);
   } catch (e) {
-    getLogger().error("Failed to fetch PR commits:", e.message);
+    getLogger().error('Failed to fetch PR commits:', e.message);
     dco = { error: true, errorMessage: e.message };
     gpg = { error: true, errorMessage: e.message };
   }
 
   if (!dco) {
-    try {
-      dco = checkDCO(commits);
-    } catch (e) {
-      dco = { error: true, errorMessage: e.message };
-    }
+    try { dco = checkDCO(commits); }
+    catch (e) { dco = { error: true, errorMessage: e.message }; }
   }
 
   if (!gpg) {
-    try {
-      gpg = checkGPG(commits);
-    } catch (e) {
-      gpg = { error: true, errorMessage: e.message };
-    }
+    try { gpg = checkGPG(commits); }
+    catch (e) { gpg = { error: true, errorMessage: e.message }; }
   }
 
   if (!merge) {
-    try {
-      merge = await checkMergeConflict(botContext);
-    } catch (e) {
-      merge = { error: true, errorMessage: e.message };
-    }
+    try { merge = await checkMergeConflict(botContext); }
+    catch (e) { merge = { error: true, errorMessage: e.message }; }
   }
 
   if (!issueLink) {
-    try {
-      issueLink = await checkIssueLink(botContext, {
-        fetchIssue,
-        fetchClosingIssueNumbers,
-      });
-    } catch (e) {
-      issueLink = { error: true, errorMessage: e.message };
-    }
+    try { issueLink = await checkIssueLink(botContext, { fetchIssue, fetchClosingIssueNumbers }); }
+    catch (e) { issueLink = { error: true, errorMessage: e.message }; }
   }
 
   const prAuthor = botContext.pr?.user?.login;
-  const { marker, body, allPassed } = buildBotComment({
-    prAuthor,
-    dco,
-    gpg,
-    merge,
-    issueLink,
-  });
+  const { marker, body, allPassed } = buildBotComment({ prAuthor, dco, gpg, merge, issueLink });
   await postOrUpdateComment(botContext, marker, body);
 
   return { allPassed };
@@ -685,9 +631,7 @@ async function fetchComments(botContext) {
     page++;
   }
 
-  getLogger().log(
-    `Fetched ${comments.length} comments for #${botContext.number}`,
-  );
+  getLogger().log(`Fetched ${comments.length} comments for #${botContext.number}`);
   return comments;
 }
 
@@ -702,15 +646,13 @@ async function closeItem(botContext) {
       owner: botContext.owner,
       repo: botContext.repo,
       issue_number: botContext.number,
-      state: "closed",
+      state: 'closed',
     });
 
     getLogger().log(`Closed #${botContext.number}`);
     return { success: true };
   } catch (error) {
-    getLogger().error(
-      `Could not close #${botContext.number}: ${error.message}`,
-    );
+    getLogger().error(`Could not close #${botContext.number}: ${error.message}`);
     return { success: false, error: error.message };
   }
 }
@@ -731,72 +673,60 @@ async function closeItem(botContext) {
  * @returns {Promise<object|null>}
  */
 async function resolveLinkedIssue(botContext) {
-  try {
-    const issueNumbers = await fetchClosingIssueNumbers(botContext);
+    try {
+        const issueNumbers = await fetchClosingIssueNumbers(botContext);
 
-    if (!issueNumbers.length) {
-      getLogger().log("No linked issue found", {
-        prNumber: botContext.number,
-      });
-      return null;
-    }
+        if (!issueNumbers.length) {
+            getLogger().log('No linked issue found', {
+                prNumber: botContext.number,
+            });
+            return null;
+        }
 
-    if (issueNumbers.length === 1) {
-      const issue = await fetchIssue(botContext, issueNumbers[0]);
-      if (
-        !issue ||
-        SKILL_HIERARCHY.findIndex((level) => hasLabel(issue, level)) === -1
-      ) {
-        getLogger().log("Single linked issue has no skill label", {
-          issueNumber: issueNumbers[0],
+        if (issueNumbers.length === 1) {
+            const issue = await fetchIssue(botContext, issueNumbers[0]);
+            if (!issue || SKILL_HIERARCHY.findIndex(level => hasLabel(issue, level)) === -1) {
+                getLogger().log('Single linked issue has no skill label', { issueNumber: issueNumbers[0] });
+                return null;
+            }
+            return issue;
+        }
+
+        const issues = await Promise.all(
+            issueNumbers.map(n => fetchIssue(botContext, n))
+        );
+        const valid = issues.filter(Boolean);
+
+        if (!valid.length) {
+            getLogger().log('All linked issue fetches returned empty', { issueNumbers });
+            return null;
+        }
+
+        const selected = valid.reduce((best, issue) => {
+            const bestIndex = SKILL_HIERARCHY.findIndex(level => hasLabel(best, level));
+            const currIndex = SKILL_HIERARCHY.findIndex(level => hasLabel(issue, level));
+            return currIndex > bestIndex ? issue : best;
+        });
+
+        const selectedIndex = SKILL_HIERARCHY.findIndex(level => hasLabel(selected, level));
+        if (selectedIndex === -1) {
+            getLogger().log('No linked issues have a skill label', { issueNumbers });
+            return null;
+        }
+
+        getLogger().log('Multiple linked issues found (using highest level)', {
+            issueNumbers,
+            selected: selected.number,
+        });
+
+        return selected;
+
+    } catch (error) {
+        getLogger().error('Failed to resolve linked issue:', {
+            message: error.message,
         });
         return null;
-      }
-      return issue;
     }
-
-    const issues = await Promise.all(
-      issueNumbers.map((n) => fetchIssue(botContext, n)),
-    );
-    const valid = issues.filter(Boolean);
-
-    if (!valid.length) {
-      getLogger().log("All linked issue fetches returned empty", {
-        issueNumbers,
-      });
-      return null;
-    }
-
-    const selected = valid.reduce((best, issue) => {
-      const bestIndex = SKILL_HIERARCHY.findIndex((level) =>
-        hasLabel(best, level),
-      );
-      const currIndex = SKILL_HIERARCHY.findIndex((level) =>
-        hasLabel(issue, level),
-      );
-      return currIndex > bestIndex ? issue : best;
-    });
-
-    const selectedIndex = SKILL_HIERARCHY.findIndex((level) =>
-      hasLabel(selected, level),
-    );
-    if (selectedIndex === -1) {
-      getLogger().log("No linked issues have a skill label", { issueNumbers });
-      return null;
-    }
-
-    getLogger().log("Multiple linked issues found (using highest level)", {
-      issueNumbers,
-      selected: selected.number,
-    });
-
-    return selected;
-  } catch (error) {
-    getLogger().error("Failed to resolve linked issue:", {
-      message: error.message,
-    });
-    return null;
-  }
 }
 
 /**

--- a/.github/scripts/tests/test-api.js
+++ b/.github/scripts/tests/test-api.js
@@ -5,7 +5,7 @@
 // Unit tests for helpers/api.js (postOrUpdateComment, fetchPRCommits, swapStatusLabel, etc.).
 // Run with: node .github/scripts/tests/test-api.js
 
-const { runTestSuite } = require('./test-utils');
+const { runTestSuite } = require("./test-utils");
 const {
   getBotComment,
   postOrUpdateComment,
@@ -17,9 +17,9 @@ const {
   hasLabel,
   resolveLinkedIssue,
   getHighestIssueSkillLevel,
-} = require('../helpers/api');
-const { LABELS } = require('../helpers/constants');
-const { isSafeSearchToken } = require('../helpers/validation');
+} = require("../helpers/api");
+const { LABELS } = require("../helpers/constants");
+const { isSafeSearchToken } = require("../helpers/validation");
 
 // =============================================================================
 // MOCK FACTORY
@@ -57,7 +57,7 @@ function createMockBotContext(overrides = {}) {
             },
             get: async ({ issue_number }) => {
               const issue = (overrides.issues || {})[issue_number];
-              if (!issue) throw new Error('Not Found');
+              if (!issue) throw new Error("Not Found");
               return { data: issue };
             },
           },
@@ -86,8 +86,8 @@ function createMockBotContext(overrides = {}) {
             },
           })),
       },
-      owner: 'test',
-      repo: 'repo',
+      owner: "test",
+      repo: "repo",
       number: 1,
       pr: overrides.pr || { labels: [] },
     },
@@ -104,32 +104,32 @@ const unitTests = [
   // hasLabel
   // ---------------------------------------------------------------------------
   {
-    name: 'hasLabel: PR with matching label object → true',
+    name: "hasLabel: PR with matching label object → true",
     test: () => {
       const pr = {
-        labels: [{ name: 'status: needs review' }],
+        labels: [{ name: "status: needs review" }],
       };
       return hasLabel(pr, LABELS.NEEDS_REVIEW) === true;
     },
   },
   {
-    name: 'hasLabel: PR with no matching label → false',
+    name: "hasLabel: PR with no matching label → false",
     test: () => {
       const pr = {
-        labels: [{ name: 'bug' }, { name: 'enhancement' }],
+        labels: [{ name: "bug" }, { name: "enhancement" }],
       };
       return hasLabel(pr, LABELS.NEEDS_REVIEW) === false;
     },
   },
   {
-    name: 'hasLabel: PR with no labels → false',
+    name: "hasLabel: PR with no labels → false",
     test: () => {
       const pr = { labels: [] };
       return hasLabel(pr, LABELS.NEEDS_REVIEW) === false;
     },
   },
   {
-    name: 'hasLabel: PR with null/undefined labels → false',
+    name: "hasLabel: PR with null/undefined labels → false",
     test: () => {
       return (
         hasLabel({ labels: null }, LABELS.NEEDS_REVIEW) === false &&
@@ -138,19 +138,19 @@ const unitTests = [
     },
   },
   {
-    name: 'hasLabel: case insensitive match → true',
+    name: "hasLabel: case insensitive match → true",
     test: () => {
       const pr = {
-        labels: [{ name: 'STATUS: NEEDS REVIEW' }],
+        labels: [{ name: "STATUS: NEEDS REVIEW" }],
       };
-      return hasLabel(pr, 'status: needs review') === true;
+      return hasLabel(pr, "status: needs review") === true;
     },
   },
   {
-    name: 'hasLabel: string labels → true',
+    name: "hasLabel: string labels → true",
     test: () => {
       const pr = {
-        labels: ['status: needs review', 'bug'],
+        labels: ["status: needs review", "bug"],
       };
       return hasLabel(pr, LABELS.NEEDS_REVIEW) === true;
     },
@@ -160,13 +160,17 @@ const unitTests = [
   // getBotComment
   // ---------------------------------------------------------------------------
   {
-    name: 'getBotComment: returns comment matched by marker',
+    name: "getBotComment: returns comment matched by marker",
     test: async () => {
-      const marker = '<!-- bot:test -->';
+      const marker = "<!-- bot:test -->";
       const { botContext } = createMockBotContext({
         comments: [
-          { id: 1, body: 'User comment 1' },
-          { id: 2, body: '<!-- bot:test -->\nBot comment' },
+          { id: 1, body: "User comment 1", user: { type: "User" } },
+          {
+            id: 2,
+            body: "<!-- bot:test -->\nBot comment",
+            user: { type: "Bot" },
+          },
         ],
       });
       const result = await getBotComment(botContext, marker);
@@ -174,12 +178,27 @@ const unitTests = [
     },
   },
   {
-    name: 'getBotComment: returns null if no marker match',
+    name: "getBotComment: returns null if no marker match",
     test: async () => {
-      const marker = '<!-- bot:test -->';
+      const marker = "<!-- bot:test -->";
+      const { botContext } = createMockBotContext({
+        comments: [{ id: 1, body: "User comment 1", user: { type: "User" } }],
+      });
+      const result = await getBotComment(botContext, marker);
+      return result === null;
+    },
+  },
+  {
+    name: "getBotComment: ignores non-bot marker comment",
+    test: async () => {
+      const marker = "<!-- bot:test -->";
       const { botContext } = createMockBotContext({
         comments: [
-          { id: 1, body: 'User comment 1' },
+          {
+            id: 1,
+            body: "<!-- bot:test -->\nHuman marker",
+            user: { type: "User" },
+          },
         ],
       });
       const result = await getBotComment(botContext, marker);
@@ -187,11 +206,23 @@ const unitTests = [
     },
   },
   {
-    name: 'getBotComment: searches across pages',
+    name: "getBotComment: searches across pages",
     test: async () => {
-      const marker = '<!-- bot:paged -->';
-      const page1 = Array(100).fill(null).map((_, i) => ({ id: i + 1, body: `Comment ${i}` }));
-      const page2 = [{ id: 101, body: '<!-- bot:paged -->\nFound on page 2' }];
+      const marker = "<!-- bot:paged -->";
+      const page1 = Array(100)
+        .fill(null)
+        .map((_, i) => ({
+          id: i + 1,
+          body: `Comment ${i}`,
+          user: { type: "User" },
+        }));
+      const page2 = [
+        {
+          id: 101,
+          body: "<!-- bot:paged -->\nFound on page 2",
+          user: { type: "Bot" },
+        },
+      ];
       const { botContext } = createMockBotContext({
         comments: [...page1, ...page2],
       });
@@ -204,13 +235,13 @@ const unitTests = [
   // postOrUpdateComment
   // ---------------------------------------------------------------------------
   {
-    name: 'postOrUpdateComment: no existing comment → creates new',
+    name: "postOrUpdateComment: no existing comment → creates new",
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         comments: [],
       });
-      const marker = '<!-- bot:test -->';
-      const body = '<!-- bot:test -->\nHello';
+      const marker = "<!-- bot:test -->";
+      const body = "<!-- bot:test -->\nHello";
       const result = await postOrUpdateComment(botContext, marker, body);
       return (
         result.success === true &&
@@ -221,15 +252,19 @@ const unitTests = [
     },
   },
   {
-    name: 'postOrUpdateComment: existing comment with marker → updates',
+    name: "postOrUpdateComment: existing comment with marker → updates",
     test: async () => {
-      const marker = '<!-- bot:test -->';
+      const marker = "<!-- bot:test -->";
       const { botContext, calls } = createMockBotContext({
         comments: [
-          { id: 999, body: '<!-- bot:test -->\nOld content' },
+          {
+            id: 999,
+            body: "<!-- bot:test -->\nOld content",
+            user: { type: "Bot" },
+          },
         ],
       });
-      const body = '<!-- bot:test -->\nNew content';
+      const body = "<!-- bot:test -->\nNew content";
       const result = await postOrUpdateComment(botContext, marker, body);
       return (
         result.success === true &&
@@ -241,17 +276,21 @@ const unitTests = [
     },
   },
   {
-    name: 'postOrUpdateComment: multiple comments, one has marker → updates correct one',
+    name: "postOrUpdateComment: multiple comments, one has marker → updates correct one",
     test: async () => {
-      const marker = '<!-- bot:test -->';
+      const marker = "<!-- bot:test -->";
       const { botContext, calls } = createMockBotContext({
         comments: [
-          { id: 1, body: 'User comment 1' },
-          { id: 2, body: '<!-- bot:test -->\nBot comment' },
-          { id: 3, body: 'User comment 2' },
+          { id: 1, body: "User comment 1", user: { type: "User" } },
+          {
+            id: 2,
+            body: "<!-- bot:test -->\nBot comment",
+            user: { type: "Bot" },
+          },
+          { id: 3, body: "User comment 2", user: { type: "User" } },
         ],
       });
-      const body = '<!-- bot:test -->\nUpdated bot';
+      const body = "<!-- bot:test -->\nUpdated bot";
       const result = await postOrUpdateComment(botContext, marker, body);
       return (
         result.success === true &&
@@ -261,33 +300,45 @@ const unitTests = [
     },
   },
   {
-    name: 'postOrUpdateComment: empty comment list → creates new',
+    name: "postOrUpdateComment: empty comment list → creates new",
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         comments: [],
       });
       const result = await postOrUpdateComment(
         botContext,
-        '<!-- bot:x -->',
-        '<!-- bot:x -->\nEmpty'
+        "<!-- bot:x -->",
+        "<!-- bot:x -->\nEmpty",
       );
-      return result.success === true && calls.created.length === 1 && calls.updated.length === 0;
+      return (
+        result.success === true &&
+        calls.created.length === 1 &&
+        calls.updated.length === 0
+      );
     },
   },
   {
-    name: 'postOrUpdateComment: comment on second page → finds and updates',
+    name: "postOrUpdateComment: comment on second page → finds and updates",
     test: async () => {
-      const marker = '<!-- bot:paged -->';
+      const marker = "<!-- bot:paged -->";
       const page1 = Array(100)
         .fill(null)
-        .map((_, i) => ({ id: i + 1, body: `Comment ${i}` }));
+        .map((_, i) => ({
+          id: i + 1,
+          body: `Comment ${i}`,
+          user: { type: "User" },
+        }));
       const page2 = [
-        { id: 101, body: '<!-- bot:paged -->\nFound on page 2' },
+        {
+          id: 101,
+          body: "<!-- bot:paged -->\nFound on page 2",
+          user: { type: "Bot" },
+        },
       ];
       const { botContext, calls } = createMockBotContext({
         comments: [...page1, ...page2],
       });
-      const body = '<!-- bot:paged -->\nUpdated';
+      const body = "<!-- bot:paged -->\nUpdated";
       const result = await postOrUpdateComment(botContext, marker, body);
       return (
         result.success === true &&
@@ -301,24 +352,24 @@ const unitTests = [
   // fetchPRCommits
   // ---------------------------------------------------------------------------
   {
-    name: 'fetchPRCommits: single page (< 100 commits) → returns all',
+    name: "fetchPRCommits: single page (< 100 commits) → returns all",
     test: async () => {
       const commits = [
-        { sha: 'a1', commit: { message: 'First' } },
-        { sha: 'b2', commit: { message: 'Second' } },
+        { sha: "a1", commit: { message: "First" } },
+        { sha: "b2", commit: { message: "Second" } },
       ];
       const { botContext } = createMockBotContext({ commits });
       const result = await fetchPRCommits(botContext);
       return (
         Array.isArray(result) &&
         result.length === 2 &&
-        result[0].sha === 'a1' &&
-        result[1].sha === 'b2'
+        result[0].sha === "a1" &&
+        result[1].sha === "b2"
       );
     },
   },
   {
-    name: 'fetchPRCommits: multiple pages → paginates and returns all',
+    name: "fetchPRCommits: multiple pages → paginates and returns all",
     test: async () => {
       const commits = Array(150)
         .fill(null)
@@ -329,7 +380,7 @@ const unitTests = [
     },
   },
   {
-    name: 'fetchPRCommits: empty PR → returns []',
+    name: "fetchPRCommits: empty PR → returns []",
     test: async () => {
       const { botContext } = createMockBotContext({ commits: [] });
       const result = await fetchPRCommits(botContext);
@@ -341,11 +392,11 @@ const unitTests = [
   // fetchOpenPRs
   // ---------------------------------------------------------------------------
   {
-    name: 'fetchOpenPRs: single page (< 100 PRs) → returns all',
+    name: "fetchOpenPRs: single page (< 100 PRs) → returns all",
     test: async () => {
       const openPRs = [
-        { number: 1, title: 'First PR' },
-        { number: 2, title: 'Second PR' },
+        { number: 1, title: "First PR" },
+        { number: 2, title: "Second PR" },
       ];
       const { botContext } = createMockBotContext({ openPRs });
       const result = await fetchOpenPRs(botContext);
@@ -358,7 +409,7 @@ const unitTests = [
     },
   },
   {
-    name: 'fetchOpenPRs: multiple pages → paginates and returns all',
+    name: "fetchOpenPRs: multiple pages → paginates and returns all",
     test: async () => {
       const openPRs = Array(150)
         .fill(null)
@@ -369,7 +420,7 @@ const unitTests = [
     },
   },
   {
-    name: 'fetchOpenPRs: zero PRs → returns []',
+    name: "fetchOpenPRs: zero PRs → returns []",
     test: async () => {
       const { botContext } = createMockBotContext({ openPRs: [] });
       const result = await fetchOpenPRs(botContext);
@@ -381,25 +432,25 @@ const unitTests = [
   // fetchIssue
   // ---------------------------------------------------------------------------
   {
-    name: 'fetchIssue: valid issue → returns issue data',
+    name: "fetchIssue: valid issue → returns issue data",
     test: async () => {
-      const issueData = { number: 5, title: 'Bug report', state: 'open' };
+      const issueData = { number: 5, title: "Bug report", state: "open" };
       const { botContext } = createMockBotContext({
         issues: { 5: issueData },
       });
       const result = await fetchIssue(botContext, 5);
-      return result.number === 5 && result.title === 'Bug report';
+      return result.number === 5 && result.title === "Bug report";
     },
   },
   {
-    name: 'fetchIssue: missing issue (API throws) → throws',
+    name: "fetchIssue: missing issue (API throws) → throws",
     test: async () => {
       const { botContext } = createMockBotContext({ issues: {} });
       try {
         await fetchIssue(botContext, 999);
         return false;
       } catch (err) {
-        return err.message === 'Not Found';
+        return err.message === "Not Found";
       }
     },
   },
@@ -408,7 +459,7 @@ const unitTests = [
   // fetchClosingIssueNumbers
   // ---------------------------------------------------------------------------
   {
-    name: 'fetchClosingIssueNumbers: 1 closing reference → returns [number]',
+    name: "fetchClosingIssueNumbers: 1 closing reference → returns [number]",
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -426,7 +477,7 @@ const unitTests = [
     },
   },
   {
-    name: 'fetchClosingIssueNumbers: 0 references → returns []',
+    name: "fetchClosingIssueNumbers: 0 references → returns []",
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -442,7 +493,7 @@ const unitTests = [
     },
   },
   {
-    name: 'fetchClosingIssueNumbers: multiple references → returns all',
+    name: "fetchClosingIssueNumbers: multiple references → returns all",
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -465,11 +516,11 @@ const unitTests = [
     },
   },
   {
-    name: 'fetchClosingIssueNumbers: GraphQL fails → returns [] (graceful)',
+    name: "fetchClosingIssueNumbers: GraphQL fails → returns [] (graceful)",
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => {
-          throw new Error('GraphQL error');
+          throw new Error("GraphQL error");
         },
       });
       const result = await fetchClosingIssueNumbers(botContext);
@@ -481,7 +532,7 @@ const unitTests = [
   // resolveLinkedIssue
   // ---------------------------------------------------------------------------
   {
-    name: 'resolveLinkedIssue: no linked issues → returns null',
+    name: "resolveLinkedIssue: no linked issues → returns null",
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -497,9 +548,13 @@ const unitTests = [
     },
   },
   {
-    name: 'resolveLinkedIssue: single linked issue with skill label → returns it',
+    name: "resolveLinkedIssue: single linked issue with skill label → returns it",
     test: async () => {
-      const issueData = { number: 10, title: 'Fix bug', labels: [{ name: LABELS.BEGINNER }] };
+      const issueData = {
+        number: 10,
+        title: "Fix bug",
+        labels: [{ name: LABELS.BEGINNER }],
+      };
       const { botContext } = createMockBotContext({
         graphql: async () => ({
           repository: {
@@ -515,7 +570,7 @@ const unitTests = [
     },
   },
   {
-    name: 'resolveLinkedIssue: single linked issue with no skill label → returns null',
+    name: "resolveLinkedIssue: single linked issue with no skill label → returns null",
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -528,7 +583,7 @@ const unitTests = [
           },
         }),
         issues: {
-          7: { number: 7, title: 'Issue 7', labels: [{ name: 'bug' }] },
+          7: { number: 7, title: "Issue 7", labels: [{ name: "bug" }] },
         },
       });
       const result = await resolveLinkedIssue(botContext);
@@ -536,7 +591,7 @@ const unitTests = [
     },
   },
   {
-    name: 'resolveLinkedIssue: multiple linked issues with skill label → returns highest skill level',
+    name: "resolveLinkedIssue: multiple linked issues with skill label → returns highest skill level",
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -549,9 +604,21 @@ const unitTests = [
           },
         }),
         issues: {
-          1: { number: 1, title: 'GFI issue',          labels: [{ name: LABELS.GOOD_FIRST_ISSUE }] },
-          2: { number: 2, title: 'Intermediate issue',  labels: [{ name: LABELS.INTERMEDIATE }] },
-          3: { number: 3, title: 'Beginner issue',      labels: [{ name: LABELS.BEGINNER }] },
+          1: {
+            number: 1,
+            title: "GFI issue",
+            labels: [{ name: LABELS.GOOD_FIRST_ISSUE }],
+          },
+          2: {
+            number: 2,
+            title: "Intermediate issue",
+            labels: [{ name: LABELS.INTERMEDIATE }],
+          },
+          3: {
+            number: 3,
+            title: "Beginner issue",
+            labels: [{ name: LABELS.BEGINNER }],
+          },
         },
       });
       const result = await resolveLinkedIssue(botContext);
@@ -559,7 +626,7 @@ const unitTests = [
     },
   },
   {
-    name: 'resolveLinkedIssue: multiple linked issues with no skill label → returns null',
+    name: "resolveLinkedIssue: multiple linked issues with no skill label → returns null",
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -572,8 +639,8 @@ const unitTests = [
           },
         }),
         issues: {
-          4: { number: 4, title: 'Issue 4', labels: [{ name: 'bug' }] },
-          5: { number: 5, title: 'Issue 5', labels: [{ name: 'enhancement' }] },
+          4: { number: 4, title: "Issue 4", labels: [{ name: "bug" }] },
+          5: { number: 5, title: "Issue 5", labels: [{ name: "enhancement" }] },
         },
       });
       const result = await resolveLinkedIssue(botContext);
@@ -581,17 +648,19 @@ const unitTests = [
     },
   },
   {
-    name: 'resolveLinkedIssue: GraphQL fails → returns null gracefully',
+    name: "resolveLinkedIssue: GraphQL fails → returns null gracefully",
     test: async () => {
       const { botContext } = createMockBotContext({
-        graphql: async () => { throw new Error('GraphQL error'); },
+        graphql: async () => {
+          throw new Error("GraphQL error");
+        },
       });
       const result = await resolveLinkedIssue(botContext);
       return result === null;
     },
   },
   {
-    name: 'resolveLinkedIssue: issue fetch fails for all linked issues → returns null',
+    name: "resolveLinkedIssue: issue fetch fails for all linked issues → returns null",
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -614,7 +683,7 @@ const unitTests = [
   // swapStatusLabel
   // ---------------------------------------------------------------------------
   {
-    name: 'swapStatusLabel: allPassed true, has NEEDS_REVISION → removes revision, adds review',
+    name: "swapStatusLabel: allPassed true, has NEEDS_REVISION → removes revision, adds review",
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         pr: { labels: [{ name: LABELS.NEEDS_REVISION }] },
@@ -630,7 +699,7 @@ const unitTests = [
     },
   },
   {
-    name: 'swapStatusLabel: allPassed true, has NEEDS_REVIEW → no-op',
+    name: "swapStatusLabel: allPassed true, has NEEDS_REVIEW → no-op",
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         pr: { labels: [{ name: LABELS.NEEDS_REVIEW }] },
@@ -640,17 +709,17 @@ const unitTests = [
     },
   },
   {
-    name: 'swapStatusLabel: allPassed true, no status label → no-op',
+    name: "swapStatusLabel: allPassed true, no status label → no-op",
     test: async () => {
       const { botContext, calls } = createMockBotContext({
-        pr: { labels: [{ name: 'bug' }] },
+        pr: { labels: [{ name: "bug" }] },
       });
       await swapStatusLabel(botContext, true);
       return calls.labelsRemoved.length === 0 && calls.labelsAdded.length === 0;
     },
   },
   {
-    name: 'swapStatusLabel: allPassed false, has NEEDS_REVIEW → removes review, adds revision',
+    name: "swapStatusLabel: allPassed false, has NEEDS_REVIEW → removes review, adds revision",
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         pr: { labels: [{ name: LABELS.NEEDS_REVIEW }] },
@@ -666,7 +735,7 @@ const unitTests = [
     },
   },
   {
-    name: 'swapStatusLabel: allPassed false, has NEEDS_REVISION → no-op',
+    name: "swapStatusLabel: allPassed false, has NEEDS_REVISION → no-op",
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         pr: { labels: [{ name: LABELS.NEEDS_REVISION }] },
@@ -676,7 +745,7 @@ const unitTests = [
     },
   },
   {
-    name: 'swapStatusLabel: allPassed false, no status label → no-op',
+    name: "swapStatusLabel: allPassed false, no status label → no-op",
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         pr: { labels: [] },
@@ -690,58 +759,74 @@ const unitTests = [
   // SafeSearchToken
   // ---------------------------------------------------------------------------
   {
-    name: 'isSafeSearchToken: dependabot[bot] → true',
-    test: () => isSafeSearchToken('dependabot[bot]') === true,
+    name: "isSafeSearchToken: dependabot[bot] → true",
+    test: () => isSafeSearchToken("dependabot[bot]") === true,
   },
   {
-    name: 'isSafeSearchToken: string with spaces → false',
-    test: () => isSafeSearchToken('bad username') === false,
+    name: "isSafeSearchToken: string with spaces → false",
+    test: () => isSafeSearchToken("bad username") === false,
   },
   {
-    name: 'isSafeSearchToken: string with angle brackets → false',
-    test: () => isSafeSearchToken('bad<username>') === false,
+    name: "isSafeSearchToken: string with angle brackets → false",
+    test: () => isSafeSearchToken("bad<username>") === false,
   },
   {
-    name: 'isSafeSearchToken: string with semicolon → false',
-    test: () => isSafeSearchToken('bad;username') === false,
+    name: "isSafeSearchToken: string with semicolon → false",
+    test: () => isSafeSearchToken("bad;username") === false,
   },
   {
-    name: 'isSafeSearchToken: string with brackets but not bot inside → false',
-    test: () => isSafeSearchToken('bad[admin]') === false,
+    name: "isSafeSearchToken: string with brackets but not bot inside → false",
+    test: () => isSafeSearchToken("bad[admin]") === false,
   },
   {
-    name: 'isSafeSearchToken: string with multiple brackets → false',
-    test: () => isSafeSearchToken('bad[[admin]') === false,
+    name: "isSafeSearchToken: string with multiple brackets → false",
+    test: () => isSafeSearchToken("bad[[admin]") === false,
   },
 
   // ---------------------------------------------------------------------------
   // getHighestIssueSkillLevel
   // ---------------------------------------------------------------------------
   {
-    name: 'getHighestIssueSkillLevel: issue with one skill label → returns that level',
+    name: "getHighestIssueSkillLevel: issue with one skill label → returns that level",
     test: () => {
-      const issue = { number: 1, title: 'Test', labels: [{ name: LABELS.BEGINNER }, { name: LABELS.READY_FOR_DEV }] };
+      const issue = {
+        number: 1,
+        title: "Test",
+        labels: [{ name: LABELS.BEGINNER }, { name: LABELS.READY_FOR_DEV }],
+      };
       return getHighestIssueSkillLevel(issue) === LABELS.BEGINNER;
     },
   },
   {
-    name: 'getHighestIssueSkillLevel: issue with no skill labels → returns null',
+    name: "getHighestIssueSkillLevel: issue with no skill labels → returns null",
     test: () => {
-      const issue = { number: 1, title: 'Test', labels: [{ name: 'bug' }, { name: 'enhancement' }] };
+      const issue = {
+        number: 1,
+        title: "Test",
+        labels: [{ name: "bug" }, { name: "enhancement" }],
+      };
       return getHighestIssueSkillLevel(issue) === null;
     },
   },
   {
-    name: 'getHighestIssueSkillLevel: issue with multiple skill labels → returns highest',
+    name: "getHighestIssueSkillLevel: issue with multiple skill labels → returns highest",
     test: () => {
-      const issue = { number: 1, title: 'Test', labels: [{ name: LABELS.GOOD_FIRST_ISSUE }, { name: LABELS.BEGINNER }, { name: LABELS.INTERMEDIATE }] };
+      const issue = {
+        number: 1,
+        title: "Test",
+        labels: [
+          { name: LABELS.GOOD_FIRST_ISSUE },
+          { name: LABELS.BEGINNER },
+          { name: LABELS.INTERMEDIATE },
+        ],
+      };
       return getHighestIssueSkillLevel(issue) === LABELS.INTERMEDIATE;
     },
   },
   {
-    name: 'getHighestIssueSkillLevel: issue with empty labels → returns null',
+    name: "getHighestIssueSkillLevel: issue with empty labels → returns null",
     test: () => {
-      const issue = { number: 1, title: 'Test', labels: [] };
+      const issue = { number: 1, title: "Test", labels: [] };
       return getHighestIssueSkillLevel(issue) === null;
     },
   },
@@ -751,8 +836,8 @@ const unitTests = [
 // =============================================================================
 
 async function runUnitTests() {
-  console.log('🔬 UNIT TESTS (api)');
-  console.log('='.repeat(70));
+  console.log("🔬 UNIT TESTS (api)");
+  console.log("=".repeat(70));
   let passed = 0;
   let failed = 0;
   for (const test of unitTests) {
@@ -770,11 +855,11 @@ async function runUnitTests() {
       failed++;
     }
   }
-  console.log('\n' + '-'.repeat(70));
+  console.log("\n" + "-".repeat(70));
   console.log(`Unit Tests: ${passed} passed, ${failed} failed`);
   return { total: unitTests.length, passed, failed };
 }
 
-runTestSuite('API HELPERS TEST SUITE', [], async () => true, [
-  { label: 'Unit Tests', run: runUnitTests },
+runTestSuite("API HELPERS TEST SUITE", [], async () => true, [
+  { label: "Unit Tests", run: runUnitTests },
 ]);

--- a/.github/scripts/tests/test-api.js
+++ b/.github/scripts/tests/test-api.js
@@ -5,7 +5,7 @@
 // Unit tests for helpers/api.js (postOrUpdateComment, fetchPRCommits, swapStatusLabel, etc.).
 // Run with: node .github/scripts/tests/test-api.js
 
-const { runTestSuite } = require("./test-utils");
+const { runTestSuite } = require('./test-utils');
 const {
   getBotComment,
   postOrUpdateComment,
@@ -17,9 +17,9 @@ const {
   hasLabel,
   resolveLinkedIssue,
   getHighestIssueSkillLevel,
-} = require("../helpers/api");
-const { LABELS } = require("../helpers/constants");
-const { isSafeSearchToken } = require("../helpers/validation");
+} = require('../helpers/api');
+const { LABELS } = require('../helpers/constants');
+const { isSafeSearchToken } = require('../helpers/validation');
 
 // =============================================================================
 // MOCK FACTORY
@@ -57,7 +57,7 @@ function createMockBotContext(overrides = {}) {
             },
             get: async ({ issue_number }) => {
               const issue = (overrides.issues || {})[issue_number];
-              if (!issue) throw new Error("Not Found");
+              if (!issue) throw new Error('Not Found');
               return { data: issue };
             },
           },
@@ -86,8 +86,8 @@ function createMockBotContext(overrides = {}) {
             },
           })),
       },
-      owner: "test",
-      repo: "repo",
+      owner: 'test',
+      repo: 'repo',
       number: 1,
       pr: overrides.pr || { labels: [] },
     },
@@ -104,32 +104,32 @@ const unitTests = [
   // hasLabel
   // ---------------------------------------------------------------------------
   {
-    name: "hasLabel: PR with matching label object → true",
+    name: 'hasLabel: PR with matching label object → true',
     test: () => {
       const pr = {
-        labels: [{ name: "status: needs review" }],
+        labels: [{ name: 'status: needs review' }],
       };
       return hasLabel(pr, LABELS.NEEDS_REVIEW) === true;
     },
   },
   {
-    name: "hasLabel: PR with no matching label → false",
+    name: 'hasLabel: PR with no matching label → false',
     test: () => {
       const pr = {
-        labels: [{ name: "bug" }, { name: "enhancement" }],
+        labels: [{ name: 'bug' }, { name: 'enhancement' }],
       };
       return hasLabel(pr, LABELS.NEEDS_REVIEW) === false;
     },
   },
   {
-    name: "hasLabel: PR with no labels → false",
+    name: 'hasLabel: PR with no labels → false',
     test: () => {
       const pr = { labels: [] };
       return hasLabel(pr, LABELS.NEEDS_REVIEW) === false;
     },
   },
   {
-    name: "hasLabel: PR with null/undefined labels → false",
+    name: 'hasLabel: PR with null/undefined labels → false',
     test: () => {
       return (
         hasLabel({ labels: null }, LABELS.NEEDS_REVIEW) === false &&
@@ -138,19 +138,19 @@ const unitTests = [
     },
   },
   {
-    name: "hasLabel: case insensitive match → true",
+    name: 'hasLabel: case insensitive match → true',
     test: () => {
       const pr = {
-        labels: [{ name: "STATUS: NEEDS REVIEW" }],
+        labels: [{ name: 'STATUS: NEEDS REVIEW' }],
       };
-      return hasLabel(pr, "status: needs review") === true;
+      return hasLabel(pr, 'status: needs review') === true;
     },
   },
   {
-    name: "hasLabel: string labels → true",
+    name: 'hasLabel: string labels → true',
     test: () => {
       const pr = {
-        labels: ["status: needs review", "bug"],
+        labels: ['status: needs review', 'bug'],
       };
       return hasLabel(pr, LABELS.NEEDS_REVIEW) === true;
     },
@@ -160,17 +160,13 @@ const unitTests = [
   // getBotComment
   // ---------------------------------------------------------------------------
   {
-    name: "getBotComment: returns comment matched by marker",
+    name: 'getBotComment: returns comment matched by marker',
     test: async () => {
-      const marker = "<!-- bot:test -->";
+      const marker = '<!-- bot:test -->';
       const { botContext } = createMockBotContext({
         comments: [
-          { id: 1, body: "User comment 1", user: { type: "User" } },
-          {
-            id: 2,
-            body: "<!-- bot:test -->\nBot comment",
-            user: { type: "Bot" },
-          },
+          { id: 1, body: 'User comment 1', user: { type: 'User' } },
+          { id: 2, body: '<!-- bot:test -->\nBot comment', user: { type: 'Bot' } },
         ],
       });
       const result = await getBotComment(botContext, marker);
@@ -178,27 +174,23 @@ const unitTests = [
     },
   },
   {
-    name: "getBotComment: returns null if no marker match",
+    name: 'getBotComment: returns null if no marker match',
     test: async () => {
-      const marker = "<!-- bot:test -->";
+      const marker = '<!-- bot:test -->';
       const { botContext } = createMockBotContext({
-        comments: [{ id: 1, body: "User comment 1", user: { type: "User" } }],
+        comments: [{ id: 1, body: 'User comment 1', user: { type: 'User' } }],
       });
       const result = await getBotComment(botContext, marker);
       return result === null;
     },
   },
   {
-    name: "getBotComment: ignores non-bot marker comment",
+    name: 'getBotComment: ignores non-bot marker comment',
     test: async () => {
-      const marker = "<!-- bot:test -->";
+      const marker = '<!-- bot:test -->';
       const { botContext } = createMockBotContext({
         comments: [
-          {
-            id: 1,
-            body: "<!-- bot:test -->\nHuman marker",
-            user: { type: "User" },
-          },
+          { id: 1, body: '<!-- bot:test -->\nHuman marker', user: { type: 'User' } },
         ],
       });
       const result = await getBotComment(botContext, marker);
@@ -206,23 +198,13 @@ const unitTests = [
     },
   },
   {
-    name: "getBotComment: searches across pages",
+    name: 'getBotComment: searches across pages',
     test: async () => {
-      const marker = "<!-- bot:paged -->";
+      const marker = '<!-- bot:paged -->';
       const page1 = Array(100)
         .fill(null)
-        .map((_, i) => ({
-          id: i + 1,
-          body: `Comment ${i}`,
-          user: { type: "User" },
-        }));
-      const page2 = [
-        {
-          id: 101,
-          body: "<!-- bot:paged -->\nFound on page 2",
-          user: { type: "Bot" },
-        },
-      ];
+        .map((_, i) => ({ id: i + 1, body: `Comment ${i}`, user: { type: 'User' } }));
+      const page2 = [{ id: 101, body: '<!-- bot:paged -->\nFound on page 2', user: { type: 'Bot' } }];
       const { botContext } = createMockBotContext({
         comments: [...page1, ...page2],
       });
@@ -235,13 +217,13 @@ const unitTests = [
   // postOrUpdateComment
   // ---------------------------------------------------------------------------
   {
-    name: "postOrUpdateComment: no existing comment → creates new",
+    name: 'postOrUpdateComment: no existing comment → creates new',
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         comments: [],
       });
-      const marker = "<!-- bot:test -->";
-      const body = "<!-- bot:test -->\nHello";
+      const marker = '<!-- bot:test -->';
+      const body = '<!-- bot:test -->\nHello';
       const result = await postOrUpdateComment(botContext, marker, body);
       return (
         result.success === true &&
@@ -252,19 +234,13 @@ const unitTests = [
     },
   },
   {
-    name: "postOrUpdateComment: existing comment with marker → updates",
+    name: 'postOrUpdateComment: existing comment with marker → updates',
     test: async () => {
-      const marker = "<!-- bot:test -->";
+      const marker = '<!-- bot:test -->';
       const { botContext, calls } = createMockBotContext({
-        comments: [
-          {
-            id: 999,
-            body: "<!-- bot:test -->\nOld content",
-            user: { type: "Bot" },
-          },
-        ],
+        comments: [{ id: 999, body: '<!-- bot:test -->\nOld content', user: { type: 'Bot' } }],
       });
-      const body = "<!-- bot:test -->\nNew content";
+      const body = '<!-- bot:test -->\nNew content';
       const result = await postOrUpdateComment(botContext, marker, body);
       return (
         result.success === true &&
@@ -276,21 +252,17 @@ const unitTests = [
     },
   },
   {
-    name: "postOrUpdateComment: multiple comments, one has marker → updates correct one",
+    name: 'postOrUpdateComment: multiple comments, one has marker → updates correct one',
     test: async () => {
-      const marker = "<!-- bot:test -->";
+      const marker = '<!-- bot:test -->';
       const { botContext, calls } = createMockBotContext({
         comments: [
-          { id: 1, body: "User comment 1", user: { type: "User" } },
-          {
-            id: 2,
-            body: "<!-- bot:test -->\nBot comment",
-            user: { type: "Bot" },
-          },
-          { id: 3, body: "User comment 2", user: { type: "User" } },
+          { id: 1, body: 'User comment 1', user: { type: 'User' } },
+          { id: 2, body: '<!-- bot:test -->\nBot comment', user: { type: 'Bot' } },
+          { id: 3, body: 'User comment 2', user: { type: 'User' } },
         ],
       });
-      const body = "<!-- bot:test -->\nUpdated bot";
+      const body = '<!-- bot:test -->\nUpdated bot';
       const result = await postOrUpdateComment(botContext, marker, body);
       return (
         result.success === true &&
@@ -300,45 +272,31 @@ const unitTests = [
     },
   },
   {
-    name: "postOrUpdateComment: empty comment list → creates new",
+    name: 'postOrUpdateComment: empty comment list → creates new',
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         comments: [],
       });
       const result = await postOrUpdateComment(
         botContext,
-        "<!-- bot:x -->",
-        "<!-- bot:x -->\nEmpty",
+        '<!-- bot:x -->',
+        '<!-- bot:x -->\nEmpty'
       );
-      return (
-        result.success === true &&
-        calls.created.length === 1 &&
-        calls.updated.length === 0
-      );
+      return result.success === true && calls.created.length === 1 && calls.updated.length === 0;
     },
   },
   {
-    name: "postOrUpdateComment: comment on second page → finds and updates",
+    name: 'postOrUpdateComment: comment on second page → finds and updates',
     test: async () => {
-      const marker = "<!-- bot:paged -->";
+      const marker = '<!-- bot:paged -->';
       const page1 = Array(100)
         .fill(null)
-        .map((_, i) => ({
-          id: i + 1,
-          body: `Comment ${i}`,
-          user: { type: "User" },
-        }));
-      const page2 = [
-        {
-          id: 101,
-          body: "<!-- bot:paged -->\nFound on page 2",
-          user: { type: "Bot" },
-        },
-      ];
+        .map((_, i) => ({ id: i + 1, body: `Comment ${i}`, user: { type: 'User' } }));
+      const page2 = [{ id: 101, body: '<!-- bot:paged -->\nFound on page 2', user: { type: 'Bot' } }];
       const { botContext, calls } = createMockBotContext({
         comments: [...page1, ...page2],
       });
-      const body = "<!-- bot:paged -->\nUpdated";
+      const body = '<!-- bot:paged -->\nUpdated';
       const result = await postOrUpdateComment(botContext, marker, body);
       return (
         result.success === true &&
@@ -352,24 +310,24 @@ const unitTests = [
   // fetchPRCommits
   // ---------------------------------------------------------------------------
   {
-    name: "fetchPRCommits: single page (< 100 commits) → returns all",
+    name: 'fetchPRCommits: single page (< 100 commits) → returns all',
     test: async () => {
       const commits = [
-        { sha: "a1", commit: { message: "First" } },
-        { sha: "b2", commit: { message: "Second" } },
+        { sha: 'a1', commit: { message: 'First' } },
+        { sha: 'b2', commit: { message: 'Second' } },
       ];
       const { botContext } = createMockBotContext({ commits });
       const result = await fetchPRCommits(botContext);
       return (
         Array.isArray(result) &&
         result.length === 2 &&
-        result[0].sha === "a1" &&
-        result[1].sha === "b2"
+        result[0].sha === 'a1' &&
+        result[1].sha === 'b2'
       );
     },
   },
   {
-    name: "fetchPRCommits: multiple pages → paginates and returns all",
+    name: 'fetchPRCommits: multiple pages → paginates and returns all',
     test: async () => {
       const commits = Array(150)
         .fill(null)
@@ -380,7 +338,7 @@ const unitTests = [
     },
   },
   {
-    name: "fetchPRCommits: empty PR → returns []",
+    name: 'fetchPRCommits: empty PR → returns []',
     test: async () => {
       const { botContext } = createMockBotContext({ commits: [] });
       const result = await fetchPRCommits(botContext);
@@ -392,11 +350,11 @@ const unitTests = [
   // fetchOpenPRs
   // ---------------------------------------------------------------------------
   {
-    name: "fetchOpenPRs: single page (< 100 PRs) → returns all",
+    name: 'fetchOpenPRs: single page (< 100 PRs) → returns all',
     test: async () => {
       const openPRs = [
-        { number: 1, title: "First PR" },
-        { number: 2, title: "Second PR" },
+        { number: 1, title: 'First PR' },
+        { number: 2, title: 'Second PR' },
       ];
       const { botContext } = createMockBotContext({ openPRs });
       const result = await fetchOpenPRs(botContext);
@@ -409,7 +367,7 @@ const unitTests = [
     },
   },
   {
-    name: "fetchOpenPRs: multiple pages → paginates and returns all",
+    name: 'fetchOpenPRs: multiple pages → paginates and returns all',
     test: async () => {
       const openPRs = Array(150)
         .fill(null)
@@ -420,7 +378,7 @@ const unitTests = [
     },
   },
   {
-    name: "fetchOpenPRs: zero PRs → returns []",
+    name: 'fetchOpenPRs: zero PRs → returns []',
     test: async () => {
       const { botContext } = createMockBotContext({ openPRs: [] });
       const result = await fetchOpenPRs(botContext);
@@ -432,25 +390,25 @@ const unitTests = [
   // fetchIssue
   // ---------------------------------------------------------------------------
   {
-    name: "fetchIssue: valid issue → returns issue data",
+    name: 'fetchIssue: valid issue → returns issue data',
     test: async () => {
-      const issueData = { number: 5, title: "Bug report", state: "open" };
+      const issueData = { number: 5, title: 'Bug report', state: 'open' };
       const { botContext } = createMockBotContext({
         issues: { 5: issueData },
       });
       const result = await fetchIssue(botContext, 5);
-      return result.number === 5 && result.title === "Bug report";
+      return result.number === 5 && result.title === 'Bug report';
     },
   },
   {
-    name: "fetchIssue: missing issue (API throws) → throws",
+    name: 'fetchIssue: missing issue (API throws) → throws',
     test: async () => {
       const { botContext } = createMockBotContext({ issues: {} });
       try {
         await fetchIssue(botContext, 999);
         return false;
       } catch (err) {
-        return err.message === "Not Found";
+        return err.message === 'Not Found';
       }
     },
   },
@@ -459,7 +417,7 @@ const unitTests = [
   // fetchClosingIssueNumbers
   // ---------------------------------------------------------------------------
   {
-    name: "fetchClosingIssueNumbers: 1 closing reference → returns [number]",
+    name: 'fetchClosingIssueNumbers: 1 closing reference → returns [number]',
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -477,7 +435,7 @@ const unitTests = [
     },
   },
   {
-    name: "fetchClosingIssueNumbers: 0 references → returns []",
+    name: 'fetchClosingIssueNumbers: 0 references → returns []',
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -493,7 +451,7 @@ const unitTests = [
     },
   },
   {
-    name: "fetchClosingIssueNumbers: multiple references → returns all",
+    name: 'fetchClosingIssueNumbers: multiple references → returns all',
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -516,11 +474,11 @@ const unitTests = [
     },
   },
   {
-    name: "fetchClosingIssueNumbers: GraphQL fails → returns [] (graceful)",
+    name: 'fetchClosingIssueNumbers: GraphQL fails → returns [] (graceful)',
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => {
-          throw new Error("GraphQL error");
+          throw new Error('GraphQL error');
         },
       });
       const result = await fetchClosingIssueNumbers(botContext);
@@ -532,7 +490,7 @@ const unitTests = [
   // resolveLinkedIssue
   // ---------------------------------------------------------------------------
   {
-    name: "resolveLinkedIssue: no linked issues → returns null",
+    name: 'resolveLinkedIssue: no linked issues → returns null',
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -548,13 +506,9 @@ const unitTests = [
     },
   },
   {
-    name: "resolveLinkedIssue: single linked issue with skill label → returns it",
+    name: 'resolveLinkedIssue: single linked issue with skill label → returns it',
     test: async () => {
-      const issueData = {
-        number: 10,
-        title: "Fix bug",
-        labels: [{ name: LABELS.BEGINNER }],
-      };
+      const issueData = { number: 10, title: 'Fix bug', labels: [{ name: LABELS.BEGINNER }] };
       const { botContext } = createMockBotContext({
         graphql: async () => ({
           repository: {
@@ -570,7 +524,7 @@ const unitTests = [
     },
   },
   {
-    name: "resolveLinkedIssue: single linked issue with no skill label → returns null",
+    name: 'resolveLinkedIssue: single linked issue with no skill label → returns null',
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -583,7 +537,7 @@ const unitTests = [
           },
         }),
         issues: {
-          7: { number: 7, title: "Issue 7", labels: [{ name: "bug" }] },
+          7: { number: 7, title: 'Issue 7', labels: [{ name: 'bug' }] },
         },
       });
       const result = await resolveLinkedIssue(botContext);
@@ -591,7 +545,7 @@ const unitTests = [
     },
   },
   {
-    name: "resolveLinkedIssue: multiple linked issues with skill label → returns highest skill level",
+    name: 'resolveLinkedIssue: multiple linked issues with skill label → returns highest skill level',
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -604,21 +558,9 @@ const unitTests = [
           },
         }),
         issues: {
-          1: {
-            number: 1,
-            title: "GFI issue",
-            labels: [{ name: LABELS.GOOD_FIRST_ISSUE }],
-          },
-          2: {
-            number: 2,
-            title: "Intermediate issue",
-            labels: [{ name: LABELS.INTERMEDIATE }],
-          },
-          3: {
-            number: 3,
-            title: "Beginner issue",
-            labels: [{ name: LABELS.BEGINNER }],
-          },
+          1: { number: 1, title: 'GFI issue',          labels: [{ name: LABELS.GOOD_FIRST_ISSUE }] },
+          2: { number: 2, title: 'Intermediate issue',  labels: [{ name: LABELS.INTERMEDIATE }] },
+          3: { number: 3, title: 'Beginner issue',      labels: [{ name: LABELS.BEGINNER }] },
         },
       });
       const result = await resolveLinkedIssue(botContext);
@@ -626,7 +568,7 @@ const unitTests = [
     },
   },
   {
-    name: "resolveLinkedIssue: multiple linked issues with no skill label → returns null",
+    name: 'resolveLinkedIssue: multiple linked issues with no skill label → returns null',
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -639,8 +581,8 @@ const unitTests = [
           },
         }),
         issues: {
-          4: { number: 4, title: "Issue 4", labels: [{ name: "bug" }] },
-          5: { number: 5, title: "Issue 5", labels: [{ name: "enhancement" }] },
+          4: { number: 4, title: 'Issue 4', labels: [{ name: 'bug' }] },
+          5: { number: 5, title: 'Issue 5', labels: [{ name: 'enhancement' }] },
         },
       });
       const result = await resolveLinkedIssue(botContext);
@@ -648,19 +590,17 @@ const unitTests = [
     },
   },
   {
-    name: "resolveLinkedIssue: GraphQL fails → returns null gracefully",
+    name: 'resolveLinkedIssue: GraphQL fails → returns null gracefully',
     test: async () => {
       const { botContext } = createMockBotContext({
-        graphql: async () => {
-          throw new Error("GraphQL error");
-        },
+        graphql: async () => { throw new Error('GraphQL error'); },
       });
       const result = await resolveLinkedIssue(botContext);
       return result === null;
     },
   },
   {
-    name: "resolveLinkedIssue: issue fetch fails for all linked issues → returns null",
+    name: 'resolveLinkedIssue: issue fetch fails for all linked issues → returns null',
     test: async () => {
       const { botContext } = createMockBotContext({
         graphql: async () => ({
@@ -683,7 +623,7 @@ const unitTests = [
   // swapStatusLabel
   // ---------------------------------------------------------------------------
   {
-    name: "swapStatusLabel: allPassed true, has NEEDS_REVISION → removes revision, adds review",
+    name: 'swapStatusLabel: allPassed true, has NEEDS_REVISION → removes revision, adds review',
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         pr: { labels: [{ name: LABELS.NEEDS_REVISION }] },
@@ -699,7 +639,7 @@ const unitTests = [
     },
   },
   {
-    name: "swapStatusLabel: allPassed true, has NEEDS_REVIEW → no-op",
+    name: 'swapStatusLabel: allPassed true, has NEEDS_REVIEW → no-op',
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         pr: { labels: [{ name: LABELS.NEEDS_REVIEW }] },
@@ -709,17 +649,17 @@ const unitTests = [
     },
   },
   {
-    name: "swapStatusLabel: allPassed true, no status label → no-op",
+    name: 'swapStatusLabel: allPassed true, no status label → no-op',
     test: async () => {
       const { botContext, calls } = createMockBotContext({
-        pr: { labels: [{ name: "bug" }] },
+        pr: { labels: [{ name: 'bug' }] },
       });
       await swapStatusLabel(botContext, true);
       return calls.labelsRemoved.length === 0 && calls.labelsAdded.length === 0;
     },
   },
   {
-    name: "swapStatusLabel: allPassed false, has NEEDS_REVIEW → removes review, adds revision",
+    name: 'swapStatusLabel: allPassed false, has NEEDS_REVIEW → removes review, adds revision',
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         pr: { labels: [{ name: LABELS.NEEDS_REVIEW }] },
@@ -735,7 +675,7 @@ const unitTests = [
     },
   },
   {
-    name: "swapStatusLabel: allPassed false, has NEEDS_REVISION → no-op",
+    name: 'swapStatusLabel: allPassed false, has NEEDS_REVISION → no-op',
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         pr: { labels: [{ name: LABELS.NEEDS_REVISION }] },
@@ -745,7 +685,7 @@ const unitTests = [
     },
   },
   {
-    name: "swapStatusLabel: allPassed false, no status label → no-op",
+    name: 'swapStatusLabel: allPassed false, no status label → no-op',
     test: async () => {
       const { botContext, calls } = createMockBotContext({
         pr: { labels: [] },
@@ -759,74 +699,58 @@ const unitTests = [
   // SafeSearchToken
   // ---------------------------------------------------------------------------
   {
-    name: "isSafeSearchToken: dependabot[bot] → true",
-    test: () => isSafeSearchToken("dependabot[bot]") === true,
+    name: 'isSafeSearchToken: dependabot[bot] → true',
+    test: () => isSafeSearchToken('dependabot[bot]') === true,
   },
   {
-    name: "isSafeSearchToken: string with spaces → false",
-    test: () => isSafeSearchToken("bad username") === false,
+    name: 'isSafeSearchToken: string with spaces → false',
+    test: () => isSafeSearchToken('bad username') === false,
   },
   {
-    name: "isSafeSearchToken: string with angle brackets → false",
-    test: () => isSafeSearchToken("bad<username>") === false,
+    name: 'isSafeSearchToken: string with angle brackets → false',
+    test: () => isSafeSearchToken('bad<username>') === false,
   },
   {
-    name: "isSafeSearchToken: string with semicolon → false",
-    test: () => isSafeSearchToken("bad;username") === false,
+    name: 'isSafeSearchToken: string with semicolon → false',
+    test: () => isSafeSearchToken('bad;username') === false,
   },
   {
-    name: "isSafeSearchToken: string with brackets but not bot inside → false",
-    test: () => isSafeSearchToken("bad[admin]") === false,
+    name: 'isSafeSearchToken: string with brackets but not bot inside → false',
+    test: () => isSafeSearchToken('bad[admin]') === false,
   },
   {
-    name: "isSafeSearchToken: string with multiple brackets → false",
-    test: () => isSafeSearchToken("bad[[admin]") === false,
+    name: 'isSafeSearchToken: string with multiple brackets → false',
+    test: () => isSafeSearchToken('bad[[admin]') === false,
   },
 
   // ---------------------------------------------------------------------------
   // getHighestIssueSkillLevel
   // ---------------------------------------------------------------------------
   {
-    name: "getHighestIssueSkillLevel: issue with one skill label → returns that level",
+    name: 'getHighestIssueSkillLevel: issue with one skill label → returns that level',
     test: () => {
-      const issue = {
-        number: 1,
-        title: "Test",
-        labels: [{ name: LABELS.BEGINNER }, { name: LABELS.READY_FOR_DEV }],
-      };
+      const issue = { number: 1, title: 'Test', labels: [{ name: LABELS.BEGINNER }, { name: LABELS.READY_FOR_DEV }] };
       return getHighestIssueSkillLevel(issue) === LABELS.BEGINNER;
     },
   },
   {
-    name: "getHighestIssueSkillLevel: issue with no skill labels → returns null",
+    name: 'getHighestIssueSkillLevel: issue with no skill labels → returns null',
     test: () => {
-      const issue = {
-        number: 1,
-        title: "Test",
-        labels: [{ name: "bug" }, { name: "enhancement" }],
-      };
+      const issue = { number: 1, title: 'Test', labels: [{ name: 'bug' }, { name: 'enhancement' }] };
       return getHighestIssueSkillLevel(issue) === null;
     },
   },
   {
-    name: "getHighestIssueSkillLevel: issue with multiple skill labels → returns highest",
+    name: 'getHighestIssueSkillLevel: issue with multiple skill labels → returns highest',
     test: () => {
-      const issue = {
-        number: 1,
-        title: "Test",
-        labels: [
-          { name: LABELS.GOOD_FIRST_ISSUE },
-          { name: LABELS.BEGINNER },
-          { name: LABELS.INTERMEDIATE },
-        ],
-      };
+      const issue = { number: 1, title: 'Test', labels: [{ name: LABELS.GOOD_FIRST_ISSUE }, { name: LABELS.BEGINNER }, { name: LABELS.INTERMEDIATE }] };
       return getHighestIssueSkillLevel(issue) === LABELS.INTERMEDIATE;
     },
   },
   {
-    name: "getHighestIssueSkillLevel: issue with empty labels → returns null",
+    name: 'getHighestIssueSkillLevel: issue with empty labels → returns null',
     test: () => {
-      const issue = { number: 1, title: "Test", labels: [] };
+      const issue = { number: 1, title: 'Test', labels: [] };
       return getHighestIssueSkillLevel(issue) === null;
     },
   },
@@ -836,8 +760,8 @@ const unitTests = [
 // =============================================================================
 
 async function runUnitTests() {
-  console.log("🔬 UNIT TESTS (api)");
-  console.log("=".repeat(70));
+  console.log('🔬 UNIT TESTS (api)');
+  console.log('='.repeat(70));
   let passed = 0;
   let failed = 0;
   for (const test of unitTests) {
@@ -855,11 +779,11 @@ async function runUnitTests() {
       failed++;
     }
   }
-  console.log("\n" + "-".repeat(70));
+  console.log('\n' + '-'.repeat(70));
   console.log(`Unit Tests: ${passed} passed, ${failed} failed`);
   return { total: unitTests.length, passed, failed };
 }
 
-runTestSuite("API HELPERS TEST SUITE", [], async () => true, [
-  { label: "Unit Tests", run: runUnitTests },
+runTestSuite('API HELPERS TEST SUITE', [], async () => true, [
+  { label: 'Unit Tests', run: runUnitTests },
 ]);

--- a/.github/scripts/tests/test-inactivity-bot.js
+++ b/.github/scripts/tests/test-inactivity-bot.js
@@ -5,16 +5,16 @@
 // Integration tests for bot-inactivity.js.
 // Run with: node .github/scripts/tests/test-inactivity-bot.js
 
-const { runTestSuite } = require('./test-utils');
-const script = require('../bot-inactivity.js');
-const { LABELS } = require('../helpers/constants');
+const { runTestSuite } = require("./test-utils");
+const script = require("../bot-inactivity.js");
+const { LABELS } = require("../helpers/constants");
 
 // =============================================================================
 // TIME HELPERS
 // =============================================================================
 
 // Fixed "now" for all tests
-const NOW = new Date('2024-01-15T12:00:00Z').getTime();
+const NOW = new Date("2024-01-15T12:00:00Z").getTime();
 
 function daysAgo(n) {
   return new Date(NOW - n * 24 * 60 * 60 * 1000).toISOString();
@@ -46,13 +46,13 @@ function createMockGithub(opts = {}) {
   } = opts;
 
   const calls = {
-    itemsClosed: [],        // issue_numbers that were closed
-    commentsCreated: [],    // { issue_number, body }
-    commentsUpdated: [],    // { comment_id, body }
-    labelsAdded: [],        // { issue_number, labels }
-    labelsRemoved: [],      // { issue_number, name }
-    assigneesRemoved: [],   // { issue_number, assignees }
-    commentsList: [],       // { issue_number } — tracked for verification
+    itemsClosed: [], // issue_numbers that were closed
+    commentsCreated: [], // { issue_number, body }
+    commentsUpdated: [], // { comment_id, body }
+    labelsAdded: [], // { issue_number, labels }
+    labelsRemoved: [], // { issue_number, name }
+    assigneesRemoved: [], // { issue_number, assignees }
+    commentsList: [], // { issue_number } — tracked for verification
   };
 
   const perPage = 100;
@@ -90,41 +90,66 @@ function createMockGithub(opts = {}) {
         },
 
         createComment: async (params) => {
-          calls.commentsCreated.push({ issue_number: params.issue_number, body: params.body });
-          console.log(`\n📝 COMMENT CREATED on #${params.issue_number}:\n${'─'.repeat(50)}\n${params.body}\n${'─'.repeat(50)}`);
+          calls.commentsCreated.push({
+            issue_number: params.issue_number,
+            body: params.body,
+          });
+          console.log(
+            `\n📝 COMMENT CREATED on #${params.issue_number}:\n${"─".repeat(50)}\n${params.body}\n${"─".repeat(50)}`,
+          );
         },
 
         updateComment: async (params) => {
-          calls.commentsUpdated.push({ comment_id: params.comment_id, body: params.body });
-          console.log(`\n✏️  COMMENT UPDATED (id=${params.comment_id}):\n${'─'.repeat(50)}\n${params.body}\n${'─'.repeat(50)}`);
+          calls.commentsUpdated.push({
+            comment_id: params.comment_id,
+            body: params.body,
+          });
+          console.log(
+            `\n✏️  COMMENT UPDATED (id=${params.comment_id}):\n${"─".repeat(50)}\n${params.body}\n${"─".repeat(50)}`,
+          );
         },
 
         update: async (params) => {
-          if (params.state === 'closed') {
+          if (params.state === "closed") {
             calls.itemsClosed.push(params.issue_number);
             console.log(`\n🔒 CLOSED #${params.issue_number}`);
           }
         },
 
         addLabels: async (params) => {
-          calls.labelsAdded.push({ issue_number: params.issue_number, labels: params.labels });
-          console.log(`\n🏷️  LABELS ADDED on #${params.issue_number}: ${params.labels.join(', ')}`);
+          calls.labelsAdded.push({
+            issue_number: params.issue_number,
+            labels: params.labels,
+          });
+          console.log(
+            `\n🏷️  LABELS ADDED on #${params.issue_number}: ${params.labels.join(", ")}`,
+          );
         },
 
         removeLabel: async (params) => {
-          calls.labelsRemoved.push({ issue_number: params.issue_number, name: params.name });
-          console.log(`\n🏷️  LABEL REMOVED on #${params.issue_number}: ${params.name}`);
+          calls.labelsRemoved.push({
+            issue_number: params.issue_number,
+            name: params.name,
+          });
+          console.log(
+            `\n🏷️  LABEL REMOVED on #${params.issue_number}: ${params.name}`,
+          );
         },
 
         removeAssignees: async (params) => {
-          calls.assigneesRemoved.push({ issue_number: params.issue_number, assignees: params.assignees });
-          console.log(`\n👤 ASSIGNEES REMOVED on #${params.issue_number}: ${params.assignees.join(', ')}`);
+          calls.assigneesRemoved.push({
+            issue_number: params.issue_number,
+            assignees: params.assignees,
+          });
+          console.log(
+            `\n👤 ASSIGNEES REMOVED on #${params.issue_number}: ${params.assignees.join(", ")}`,
+          );
         },
 
         get: async (params) => {
           const data = issuesByNumber[params.issue_number] || {
             number: params.issue_number,
-            state: 'open',
+            state: "open",
             assignees: [],
             labels: [],
             created_at: daysAgo(1),
@@ -158,41 +183,57 @@ function createMockGithub(opts = {}) {
 // HELPERS — ITEM BUILDERS
 // =============================================================================
 
-function makeIssue(number, { createdAt = daysAgo(1), assignees = [], labels = [] } = {}) {
+function makeIssue(
+  number,
+  { createdAt = daysAgo(1), assignees = [], labels = [] } = {},
+) {
   return {
     number,
-    state: 'open',
+    state: "open",
     created_at: createdAt,
-    assignees: assignees.map(l => ({ login: l })),
-    labels: labels.map(l => ({ name: l })),
+    assignees: assignees.map((l) => ({ login: l })),
+    labels: labels.map((l) => ({ name: l })),
     pull_request: undefined,
   };
 }
 
-function makePR(number, { createdAt = daysAgo(1), assignees = [], labels = [], body = '', authorLogin = 'contributor' } = {}) {
+function makePR(
+  number,
+  {
+    createdAt = daysAgo(1),
+    assignees = [],
+    labels = [],
+    body = "",
+    authorLogin = "contributor",
+  } = {},
+) {
   return {
     number,
-    state: 'open',
+    state: "open",
     created_at: createdAt,
-    user: { login: authorLogin, type: 'User' },
-    assignees: assignees.map(l => ({ login: l })),
-    labels: labels.map(l => ({ name: l })),
+    user: { login: authorLogin, type: "User" },
+    assignees: assignees.map((l) => ({ login: l })),
+    labels: labels.map((l) => ({ name: l })),
     body,
   };
 }
 
 function makeUnlabeledEvent(labelName, createdAt) {
-  return { event: 'unlabeled', created_at: createdAt, label: { name: labelName } };
+  return {
+    event: "unlabeled",
+    created_at: createdAt,
+    label: { name: labelName },
+  };
 }
 
 function makeAssignedEvent(createdAt) {
-  return { event: 'assigned', created_at: createdAt };
+  return { event: "assigned", created_at: createdAt };
 }
 
 function makeComment(userLogin, createdAt, { isBot = false } = {}) {
   return {
     id: Math.floor(Math.random() * 100000),
-    user: { login: userLogin, type: isBot ? 'Bot' : 'User' },
+    user: { login: userLogin, type: isBot ? "Bot" : "User" },
     body: `Comment from ${userLogin}`,
     created_at: createdAt,
   };
@@ -204,14 +245,14 @@ function makeCommit(authorLogin, date) {
     commit: {
       author: { date },
       committer: { date },
-      message: 'chore: some work',
+      message: "chore: some work",
       verification: { verified: true },
     },
   };
 }
 
 const defaultContext = {
-  repo: { owner: 'test-org', repo: 'test-repo' },
+  repo: { owner: "test-org", repo: "test-repo" },
 };
 
 // =============================================================================
@@ -221,8 +262,9 @@ const defaultContext = {
 const scenarios = [
   // ── 1 ──────────────────────────────────────────────────────────────────────
   {
-    name: 'No in-progress items — no action taken',
-    description: 'When there are no assigned issues or PRs, the bot should be silent.',
+    name: "No in-progress items — no action taken",
+    description:
+      "When there are no assigned issues or PRs, the bot should be silent.",
     github: createMockGithub(),
     expect: {
       itemsClosed: [],
@@ -234,11 +276,16 @@ const scenarios = [
 
   // ── 2 ──────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: 3 days inactive — no action',
-    description: 'An issue created 3 days ago with no comments should not be flagged.',
+    name: "Issue: 3 days inactive — no action",
+    description:
+      "An issue created 3 days ago with no comments should not be flagged.",
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(10, { createdAt: daysAgo(3), assignees: ['alice'], labels: [LABELS.IN_PROGRESS] }),
+        makeIssue(10, {
+          createdAt: daysAgo(3),
+          assignees: ["alice"],
+          labels: [LABELS.IN_PROGRESS],
+        }),
       ],
       eventsByNumber: {
         10: [makeAssignedEvent(daysAgo(3))],
@@ -254,11 +301,16 @@ const scenarios = [
 
   // ── 3 ──────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: 6 days inactive — warning posted',
-    description: 'An issue with no activity for 6 days should receive a warning comment.',
+    name: "Issue: 6 days inactive — warning posted",
+    description:
+      "An issue with no activity for 6 days should receive a warning comment.",
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(20, { createdAt: daysAgo(6), assignees: ['alice'], labels: [LABELS.IN_PROGRESS] }),
+        makeIssue(20, {
+          createdAt: daysAgo(6),
+          assignees: ["alice"],
+          labels: [LABELS.IN_PROGRESS],
+        }),
       ],
       eventsByNumber: {
         20: [makeAssignedEvent(daysAgo(6))],
@@ -275,11 +327,16 @@ const scenarios = [
 
   // ── 4 ──────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: 8 days inactive — reset (not closed)',
-    description: 'An issue with no activity for 8 days should be reset but remain open.',
+    name: "Issue: 8 days inactive — reset (not closed)",
+    description:
+      "An issue with no activity for 8 days should be reset but remain open.",
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(30, { createdAt: daysAgo(8), assignees: ['alice'], labels: [LABELS.IN_PROGRESS] }),
+        makeIssue(30, {
+          createdAt: daysAgo(8),
+          assignees: ["alice"],
+          labels: [LABELS.IN_PROGRESS],
+        }),
       ],
       eventsByNumber: {
         30: [makeAssignedEvent(daysAgo(8))],
@@ -290,20 +347,24 @@ const scenarios = [
       resetCommentOn: [30],
       labelsAdded: [{ issue_number: 30, labels: [LABELS.READY_FOR_DEV] }],
       labelsRemoved: [{ issue_number: 30, name: LABELS.IN_PROGRESS }],
-      assigneesRemoved: [{ issue_number: 30, assignees: ['alice'] }],
+      assigneesRemoved: [{ issue_number: 30, assignees: ["alice"] }],
     },
   },
 
   // ── 5 ──────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: 8 days old but assignee commented 2 days ago — no action',
-    description: 'An assignee comment resets the inactivity clock.',
+    name: "Issue: 8 days old but assignee commented 2 days ago — no action",
+    description: "An assignee comment resets the inactivity clock.",
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(40, { createdAt: daysAgo(8), assignees: ['bob'], labels: [LABELS.IN_PROGRESS] }),
+        makeIssue(40, {
+          createdAt: daysAgo(8),
+          assignees: ["bob"],
+          labels: [LABELS.IN_PROGRESS],
+        }),
       ],
       commentsByNumber: {
-        40: [makeComment('bob', daysAgo(2))],
+        40: [makeComment("bob", daysAgo(2))],
       },
       eventsByNumber: {
         40: [makeAssignedEvent(daysAgo(8))],
@@ -319,14 +380,19 @@ const scenarios = [
 
   // ── 6 ──────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: 8 days old, non-assignee commented — clock not reset, reset (not closed)',
-    description: 'A comment by a non-assignee (e.g. maintainer) should not reset the clock.',
+    name: "Issue: 8 days old, non-assignee commented — clock not reset, reset (not closed)",
+    description:
+      "A comment by a non-assignee (e.g. maintainer) should not reset the clock.",
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(50, { createdAt: daysAgo(8), assignees: ['alice'], labels: [LABELS.IN_PROGRESS] }),
+        makeIssue(50, {
+          createdAt: daysAgo(8),
+          assignees: ["alice"],
+          labels: [LABELS.IN_PROGRESS],
+        }),
       ],
       commentsByNumber: {
-        50: [makeComment('maintainer', daysAgo(1))],
+        50: [makeComment("maintainer", daysAgo(1))],
       },
       eventsByNumber: {
         50: [makeAssignedEvent(daysAgo(8))],
@@ -335,19 +401,20 @@ const scenarios = [
     expect: {
       itemsClosed: [],
       resetCommentOn: [50],
-      assigneesRemoved: [{ issue_number: 50, assignees: ['alice'] }],
+      assigneesRemoved: [{ issue_number: 50, assignees: ["alice"] }],
     },
   },
 
   // ── 7 ──────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: blocked label — skipped for inactivity, receives check-in',
-    description: 'Blocked issues are exempt from close/warn, but get a 30-day check-in comment.',
+    name: "Issue: blocked label — skipped for inactivity, receives check-in",
+    description:
+      "Blocked issues are exempt from close/warn, but get a 30-day check-in comment.",
     github: createMockGithub({
       assignedIssues: [
         makeIssue(60, {
           createdAt: daysAgo(8),
-          assignees: ['alice'],
+          assignees: ["alice"],
           labels: [LABELS.IN_PROGRESS, LABELS.BLOCKED],
         }),
       ],
@@ -362,22 +429,27 @@ const scenarios = [
 
   // ── 8 ──────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: 8 days inactive but linked open PR has recent author commit — no action',
-    description: 'Activity on a linked PR (author commit 1 day ago) should protect the issue.',
+    name: "Issue: 8 days inactive but linked open PR has recent author commit — no action",
+    description:
+      "Activity on a linked PR (author commit 1 day ago) should protect the issue.",
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(70, { createdAt: daysAgo(8), assignees: ['carol'], labels: [LABELS.IN_PROGRESS] }),
+        makeIssue(70, {
+          createdAt: daysAgo(8),
+          assignees: ["carol"],
+          labels: [LABELS.IN_PROGRESS],
+        }),
       ],
       openPRs: [
         makePR(71, {
           createdAt: daysAgo(8),
-          assignees: ['carol'],
-          authorLogin: 'carol',
-          body: 'Fixes #70',
+          assignees: ["carol"],
+          authorLogin: "carol",
+          body: "Fixes #70",
         }),
       ],
       commitsByPRNumber: {
-        71: [makeCommit('carol', daysAgo(1))],
+        71: [makeCommit("carol", daysAgo(1))],
       },
       eventsByNumber: {
         70: [makeAssignedEvent(daysAgo(8))],
@@ -393,11 +465,16 @@ const scenarios = [
 
   // ── 9 ──────────────────────────────────────────────────────────────────────
   {
-    name: 'PR: 6 days inactive — warning posted',
-    description: 'An assigned PR with no activity for 6 days should receive a warning.',
+    name: "PR: 6 days inactive — warning posted",
+    description:
+      "An assigned PR with no activity for 6 days should receive a warning.",
     github: createMockGithub({
       openPRs: [
-        makePR(80, { createdAt: daysAgo(6), assignees: ['dave'], authorLogin: 'dave' }),
+        makePR(80, {
+          createdAt: daysAgo(6),
+          assignees: ["dave"],
+          authorLogin: "dave",
+        }),
       ],
     }),
     expect: {
@@ -411,22 +488,23 @@ const scenarios = [
 
   // ── 10 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'PR: 8 days inactive — closed, reset, linked issue cleaned up',
-    description: 'A stale PR should be closed and its linked issue unassigned and reset.',
+    name: "PR: 8 days inactive — closed, reset, linked issue cleaned up",
+    description:
+      "A stale PR should be closed and its linked issue unassigned and reset.",
     github: createMockGithub({
       openPRs: [
         makePR(90, {
           createdAt: daysAgo(8),
-          assignees: ['eve'],
-          authorLogin: 'eve',
-          body: 'Fixes #91',
+          assignees: ["eve"],
+          authorLogin: "eve",
+          body: "Fixes #91",
         }),
       ],
       issuesByNumber: {
         91: {
           number: 91,
-          state: 'open',
-          assignees: [{ login: 'eve' }],
+          state: "open",
+          assignees: [{ login: "eve" }],
           labels: [{ name: LABELS.IN_PROGRESS }],
           created_at: daysAgo(8),
         },
@@ -442,14 +520,15 @@ const scenarios = [
 
   // ── 11 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'PR: blocked label — skipped for inactivity, receives check-in',
-    description: 'Blocked PRs are exempt from close/warn, but get a 30-day check-in comment.',
+    name: "PR: blocked label — skipped for inactivity, receives check-in",
+    description:
+      "Blocked PRs are exempt from close/warn, but get a 30-day check-in comment.",
     github: createMockGithub({
       openPRs: [
         makePR(100, {
           createdAt: daysAgo(8),
-          assignees: ['frank'],
-          authorLogin: 'frank',
+          assignees: ["frank"],
+          authorLogin: "frank",
           labels: [LABELS.BLOCKED],
         }),
       ],
@@ -464,14 +543,19 @@ const scenarios = [
 
   // ── 12 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'PR: 8 days old but author committed 1 day ago — no action',
-    description: 'A recent commit by the PR author resets the inactivity clock.',
+    name: "PR: 8 days old but author committed 1 day ago — no action",
+    description:
+      "A recent commit by the PR author resets the inactivity clock.",
     github: createMockGithub({
       openPRs: [
-        makePR(110, { createdAt: daysAgo(8), assignees: ['grace'], authorLogin: 'grace' }),
+        makePR(110, {
+          createdAt: daysAgo(8),
+          assignees: ["grace"],
+          authorLogin: "grace",
+        }),
       ],
       commitsByPRNumber: {
-        110: [makeCommit('grace', daysAgo(1))],
+        110: [makeCommit("grace", daysAgo(1))],
       },
     }),
     expect: {
@@ -484,31 +568,40 @@ const scenarios = [
 
   // ── 13 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'PR: 8 days old, commit by different author — clock not reset, closed',
-    description: 'A commit by someone other than the PR author must not reset the clock.',
+    name: "PR: 8 days old, commit by different author — clock not reset, closed",
+    description:
+      "A commit by someone other than the PR author must not reset the clock.",
     github: createMockGithub({
       openPRs: [
-        makePR(120, { createdAt: daysAgo(8), assignees: ['henry'], authorLogin: 'henry' }),
+        makePR(120, {
+          createdAt: daysAgo(8),
+          assignees: ["henry"],
+          authorLogin: "henry",
+        }),
       ],
       commitsByPRNumber: {
         // Commit is by a maintainer, not the PR author
-        120: [makeCommit('maintainer', daysAgo(1))],
+        120: [makeCommit("maintainer", daysAgo(1))],
       },
     }),
     expect: {
       itemsClosed: [120],
       closureCommentOn: [120],
-      assigneesRemoved: [{ issue_number: 120, assignees: ['henry'] }],
+      assigneesRemoved: [{ issue_number: 120, assignees: ["henry"] }],
     },
   },
 
   // ── 14 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'Unassigned PR — not tracked for inactivity',
-    description: 'Open PRs without assignees should not be processed.',
+    name: "Unassigned PR — not tracked for inactivity",
+    description: "Open PRs without assignees should not be processed.",
     github: createMockGithub({
       openPRs: [
-        makePR(130, { createdAt: daysAgo(8), assignees: [], authorLogin: 'ivan' }),
+        makePR(130, {
+          createdAt: daysAgo(8),
+          assignees: [],
+          authorLogin: "ivan",
+        }),
       ],
     }),
     expect: {
@@ -521,14 +614,21 @@ const scenarios = [
 
   // ── 15 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: unblocked 3 days ago (was 8 days old) — no action',
-    description: 'Removing the blocked label resets the 5-day clock.',
+    name: "Issue: unblocked 3 days ago (was 8 days old) — no action",
+    description: "Removing the blocked label resets the 5-day clock.",
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(140, { createdAt: daysAgo(8), assignees: ['judy'], labels: [LABELS.IN_PROGRESS] }),
+        makeIssue(140, {
+          createdAt: daysAgo(8),
+          assignees: ["judy"],
+          labels: [LABELS.IN_PROGRESS],
+        }),
       ],
       eventsByNumber: {
-        140: [makeAssignedEvent(daysAgo(8)), makeUnlabeledEvent(LABELS.BLOCKED, daysAgo(3))],
+        140: [
+          makeAssignedEvent(daysAgo(8)),
+          makeUnlabeledEvent(LABELS.BLOCKED, daysAgo(3)),
+        ],
       },
     }),
     expect: {
@@ -541,32 +641,41 @@ const scenarios = [
 
   // ── 16 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: unblocked 8 days ago — reset (not closed)',
-    description: 'If the unblocked date is still more than 7 days ago, the issue should be reset but remain open.',
+    name: "Issue: unblocked 8 days ago — reset (not closed)",
+    description:
+      "If the unblocked date is still more than 7 days ago, the issue should be reset but remain open.",
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(150, { createdAt: daysAgo(10), assignees: ['kate'], labels: [LABELS.IN_PROGRESS] }),
+        makeIssue(150, {
+          createdAt: daysAgo(10),
+          assignees: ["kate"],
+          labels: [LABELS.IN_PROGRESS],
+        }),
       ],
       eventsByNumber: {
-        150: [makeAssignedEvent(daysAgo(10)), makeUnlabeledEvent(LABELS.BLOCKED, daysAgo(8))],
+        150: [
+          makeAssignedEvent(daysAgo(10)),
+          makeUnlabeledEvent(LABELS.BLOCKED, daysAgo(8)),
+        ],
       },
     }),
     expect: {
       itemsClosed: [],
       resetCommentOn: [150],
-      assigneesRemoved: [{ issue_number: 150, assignees: ['kate'] }],
+      assigneesRemoved: [{ issue_number: 150, assignees: ["kate"] }],
     },
   },
 
   // ── 17 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: blocked, no prior check-in — check-in comment posted',
-    description: 'First time the bot sees a blocked item, it should post a check-in.',
+    name: "Issue: blocked, no prior check-in — check-in comment posted",
+    description:
+      "First time the bot sees a blocked item, it should post a check-in.",
     github: createMockGithub({
       assignedIssues: [
         makeIssue(160, {
           createdAt: daysAgo(35),
-          assignees: ['liam'],
+          assignees: ["liam"],
           labels: [LABELS.IN_PROGRESS, LABELS.BLOCKED],
         }),
       ],
@@ -580,24 +689,26 @@ const scenarios = [
 
   // ── 18 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: blocked, check-in posted 35 days ago — new check-in posted',
-    description: 'After 30 days the check-in comment should be refreshed.',
+    name: "Issue: blocked, check-in posted 35 days ago — new check-in posted",
+    description: "After 30 days the check-in comment should be refreshed.",
     github: createMockGithub({
       assignedIssues: [
         makeIssue(170, {
           createdAt: daysAgo(40),
-          assignees: ['mia'],
+          assignees: ["mia"],
           labels: [LABELS.IN_PROGRESS, LABELS.BLOCKED],
         }),
       ],
       commentsByNumber: {
-        170: [{
-          id: 9001,
-          user: { login: 'github-actions[bot]', type: 'Bot' },
-          body: '<!-- bot:blocked-checkin -->\n👋 Hey @mia, just checking in!...',
-          created_at: daysAgo(35),
-          updated_at: daysAgo(35),
-        }],
+        170: [
+          {
+            id: 9001,
+            user: { login: "github-actions[bot]", type: "Bot" },
+            body: "<!-- bot:blocked-checkin -->\n👋 Hey @mia, just checking in!...",
+            created_at: daysAgo(35),
+            updated_at: daysAgo(35),
+          },
+        ],
       },
     }),
     expect: {
@@ -609,24 +720,27 @@ const scenarios = [
 
   // ── 19 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: blocked, check-in posted 10 days ago — no action',
-    description: 'If a check-in was posted within 30 days, the bot should stay quiet.',
+    name: "Issue: blocked, check-in posted 10 days ago — no action",
+    description:
+      "If a check-in was posted within 30 days, the bot should stay quiet.",
     github: createMockGithub({
       assignedIssues: [
         makeIssue(180, {
           createdAt: daysAgo(40),
-          assignees: ['noah'],
+          assignees: ["noah"],
           labels: [LABELS.IN_PROGRESS, LABELS.BLOCKED],
         }),
       ],
       commentsByNumber: {
-        180: [{
-          id: 9002,
-          user: { login: 'github-actions[bot]', type: 'Bot' },
-          body: '<!-- bot:blocked-checkin -->\n👋 Hey @noah, just checking in!...',
-          created_at: daysAgo(10),
-          updated_at: daysAgo(10),
-        }],
+        180: [
+          {
+            id: 9002,
+            user: { login: "github-actions[bot]", type: "Bot" },
+            body: "<!-- bot:blocked-checkin -->\n👋 Hey @noah, just checking in!...",
+            created_at: daysAgo(10),
+            updated_at: daysAgo(10),
+          },
+        ],
       },
     }),
     expect: {
@@ -639,14 +753,14 @@ const scenarios = [
 
   // ── 20 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'PR: blocked, no prior check-in — check-in posted',
-    description: 'Blocked PRs also receive the 30-day check-in.',
+    name: "PR: blocked, no prior check-in — check-in posted",
+    description: "Blocked PRs also receive the 30-day check-in.",
     github: createMockGithub({
       openPRs: [
         makePR(190, {
           createdAt: daysAgo(35),
-          assignees: ['olivia'],
-          authorLogin: 'olivia',
+          assignees: ["olivia"],
+          authorLogin: "olivia",
           labels: [LABELS.BLOCKED],
         }),
       ],
@@ -660,11 +774,16 @@ const scenarios = [
 
   // ── 21 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: created 30 days ago but assigned 2 days ago — no action',
-    description: 'The inactivity clock starts from the assignment date, not creation date.',
+    name: "Issue: created 30 days ago but assigned 2 days ago — no action",
+    description:
+      "The inactivity clock starts from the assignment date, not creation date.",
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(200, { createdAt: daysAgo(30), assignees: ['pat'], labels: [LABELS.IN_PROGRESS] }),
+        makeIssue(200, {
+          createdAt: daysAgo(30),
+          assignees: ["pat"],
+          labels: [LABELS.IN_PROGRESS],
+        }),
       ],
       eventsByNumber: {
         200: [makeAssignedEvent(daysAgo(2))],
@@ -680,11 +799,16 @@ const scenarios = [
 
   // ── 22 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: no assigned event — skipped without error',
-    description: 'If the events API returns no assigned event, the issue is skipped entirely.',
+    name: "Issue: no assigned event — skipped without error",
+    description:
+      "If the events API returns no assigned event, the issue is skipped entirely.",
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(210, { createdAt: daysAgo(10), assignees: ['quinn'], labels: [LABELS.IN_PROGRESS] }),
+        makeIssue(210, {
+          createdAt: daysAgo(10),
+          assignees: ["quinn"],
+          labels: [LABELS.IN_PROGRESS],
+        }),
       ],
       eventsByNumber: {
         210: [],
@@ -700,22 +824,27 @@ const scenarios = [
 
   // ── 23 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: warning exists, activity happened after warning, now inactive again — new warning posted',
-    description: 'A fresh warning should be posted when the clock was reset after the previous warning.',
+    name: "Issue: warning exists, activity happened after warning, now inactive again — new warning posted",
+    description:
+      "A fresh warning should be posted when the clock was reset after the previous warning.",
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(220, { createdAt: daysAgo(14), assignees: ['riley'], labels: [LABELS.IN_PROGRESS] }),
+        makeIssue(220, {
+          createdAt: daysAgo(14),
+          assignees: ["riley"],
+          labels: [LABELS.IN_PROGRESS],
+        }),
       ],
       commentsByNumber: {
         220: [
           {
             id: 9201,
-            user: { login: 'github-actions[bot]', type: 'Bot' },
-            body: '<!-- bot:inactivity-warning -->\n👋 Hey @riley! This issue has been inactive for 5 days.',
+            user: { login: "github-actions[bot]", type: "Bot" },
+            body: "<!-- bot:inactivity-warning -->\n👋 Hey @riley! This issue has been inactive for 5 days.",
             created_at: daysAgo(10),
             updated_at: daysAgo(10),
           },
-          makeComment('riley', daysAgo(6)),
+          makeComment("riley", daysAgo(6)),
         ],
       },
       eventsByNumber: {
@@ -734,18 +863,23 @@ const scenarios = [
 
   // ── 24 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'Issue: warning exists, no activity since warning — no duplicate warning',
-    description: 'If no activity occurred after the existing warning, the bot should not post another warning.',
+    name: "Issue: warning exists, no activity since warning — no duplicate warning",
+    description:
+      "If no activity occurred after the existing warning, the bot should not post another warning.",
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(230, { createdAt: daysAgo(6), assignees: ['sam'], labels: [LABELS.IN_PROGRESS] }),
+        makeIssue(230, {
+          createdAt: daysAgo(6),
+          assignees: ["sam"],
+          labels: [LABELS.IN_PROGRESS],
+        }),
       ],
       commentsByNumber: {
         230: [
           {
             id: 9301,
-            user: { login: 'github-actions[bot]', type: 'Bot' },
-            body: '<!-- bot:inactivity-warning -->\n👋 Hey @sam! This issue has been inactive for 5 days.',
+            user: { login: "github-actions[bot]", type: "Bot" },
+            body: "<!-- bot:inactivity-warning -->\n👋 Hey @sam! This issue has been inactive for 5 days.",
             created_at: daysAgo(5),
             updated_at: daysAgo(5),
           },
@@ -753,6 +887,128 @@ const scenarios = [
       },
       eventsByNumber: {
         230: [makeAssignedEvent(daysAgo(6))],
+      },
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreated: 0,
+      commentsUpdated: 0,
+      labelsAdded: 0,
+      assigneesRemoved: 0,
+    },
+  },
+
+  // ── 25 ─────────────────────────────────────────────────────────────────────
+  {
+    name: "Issue: activity after warning but still under 5 days — no action",
+    description:
+      "If activity happens after the warning yet the item has not crossed 5 inactive days again, the bot should stay quiet.",
+    github: createMockGithub({
+      assignedIssues: [
+        makeIssue(240, {
+          createdAt: daysAgo(6),
+          assignees: ["tom"],
+          labels: [LABELS.IN_PROGRESS],
+        }),
+      ],
+      commentsByNumber: {
+        240: [
+          {
+            id: 9401,
+            user: { login: "github-actions[bot]", type: "Bot" },
+            body: "<!-- bot:inactivity-warning -->\n👋 Hey @tom! This issue has been inactive for 5 days.",
+            created_at: daysAgo(5),
+            updated_at: daysAgo(5),
+          },
+          makeComment("tom", daysAgo(4)),
+        ],
+      },
+      eventsByNumber: {
+        240: [makeAssignedEvent(daysAgo(6))],
+      },
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreated: 0,
+      commentsUpdated: 0,
+      labelsAdded: 0,
+      assigneesRemoved: 0,
+    },
+  },
+
+  // ── 26 ─────────────────────────────────────────────────────────────────────
+  {
+    name: "Issue: non-bot marker comment is ignored",
+    description:
+      "A user comment that happens to include the warning marker should not suppress the bot warning.",
+    github: createMockGithub({
+      assignedIssues: [
+        makeIssue(250, {
+          createdAt: daysAgo(6),
+          assignees: ["uma"],
+          labels: [LABELS.IN_PROGRESS],
+        }),
+      ],
+      commentsByNumber: {
+        250: [
+          {
+            id: 9501,
+            user: { login: "maintainer", type: "User" },
+            body: "<!-- bot:inactivity-warning -->\nThis is a human comment with a marker.",
+            created_at: daysAgo(5),
+            updated_at: daysAgo(5),
+          },
+        ],
+      },
+      eventsByNumber: {
+        250: [makeAssignedEvent(daysAgo(6))],
+      },
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreatedCount: 1,
+      warningPostedOn: [250],
+      commentsUpdated: 0,
+      labelsAdded: 0,
+      assigneesRemoved: 0,
+    },
+  },
+
+  // ── 27 ─────────────────────────────────────────────────────────────────────
+  {
+    name: "Issue: warning comment on second page is still found",
+    description:
+      "The bot should inspect paginated comments and respect a warning that lives on page 2.",
+    github: createMockGithub({
+      assignedIssues: [
+        makeIssue(260, {
+          createdAt: daysAgo(6),
+          assignees: ["vera"],
+          labels: [LABELS.IN_PROGRESS],
+        }),
+      ],
+      commentsByNumber: {
+        260: [
+          ...Array(100)
+            .fill(null)
+            .map((_, i) => ({
+              id: 9600 + i,
+              user: { login: "user" + i, type: "User" },
+              body: "Comment " + i,
+              created_at: daysAgo(10 + i),
+              updated_at: daysAgo(10 + i),
+            })),
+          {
+            id: 9701,
+            user: { login: "github-actions[bot]", type: "Bot" },
+            body: "<!-- bot:inactivity-warning -->\n👋 Hey @vera! This issue has been inactive for 5 days.",
+            created_at: daysAgo(5),
+            updated_at: daysAgo(5),
+          },
+        ],
+      },
+      eventsByNumber: {
+        260: [makeAssignedEvent(daysAgo(6))],
       },
     }),
     expect: {
@@ -772,7 +1028,7 @@ const scenarios = [
 async function runScenario(scenario, index) {
   const { name, description, github, expect: expected } = scenario;
 
-  console.log(`\n${'─'.repeat(70)}`);
+  console.log(`\n${"─".repeat(70)}`);
   console.log(`[${index}] ${name}`);
   if (description) console.log(`    ${description}`);
 
@@ -790,8 +1046,13 @@ async function runScenario(scenario, index) {
   // itemsClosed
   if (expected.itemsClosed !== undefined) {
     const closed = calls.itemsClosed;
-    if (JSON.stringify(closed.sort()) !== JSON.stringify(expected.itemsClosed.sort())) {
-      failures.push(`itemsClosed: expected ${JSON.stringify(expected.itemsClosed)}, got ${JSON.stringify(closed)}`);
+    if (
+      JSON.stringify(closed.sort()) !==
+      JSON.stringify(expected.itemsClosed.sort())
+    ) {
+      failures.push(
+        `itemsClosed: expected ${JSON.stringify(expected.itemsClosed)}, got ${JSON.stringify(closed)}`,
+      );
     }
   }
 
@@ -799,23 +1060,29 @@ async function runScenario(scenario, index) {
   if (expected.commentsCreated !== undefined) {
     const count = calls.commentsCreated.length + calls.commentsUpdated.length;
     if (count !== expected.commentsCreated) {
-      failures.push(`comments posted: expected ${expected.commentsCreated}, got ${count}`);
+      failures.push(
+        `comments posted: expected ${expected.commentsCreated}, got ${count}`,
+      );
     }
   }
 
   if (expected.commentsCreatedCount !== undefined) {
     const count = calls.commentsCreated.length;
     if (count !== expected.commentsCreatedCount) {
-      failures.push(`commentsCreated count: expected ${expected.commentsCreatedCount}, got ${count}`);
+      failures.push(
+        `commentsCreated count: expected ${expected.commentsCreatedCount}, got ${count}`,
+      );
     }
   }
 
   // warningPostedOn — check that warning marker appears in comments for these items
   if (expected.warningPostedOn) {
     for (const num of expected.warningPostedOn) {
-      const MARKER = '<!-- bot:inactivity-warning -->';
-      const found = calls.commentsCreated.some(c => c.issue_number === num && c.body.startsWith(MARKER))
-                 || calls.commentsUpdated.some(c => c.body.startsWith(MARKER));
+      const MARKER = "<!-- bot:inactivity-warning -->";
+      const found =
+        calls.commentsCreated.some(
+          (c) => c.issue_number === num && c.body.startsWith(MARKER),
+        ) || calls.commentsUpdated.some((c) => c.body.startsWith(MARKER));
       if (!found) {
         failures.push(`Expected warning comment on #${num}`);
       }
@@ -825,7 +1092,9 @@ async function runScenario(scenario, index) {
   // closureCommentOn — check that PR closure comment appears for these items
   if (expected.closureCommentOn) {
     for (const num of expected.closureCommentOn) {
-      const found = calls.commentsCreated.some(c => c.issue_number === num && c.body.includes('closed due to'));
+      const found = calls.commentsCreated.some(
+        (c) => c.issue_number === num && c.body.includes("closed due to"),
+      );
       if (!found) {
         failures.push(`Expected closure comment on #${num}`);
       }
@@ -835,7 +1104,10 @@ async function runScenario(scenario, index) {
   // resetCommentOn — check that issue reset comment appears for these items (not closed)
   if (expected.resetCommentOn) {
     for (const num of expected.resetCommentOn) {
-      const found = calls.commentsCreated.some(c => c.issue_number === num && c.body.includes('unassigned and reset'));
+      const found = calls.commentsCreated.some(
+        (c) =>
+          c.issue_number === num && c.body.includes("unassigned and reset"),
+      );
       if (!found) {
         failures.push(`Expected reset comment on #${num}`);
       }
@@ -844,18 +1116,23 @@ async function runScenario(scenario, index) {
 
   // labelsAdded
   if (expected.labelsAdded !== undefined) {
-    if (typeof expected.labelsAdded === 'number') {
+    if (typeof expected.labelsAdded === "number") {
       if (calls.labelsAdded.length !== expected.labelsAdded) {
-        failures.push(`labelsAdded count: expected ${expected.labelsAdded}, got ${calls.labelsAdded.length}`);
+        failures.push(
+          `labelsAdded count: expected ${expected.labelsAdded}, got ${calls.labelsAdded.length}`,
+        );
       }
     } else if (Array.isArray(expected.labelsAdded)) {
       for (const exp of expected.labelsAdded) {
         const found = calls.labelsAdded.some(
-          a => a.issue_number === exp.issue_number &&
-               JSON.stringify(a.labels) === JSON.stringify(exp.labels)
+          (a) =>
+            a.issue_number === exp.issue_number &&
+            JSON.stringify(a.labels) === JSON.stringify(exp.labels),
         );
         if (!found) {
-          failures.push(`Expected labels ${JSON.stringify(exp.labels)} added on #${exp.issue_number}`);
+          failures.push(
+            `Expected labels ${JSON.stringify(exp.labels)} added on #${exp.issue_number}`,
+          );
         }
       }
     }
@@ -863,17 +1140,21 @@ async function runScenario(scenario, index) {
 
   // labelsRemoved
   if (expected.labelsRemoved !== undefined) {
-    if (typeof expected.labelsRemoved === 'number') {
+    if (typeof expected.labelsRemoved === "number") {
       if (calls.labelsRemoved.length !== expected.labelsRemoved) {
-        failures.push(`labelsRemoved count: expected ${expected.labelsRemoved}, got ${calls.labelsRemoved.length}`);
+        failures.push(
+          `labelsRemoved count: expected ${expected.labelsRemoved}, got ${calls.labelsRemoved.length}`,
+        );
       }
     } else if (Array.isArray(expected.labelsRemoved)) {
       for (const exp of expected.labelsRemoved) {
         const found = calls.labelsRemoved.some(
-          r => r.issue_number === exp.issue_number && r.name === exp.name
+          (r) => r.issue_number === exp.issue_number && r.name === exp.name,
         );
         if (!found) {
-          failures.push(`Expected label "${exp.name}" removed on #${exp.issue_number}`);
+          failures.push(
+            `Expected label "${exp.name}" removed on #${exp.issue_number}`,
+          );
         }
       }
     }
@@ -881,18 +1162,24 @@ async function runScenario(scenario, index) {
 
   // assigneesRemoved
   if (expected.assigneesRemoved !== undefined) {
-    if (typeof expected.assigneesRemoved === 'number') {
+    if (typeof expected.assigneesRemoved === "number") {
       if (calls.assigneesRemoved.length !== expected.assigneesRemoved) {
-        failures.push(`assigneesRemoved count: expected ${expected.assigneesRemoved}, got ${calls.assigneesRemoved.length}`);
+        failures.push(
+          `assigneesRemoved count: expected ${expected.assigneesRemoved}, got ${calls.assigneesRemoved.length}`,
+        );
       }
     } else if (Array.isArray(expected.assigneesRemoved)) {
       for (const exp of expected.assigneesRemoved) {
         const found = calls.assigneesRemoved.some(
-          r => r.issue_number === exp.issue_number &&
-               JSON.stringify(r.assignees.sort()) === JSON.stringify(exp.assignees.sort())
+          (r) =>
+            r.issue_number === exp.issue_number &&
+            JSON.stringify(r.assignees.sort()) ===
+              JSON.stringify(exp.assignees.sort()),
         );
         if (!found) {
-          failures.push(`Expected assignees ${JSON.stringify(exp.assignees)} removed on #${exp.issue_number}`);
+          failures.push(
+            `Expected assignees ${JSON.stringify(exp.assignees)} removed on #${exp.issue_number}`,
+          );
         }
       }
     }
@@ -901,7 +1188,7 @@ async function runScenario(scenario, index) {
   // assigneesRemovedOn — just check items (not specific logins)
   if (expected.assigneesRemovedOn) {
     for (const num of expected.assigneesRemovedOn) {
-      const found = calls.assigneesRemoved.some(r => r.issue_number === num);
+      const found = calls.assigneesRemoved.some((r) => r.issue_number === num);
       if (!found) {
         failures.push(`Expected assignees removed on #${num}`);
       }
@@ -911,19 +1198,31 @@ async function runScenario(scenario, index) {
   // linkedIssueCleaned — issue was reset (assignees removed AND ready-for-dev label added)
   if (expected.linkedIssueCleaned) {
     for (const num of expected.linkedIssueCleaned) {
-      const unassigned = calls.assigneesRemoved.some(r => r.issue_number === num);
-      const relabeled  = calls.labelsAdded.some(r => r.issue_number === num && r.labels.includes(LABELS.READY_FOR_DEV));
-      if (!unassigned) failures.push(`Expected assignees removed on linked issue #${num}`);
-      if (!relabeled)  failures.push(`Expected "${LABELS.READY_FOR_DEV}" added on linked issue #${num}`);
+      const unassigned = calls.assigneesRemoved.some(
+        (r) => r.issue_number === num,
+      );
+      const relabeled = calls.labelsAdded.some(
+        (r) =>
+          r.issue_number === num && r.labels.includes(LABELS.READY_FOR_DEV),
+      );
+      if (!unassigned)
+        failures.push(`Expected assignees removed on linked issue #${num}`);
+      if (!relabeled)
+        failures.push(
+          `Expected "${LABELS.READY_FOR_DEV}" added on linked issue #${num}`,
+        );
     }
   }
 
   // checkinPostedOn — blocked check-in marker appears in created or updated comments
   if (expected.checkinPostedOn) {
-    const CHECKIN_MARKER = '<!-- bot:blocked-checkin -->';
+    const CHECKIN_MARKER = "<!-- bot:blocked-checkin -->";
     for (const num of expected.checkinPostedOn) {
-      const found = calls.commentsCreated.some(c => c.issue_number === num && c.body.startsWith(CHECKIN_MARKER))
-                 || calls.commentsUpdated.some(c => c.body.startsWith(CHECKIN_MARKER));
+      const found =
+        calls.commentsCreated.some(
+          (c) => c.issue_number === num && c.body.startsWith(CHECKIN_MARKER),
+        ) ||
+        calls.commentsUpdated.some((c) => c.body.startsWith(CHECKIN_MARKER));
       if (!found) {
         failures.push(`Expected blocked check-in comment on #${num}`);
       }
@@ -933,7 +1232,9 @@ async function runScenario(scenario, index) {
   // commentsUpdated count
   if (expected.commentsUpdated !== undefined) {
     if (calls.commentsUpdated.length !== expected.commentsUpdated) {
-      failures.push(`commentsUpdated count: expected ${expected.commentsUpdated}, got ${calls.commentsUpdated.length}`);
+      failures.push(
+        `commentsUpdated count: expected ${expected.commentsUpdated}, got ${calls.commentsUpdated.length}`,
+      );
     }
   }
 
@@ -942,7 +1243,7 @@ async function runScenario(scenario, index) {
     return false;
   }
 
-  console.log('  ✅ All assertions passed');
+  console.log("  ✅ All assertions passed");
   return true;
 }
 
@@ -950,4 +1251,4 @@ async function runScenario(scenario, index) {
 // ENTRY POINT
 // =============================================================================
 
-runTestSuite('INACTIVITY BOT TEST SUITE', scenarios, runScenario);
+runTestSuite("INACTIVITY BOT TEST SUITE", scenarios, runScenario);

--- a/.github/scripts/tests/test-inactivity-bot.js
+++ b/.github/scripts/tests/test-inactivity-bot.js
@@ -1019,6 +1019,78 @@ const scenarios = [
       assigneesRemoved: 0,
     },
   },
+
+  // ── 28 ─────────────────────────────────────────────────────────────────────
+  {
+    name: "PR: warning exists, activity happened after warning, now inactive again — new warning posted",
+    description:
+      "A PR should receive a fresh warning when activity after the previous warning reset the clock.",
+    github: createMockGithub({
+      openPRs: [
+        makePR(270, {
+          createdAt: daysAgo(14),
+          assignees: ["will"],
+          authorLogin: "will",
+        }),
+      ],
+      commentsByNumber: {
+        270: [
+          {
+            id: 9801,
+            user: { login: "github-actions[bot]", type: "Bot" },
+            body: "<!-- bot:inactivity-warning -->\n👋 Hey @will! This PR has been inactive for 5 days.",
+            created_at: daysAgo(10),
+            updated_at: daysAgo(10),
+          },
+        ],
+      },
+      commitsByPRNumber: {
+        270: [makeCommit("will", daysAgo(6))],
+      },
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreatedCount: 1,
+      warningPostedOn: [270],
+      commentsUpdated: 0,
+      labelsAdded: 0,
+      assigneesRemoved: 0,
+    },
+  },
+
+  // ── 29 ─────────────────────────────────────────────────────────────────────
+  {
+    name: "PR: warning exists, no activity since warning — no duplicate warning",
+    description:
+      "If no activity happened since an existing PR warning, the bot should not post another warning.",
+    github: createMockGithub({
+      openPRs: [
+        makePR(280, {
+          createdAt: daysAgo(6),
+          assignees: ["xena"],
+          authorLogin: "xena",
+        }),
+      ],
+      commentsByNumber: {
+        280: [
+          {
+            id: 9901,
+            user: { login: "github-actions[bot]", type: "Bot" },
+            body: "<!-- bot:inactivity-warning -->\n👋 Hey @xena! This PR has been inactive for 5 days.",
+            created_at: daysAgo(5),
+            updated_at: daysAgo(5),
+          },
+        ],
+      },
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreated: 0,
+      commentsUpdated: 0,
+      labelsAdded: 0,
+      assigneesRemoved: 0,
+    },
+  },
 ];
 
 // =============================================================================

--- a/.github/scripts/tests/test-inactivity-bot.js
+++ b/.github/scripts/tests/test-inactivity-bot.js
@@ -872,7 +872,7 @@ const scenarios = [
           {
             id: 9201,
             user: { login: 'github-actions[bot]', type: 'Bot' },
-            body: '<!-- bot:inactivity-warning -->\n\u{1F44B} Hey @riley! This issue has been inactive for 5 days.',
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @riley! This issue has been inactive for 5 days.',
             created_at: daysAgo(10),
             updated_at: daysAgo(10),
           },
@@ -906,7 +906,7 @@ const scenarios = [
           {
             id: 9301,
             user: { login: 'github-actions[bot]', type: 'Bot' },
-            body: '<!-- bot:inactivity-warning -->\n\u{1F44B} Hey @sam2! This issue has been inactive for 5 days.',
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @sam2! This issue has been inactive for 5 days.',
             created_at: daysAgo(5),
             updated_at: daysAgo(5),
           },
@@ -938,7 +938,7 @@ const scenarios = [
           {
             id: 9401,
             user: { login: 'github-actions[bot]', type: 'Bot' },
-            body: '<!-- bot:inactivity-warning -->\n\u{1F44B} Hey @tom! This issue has been inactive for 5 days.',
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @tom! This issue has been inactive for 5 days.',
             created_at: daysAgo(5),
             updated_at: daysAgo(5),
           },
@@ -1011,7 +1011,7 @@ const scenarios = [
           {
             id: 34101,
             user: { login: 'github-actions[bot]', type: 'Bot' },
-            body: '<!-- bot:inactivity-warning -->\n\u{1F44B} Hey @vera2! This issue has been inactive for 5 days.',
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @vera2! This issue has been inactive for 5 days.',
             created_at: daysAgo(5),
             updated_at: daysAgo(5),
           },
@@ -1047,7 +1047,7 @@ const scenarios = [
           {
             id: 9801,
             user: { login: 'github-actions[bot]', type: 'Bot' },
-            body: '<!-- bot:inactivity-warning -->\n\u{1F44B} Hey @will! This PR has been inactive for 5 days.',
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @will! This PR has been inactive for 5 days.',
             created_at: daysAgo(10),
             updated_at: daysAgo(10),
           },
@@ -1084,7 +1084,7 @@ const scenarios = [
           {
             id: 9901,
             user: { login: 'github-actions[bot]', type: 'Bot' },
-            body: '<!-- bot:inactivity-warning -->\n\u{1F44B} Hey @xena! This PR has been inactive for 5 days.',
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @xena! This PR has been inactive for 5 days.',
             created_at: daysAgo(5),
             updated_at: daysAgo(5),
           },
@@ -1113,7 +1113,7 @@ const scenarios = [
           {
             id: 9701,
             user: { login: 'github-actions[bot]', type: 'Bot' },
-            body: '<!-- bot:inactivity-warning -->\n\u{1F44B} Hey @yuki! This issue has been inactive for 5 days.',
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @yuki! This issue has been inactive for 5 days.',
             created_at: daysAgo(10),
             updated_at: daysAgo(10),
           },
@@ -1127,7 +1127,7 @@ const scenarios = [
           {
             id: 9703,
             user: { login: 'github-actions[bot]', type: 'Bot' },
-            body: '<!-- bot:inactivity-warning -->\n\u{1F44B} Hey @yuki! This issue has been inactive for 5 days.',
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @yuki! This issue has been inactive for 5 days.',
             created_at: daysAgo(4),
             updated_at: daysAgo(4),
           },

--- a/.github/scripts/tests/test-inactivity-bot.js
+++ b/.github/scripts/tests/test-inactivity-bot.js
@@ -5,16 +5,16 @@
 // Integration tests for bot-inactivity.js.
 // Run with: node .github/scripts/tests/test-inactivity-bot.js
 
-const { runTestSuite } = require("./test-utils");
-const script = require("../bot-inactivity.js");
-const { LABELS } = require("../helpers/constants");
+const { runTestSuite } = require('./test-utils');
+const script = require('../bot-inactivity.js');
+const { LABELS } = require('../helpers/constants');
 
 // =============================================================================
 // TIME HELPERS
 // =============================================================================
 
 // Fixed "now" for all tests
-const NOW = new Date("2024-01-15T12:00:00Z").getTime();
+const NOW = new Date('2024-01-15T12:00:00Z').getTime();
 
 function daysAgo(n) {
   return new Date(NOW - n * 24 * 60 * 60 * 1000).toISOString();
@@ -46,13 +46,13 @@ function createMockGithub(opts = {}) {
   } = opts;
 
   const calls = {
-    itemsClosed: [], // issue_numbers that were closed
-    commentsCreated: [], // { issue_number, body }
-    commentsUpdated: [], // { comment_id, body }
-    labelsAdded: [], // { issue_number, labels }
-    labelsRemoved: [], // { issue_number, name }
-    assigneesRemoved: [], // { issue_number, assignees }
-    commentsList: [], // { issue_number } — tracked for verification
+    itemsClosed: [],        // issue_numbers that were closed
+    commentsCreated: [],    // { issue_number, body }
+    commentsUpdated: [],    // { comment_id, body }
+    labelsAdded: [],        // { issue_number, labels }
+    labelsRemoved: [],      // { issue_number, name }
+    assigneesRemoved: [],   // { issue_number, assignees }
+    commentsList: [],       // { issue_number } — tracked for verification
   };
 
   const perPage = 100;
@@ -90,66 +90,41 @@ function createMockGithub(opts = {}) {
         },
 
         createComment: async (params) => {
-          calls.commentsCreated.push({
-            issue_number: params.issue_number,
-            body: params.body,
-          });
-          console.log(
-            `\n📝 COMMENT CREATED on #${params.issue_number}:\n${"─".repeat(50)}\n${params.body}\n${"─".repeat(50)}`,
-          );
+          calls.commentsCreated.push({ issue_number: params.issue_number, body: params.body });
+          console.log(`\n📝 COMMENT CREATED on #${params.issue_number}:\n${'─'.repeat(50)}\n${params.body}\n${'─'.repeat(50)}`);
         },
 
         updateComment: async (params) => {
-          calls.commentsUpdated.push({
-            comment_id: params.comment_id,
-            body: params.body,
-          });
-          console.log(
-            `\n✏️  COMMENT UPDATED (id=${params.comment_id}):\n${"─".repeat(50)}\n${params.body}\n${"─".repeat(50)}`,
-          );
+          calls.commentsUpdated.push({ comment_id: params.comment_id, body: params.body });
+          console.log(`\n✏️  COMMENT UPDATED (id=${params.comment_id}):\n${'─'.repeat(50)}\n${params.body}\n${'─'.repeat(50)}`);
         },
 
         update: async (params) => {
-          if (params.state === "closed") {
+          if (params.state === 'closed') {
             calls.itemsClosed.push(params.issue_number);
             console.log(`\n🔒 CLOSED #${params.issue_number}`);
           }
         },
 
         addLabels: async (params) => {
-          calls.labelsAdded.push({
-            issue_number: params.issue_number,
-            labels: params.labels,
-          });
-          console.log(
-            `\n🏷️  LABELS ADDED on #${params.issue_number}: ${params.labels.join(", ")}`,
-          );
+          calls.labelsAdded.push({ issue_number: params.issue_number, labels: params.labels });
+          console.log(`\n🏷️  LABELS ADDED on #${params.issue_number}: ${params.labels.join(', ')}`);
         },
 
         removeLabel: async (params) => {
-          calls.labelsRemoved.push({
-            issue_number: params.issue_number,
-            name: params.name,
-          });
-          console.log(
-            `\n🏷️  LABEL REMOVED on #${params.issue_number}: ${params.name}`,
-          );
+          calls.labelsRemoved.push({ issue_number: params.issue_number, name: params.name });
+          console.log(`\n🏷️  LABEL REMOVED on #${params.issue_number}: ${params.name}`);
         },
 
         removeAssignees: async (params) => {
-          calls.assigneesRemoved.push({
-            issue_number: params.issue_number,
-            assignees: params.assignees,
-          });
-          console.log(
-            `\n👤 ASSIGNEES REMOVED on #${params.issue_number}: ${params.assignees.join(", ")}`,
-          );
+          calls.assigneesRemoved.push({ issue_number: params.issue_number, assignees: params.assignees });
+          console.log(`\n👤 ASSIGNEES REMOVED on #${params.issue_number}: ${params.assignees.join(', ')}`);
         },
 
         get: async (params) => {
           const data = issuesByNumber[params.issue_number] || {
             number: params.issue_number,
-            state: "open",
+            state: 'open',
             assignees: [],
             labels: [],
             created_at: daysAgo(1),
@@ -183,57 +158,41 @@ function createMockGithub(opts = {}) {
 // HELPERS — ITEM BUILDERS
 // =============================================================================
 
-function makeIssue(
-  number,
-  { createdAt = daysAgo(1), assignees = [], labels = [] } = {},
-) {
+function makeIssue(number, { createdAt = daysAgo(1), assignees = [], labels = [] } = {}) {
   return {
     number,
-    state: "open",
+    state: 'open',
     created_at: createdAt,
-    assignees: assignees.map((l) => ({ login: l })),
-    labels: labels.map((l) => ({ name: l })),
+    assignees: assignees.map(l => ({ login: l })),
+    labels: labels.map(l => ({ name: l })),
     pull_request: undefined,
   };
 }
 
-function makePR(
-  number,
-  {
-    createdAt = daysAgo(1),
-    assignees = [],
-    labels = [],
-    body = "",
-    authorLogin = "contributor",
-  } = {},
-) {
+function makePR(number, { createdAt = daysAgo(1), assignees = [], labels = [], body = '', authorLogin = 'contributor' } = {}) {
   return {
     number,
-    state: "open",
+    state: 'open',
     created_at: createdAt,
-    user: { login: authorLogin, type: "User" },
-    assignees: assignees.map((l) => ({ login: l })),
-    labels: labels.map((l) => ({ name: l })),
+    user: { login: authorLogin, type: 'User' },
+    assignees: assignees.map(l => ({ login: l })),
+    labels: labels.map(l => ({ name: l })),
     body,
   };
 }
 
 function makeUnlabeledEvent(labelName, createdAt) {
-  return {
-    event: "unlabeled",
-    created_at: createdAt,
-    label: { name: labelName },
-  };
+  return { event: 'unlabeled', created_at: createdAt, label: { name: labelName } };
 }
 
 function makeAssignedEvent(createdAt) {
-  return { event: "assigned", created_at: createdAt };
+  return { event: 'assigned', created_at: createdAt };
 }
 
 function makeComment(userLogin, createdAt, { isBot = false } = {}) {
   return {
     id: Math.floor(Math.random() * 100000),
-    user: { login: userLogin, type: isBot ? "Bot" : "User" },
+    user: { login: userLogin, type: isBot ? 'Bot' : 'User' },
     body: `Comment from ${userLogin}`,
     created_at: createdAt,
   };
@@ -245,14 +204,14 @@ function makeCommit(authorLogin, date) {
     commit: {
       author: { date },
       committer: { date },
-      message: "chore: some work",
+      message: 'chore: some work',
       verification: { verified: true },
     },
   };
 }
 
 const defaultContext = {
-  repo: { owner: "test-org", repo: "test-repo" },
+  repo: { owner: 'test-org', repo: 'test-repo' },
 };
 
 // =============================================================================
@@ -262,9 +221,8 @@ const defaultContext = {
 const scenarios = [
   // ── 1 ──────────────────────────────────────────────────────────────────────
   {
-    name: "No in-progress items — no action taken",
-    description:
-      "When there are no assigned issues or PRs, the bot should be silent.",
+    name: 'No in-progress items — no action taken',
+    description: 'When there are no assigned issues or PRs, the bot should be silent.',
     github: createMockGithub(),
     expect: {
       itemsClosed: [],
@@ -276,16 +234,11 @@ const scenarios = [
 
   // ── 2 ──────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: 3 days inactive — no action",
-    description:
-      "An issue created 3 days ago with no comments should not be flagged.",
+    name: 'Issue: 3 days inactive — no action',
+    description: 'An issue created 3 days ago with no comments should not be flagged.',
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(10, {
-          createdAt: daysAgo(3),
-          assignees: ["alice"],
-          labels: [LABELS.IN_PROGRESS],
-        }),
+        makeIssue(10, { createdAt: daysAgo(3), assignees: ['alice'], labels: [LABELS.IN_PROGRESS] }),
       ],
       eventsByNumber: {
         10: [makeAssignedEvent(daysAgo(3))],
@@ -301,16 +254,11 @@ const scenarios = [
 
   // ── 3 ──────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: 6 days inactive — warning posted",
-    description:
-      "An issue with no activity for 6 days should receive a warning comment.",
+    name: 'Issue: 6 days inactive — warning posted',
+    description: 'An issue with no activity for 6 days should receive a warning comment.',
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(20, {
-          createdAt: daysAgo(6),
-          assignees: ["alice"],
-          labels: [LABELS.IN_PROGRESS],
-        }),
+        makeIssue(20, { createdAt: daysAgo(6), assignees: ['alice'], labels: [LABELS.IN_PROGRESS] }),
       ],
       eventsByNumber: {
         20: [makeAssignedEvent(daysAgo(6))],
@@ -327,16 +275,11 @@ const scenarios = [
 
   // ── 4 ──────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: 8 days inactive — reset (not closed)",
-    description:
-      "An issue with no activity for 8 days should be reset but remain open.",
+    name: 'Issue: 8 days inactive — reset (not closed)',
+    description: 'An issue with no activity for 8 days should be reset but remain open.',
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(30, {
-          createdAt: daysAgo(8),
-          assignees: ["alice"],
-          labels: [LABELS.IN_PROGRESS],
-        }),
+        makeIssue(30, { createdAt: daysAgo(8), assignees: ['alice'], labels: [LABELS.IN_PROGRESS] }),
       ],
       eventsByNumber: {
         30: [makeAssignedEvent(daysAgo(8))],
@@ -347,24 +290,20 @@ const scenarios = [
       resetCommentOn: [30],
       labelsAdded: [{ issue_number: 30, labels: [LABELS.READY_FOR_DEV] }],
       labelsRemoved: [{ issue_number: 30, name: LABELS.IN_PROGRESS }],
-      assigneesRemoved: [{ issue_number: 30, assignees: ["alice"] }],
+      assigneesRemoved: [{ issue_number: 30, assignees: ['alice'] }],
     },
   },
 
   // ── 5 ──────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: 8 days old but assignee commented 2 days ago — no action",
-    description: "An assignee comment resets the inactivity clock.",
+    name: 'Issue: 8 days old but assignee commented 2 days ago — no action',
+    description: 'An assignee comment resets the inactivity clock.',
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(40, {
-          createdAt: daysAgo(8),
-          assignees: ["bob"],
-          labels: [LABELS.IN_PROGRESS],
-        }),
+        makeIssue(40, { createdAt: daysAgo(8), assignees: ['bob'], labels: [LABELS.IN_PROGRESS] }),
       ],
       commentsByNumber: {
-        40: [makeComment("bob", daysAgo(2))],
+        40: [makeComment('bob', daysAgo(2))],
       },
       eventsByNumber: {
         40: [makeAssignedEvent(daysAgo(8))],
@@ -380,19 +319,14 @@ const scenarios = [
 
   // ── 6 ──────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: 8 days old, non-assignee commented — clock not reset, reset (not closed)",
-    description:
-      "A comment by a non-assignee (e.g. maintainer) should not reset the clock.",
+    name: 'Issue: 8 days old, non-assignee commented — clock not reset, reset (not closed)',
+    description: 'A comment by a non-assignee (e.g. maintainer) should not reset the clock.',
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(50, {
-          createdAt: daysAgo(8),
-          assignees: ["alice"],
-          labels: [LABELS.IN_PROGRESS],
-        }),
+        makeIssue(50, { createdAt: daysAgo(8), assignees: ['alice'], labels: [LABELS.IN_PROGRESS] }),
       ],
       commentsByNumber: {
-        50: [makeComment("maintainer", daysAgo(1))],
+        50: [makeComment('maintainer', daysAgo(1))],
       },
       eventsByNumber: {
         50: [makeAssignedEvent(daysAgo(8))],
@@ -401,20 +335,19 @@ const scenarios = [
     expect: {
       itemsClosed: [],
       resetCommentOn: [50],
-      assigneesRemoved: [{ issue_number: 50, assignees: ["alice"] }],
+      assigneesRemoved: [{ issue_number: 50, assignees: ['alice'] }],
     },
   },
 
   // ── 7 ──────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: blocked label — skipped for inactivity, receives check-in",
-    description:
-      "Blocked issues are exempt from close/warn, but get a 30-day check-in comment.",
+    name: 'Issue: blocked label — skipped for inactivity, receives check-in',
+    description: 'Blocked issues are exempt from close/warn, but get a 30-day check-in comment.',
     github: createMockGithub({
       assignedIssues: [
         makeIssue(60, {
           createdAt: daysAgo(8),
-          assignees: ["alice"],
+          assignees: ['alice'],
           labels: [LABELS.IN_PROGRESS, LABELS.BLOCKED],
         }),
       ],
@@ -429,27 +362,22 @@ const scenarios = [
 
   // ── 8 ──────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: 8 days inactive but linked open PR has recent author commit — no action",
-    description:
-      "Activity on a linked PR (author commit 1 day ago) should protect the issue.",
+    name: 'Issue: 8 days inactive but linked open PR has recent author commit — no action',
+    description: 'Activity on a linked PR (author commit 1 day ago) should protect the issue.',
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(70, {
-          createdAt: daysAgo(8),
-          assignees: ["carol"],
-          labels: [LABELS.IN_PROGRESS],
-        }),
+        makeIssue(70, { createdAt: daysAgo(8), assignees: ['carol'], labels: [LABELS.IN_PROGRESS] }),
       ],
       openPRs: [
         makePR(71, {
           createdAt: daysAgo(8),
-          assignees: ["carol"],
-          authorLogin: "carol",
-          body: "Fixes #70",
+          assignees: ['carol'],
+          authorLogin: 'carol',
+          body: 'Fixes #70',
         }),
       ],
       commitsByPRNumber: {
-        71: [makeCommit("carol", daysAgo(1))],
+        71: [makeCommit('carol', daysAgo(1))],
       },
       eventsByNumber: {
         70: [makeAssignedEvent(daysAgo(8))],
@@ -465,16 +393,11 @@ const scenarios = [
 
   // ── 9 ──────────────────────────────────────────────────────────────────────
   {
-    name: "PR: 6 days inactive — warning posted",
-    description:
-      "An assigned PR with no activity for 6 days should receive a warning.",
+    name: 'PR: 6 days inactive — warning posted',
+    description: 'An assigned PR with no activity for 6 days should receive a warning.',
     github: createMockGithub({
       openPRs: [
-        makePR(80, {
-          createdAt: daysAgo(6),
-          assignees: ["dave"],
-          authorLogin: "dave",
-        }),
+        makePR(80, { createdAt: daysAgo(6), assignees: ['dave'], authorLogin: 'dave' }),
       ],
     }),
     expect: {
@@ -488,23 +411,22 @@ const scenarios = [
 
   // ── 10 ─────────────────────────────────────────────────────────────────────
   {
-    name: "PR: 8 days inactive — closed, reset, linked issue cleaned up",
-    description:
-      "A stale PR should be closed and its linked issue unassigned and reset.",
+    name: 'PR: 8 days inactive — closed, reset, linked issue cleaned up',
+    description: 'A stale PR should be closed and its linked issue unassigned and reset.',
     github: createMockGithub({
       openPRs: [
         makePR(90, {
           createdAt: daysAgo(8),
-          assignees: ["eve"],
-          authorLogin: "eve",
-          body: "Fixes #91",
+          assignees: ['eve'],
+          authorLogin: 'eve',
+          body: 'Fixes #91',
         }),
       ],
       issuesByNumber: {
         91: {
           number: 91,
-          state: "open",
-          assignees: [{ login: "eve" }],
+          state: 'open',
+          assignees: [{ login: 'eve' }],
           labels: [{ name: LABELS.IN_PROGRESS }],
           created_at: daysAgo(8),
         },
@@ -520,15 +442,14 @@ const scenarios = [
 
   // ── 11 ─────────────────────────────────────────────────────────────────────
   {
-    name: "PR: blocked label — skipped for inactivity, receives check-in",
-    description:
-      "Blocked PRs are exempt from close/warn, but get a 30-day check-in comment.",
+    name: 'PR: blocked label — skipped for inactivity, receives check-in',
+    description: 'Blocked PRs are exempt from close/warn, but get a 30-day check-in comment.',
     github: createMockGithub({
       openPRs: [
         makePR(100, {
           createdAt: daysAgo(8),
-          assignees: ["frank"],
-          authorLogin: "frank",
+          assignees: ['frank'],
+          authorLogin: 'frank',
           labels: [LABELS.BLOCKED],
         }),
       ],
@@ -543,19 +464,14 @@ const scenarios = [
 
   // ── 12 ─────────────────────────────────────────────────────────────────────
   {
-    name: "PR: 8 days old but author committed 1 day ago — no action",
-    description:
-      "A recent commit by the PR author resets the inactivity clock.",
+    name: 'PR: 8 days old but author committed 1 day ago — no action',
+    description: 'A recent commit by the PR author resets the inactivity clock.',
     github: createMockGithub({
       openPRs: [
-        makePR(110, {
-          createdAt: daysAgo(8),
-          assignees: ["grace"],
-          authorLogin: "grace",
-        }),
+        makePR(110, { createdAt: daysAgo(8), assignees: ['grace'], authorLogin: 'grace' }),
       ],
       commitsByPRNumber: {
-        110: [makeCommit("grace", daysAgo(1))],
+        110: [makeCommit('grace', daysAgo(1))],
       },
     }),
     expect: {
@@ -568,40 +484,31 @@ const scenarios = [
 
   // ── 13 ─────────────────────────────────────────────────────────────────────
   {
-    name: "PR: 8 days old, commit by different author — clock not reset, closed",
-    description:
-      "A commit by someone other than the PR author must not reset the clock.",
+    name: 'PR: 8 days old, commit by different author — clock not reset, closed',
+    description: 'A commit by someone other than the PR author must not reset the clock.',
     github: createMockGithub({
       openPRs: [
-        makePR(120, {
-          createdAt: daysAgo(8),
-          assignees: ["henry"],
-          authorLogin: "henry",
-        }),
+        makePR(120, { createdAt: daysAgo(8), assignees: ['henry'], authorLogin: 'henry' }),
       ],
       commitsByPRNumber: {
         // Commit is by a maintainer, not the PR author
-        120: [makeCommit("maintainer", daysAgo(1))],
+        120: [makeCommit('maintainer', daysAgo(1))],
       },
     }),
     expect: {
       itemsClosed: [120],
       closureCommentOn: [120],
-      assigneesRemoved: [{ issue_number: 120, assignees: ["henry"] }],
+      assigneesRemoved: [{ issue_number: 120, assignees: ['henry'] }],
     },
   },
 
   // ── 14 ─────────────────────────────────────────────────────────────────────
   {
-    name: "Unassigned PR — not tracked for inactivity",
-    description: "Open PRs without assignees should not be processed.",
+    name: 'Unassigned PR — not tracked for inactivity',
+    description: 'Open PRs without assignees should not be processed.',
     github: createMockGithub({
       openPRs: [
-        makePR(130, {
-          createdAt: daysAgo(8),
-          assignees: [],
-          authorLogin: "ivan",
-        }),
+        makePR(130, { createdAt: daysAgo(8), assignees: [], authorLogin: 'ivan' }),
       ],
     }),
     expect: {
@@ -614,21 +521,14 @@ const scenarios = [
 
   // ── 15 ─────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: unblocked 3 days ago (was 8 days old) — no action",
-    description: "Removing the blocked label resets the 5-day clock.",
+    name: 'Issue: unblocked 3 days ago (was 8 days old) — no action',
+    description: 'Removing the blocked label resets the 5-day clock.',
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(140, {
-          createdAt: daysAgo(8),
-          assignees: ["judy"],
-          labels: [LABELS.IN_PROGRESS],
-        }),
+        makeIssue(140, { createdAt: daysAgo(8), assignees: ['judy'], labels: [LABELS.IN_PROGRESS] }),
       ],
       eventsByNumber: {
-        140: [
-          makeAssignedEvent(daysAgo(8)),
-          makeUnlabeledEvent(LABELS.BLOCKED, daysAgo(3)),
-        ],
+        140: [makeAssignedEvent(daysAgo(8)), makeUnlabeledEvent(LABELS.BLOCKED, daysAgo(3))],
       },
     }),
     expect: {
@@ -641,41 +541,32 @@ const scenarios = [
 
   // ── 16 ─────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: unblocked 8 days ago — reset (not closed)",
-    description:
-      "If the unblocked date is still more than 7 days ago, the issue should be reset but remain open.",
+    name: 'Issue: unblocked 8 days ago — reset (not closed)',
+    description: 'If the unblocked date is still more than 7 days ago, the issue should be reset but remain open.',
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(150, {
-          createdAt: daysAgo(10),
-          assignees: ["kate"],
-          labels: [LABELS.IN_PROGRESS],
-        }),
+        makeIssue(150, { createdAt: daysAgo(10), assignees: ['kate'], labels: [LABELS.IN_PROGRESS] }),
       ],
       eventsByNumber: {
-        150: [
-          makeAssignedEvent(daysAgo(10)),
-          makeUnlabeledEvent(LABELS.BLOCKED, daysAgo(8)),
-        ],
+        150: [makeAssignedEvent(daysAgo(10)), makeUnlabeledEvent(LABELS.BLOCKED, daysAgo(8))],
       },
     }),
     expect: {
       itemsClosed: [],
       resetCommentOn: [150],
-      assigneesRemoved: [{ issue_number: 150, assignees: ["kate"] }],
+      assigneesRemoved: [{ issue_number: 150, assignees: ['kate'] }],
     },
   },
 
   // ── 17 ─────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: blocked, no prior check-in — check-in comment posted",
-    description:
-      "First time the bot sees a blocked item, it should post a check-in.",
+    name: 'Issue: blocked, no prior check-in — check-in comment posted',
+    description: 'First time the bot sees a blocked item, it should post a check-in.',
     github: createMockGithub({
       assignedIssues: [
         makeIssue(160, {
           createdAt: daysAgo(35),
-          assignees: ["liam"],
+          assignees: ['liam'],
           labels: [LABELS.IN_PROGRESS, LABELS.BLOCKED],
         }),
       ],
@@ -689,26 +580,24 @@ const scenarios = [
 
   // ── 18 ─────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: blocked, check-in posted 35 days ago — new check-in posted",
-    description: "After 30 days the check-in comment should be refreshed.",
+    name: 'Issue: blocked, check-in posted 35 days ago — new check-in posted',
+    description: 'After 30 days the check-in comment should be refreshed.',
     github: createMockGithub({
       assignedIssues: [
         makeIssue(170, {
           createdAt: daysAgo(40),
-          assignees: ["mia"],
+          assignees: ['mia'],
           labels: [LABELS.IN_PROGRESS, LABELS.BLOCKED],
         }),
       ],
       commentsByNumber: {
-        170: [
-          {
-            id: 9001,
-            user: { login: "github-actions[bot]", type: "Bot" },
-            body: "<!-- bot:blocked-checkin -->\n👋 Hey @mia, just checking in!...",
-            created_at: daysAgo(35),
-            updated_at: daysAgo(35),
-          },
-        ],
+        170: [{
+          id: 9001,
+          user: { login: 'github-actions[bot]', type: 'Bot' },
+          body: '<!-- bot:blocked-checkin -->\n👋 Hey @mia, just checking in!...',
+          created_at: daysAgo(35),
+          updated_at: daysAgo(35),
+        }],
       },
     }),
     expect: {
@@ -720,27 +609,24 @@ const scenarios = [
 
   // ── 19 ─────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: blocked, check-in posted 10 days ago — no action",
-    description:
-      "If a check-in was posted within 30 days, the bot should stay quiet.",
+    name: 'Issue: blocked, check-in posted 10 days ago — no action',
+    description: 'If a check-in was posted within 30 days, the bot should stay quiet.',
     github: createMockGithub({
       assignedIssues: [
         makeIssue(180, {
           createdAt: daysAgo(40),
-          assignees: ["noah"],
+          assignees: ['noah'],
           labels: [LABELS.IN_PROGRESS, LABELS.BLOCKED],
         }),
       ],
       commentsByNumber: {
-        180: [
-          {
-            id: 9002,
-            user: { login: "github-actions[bot]", type: "Bot" },
-            body: "<!-- bot:blocked-checkin -->\n👋 Hey @noah, just checking in!...",
-            created_at: daysAgo(10),
-            updated_at: daysAgo(10),
-          },
-        ],
+        180: [{
+          id: 9002,
+          user: { login: 'github-actions[bot]', type: 'Bot' },
+          body: '<!-- bot:blocked-checkin -->\n👋 Hey @noah, just checking in!...',
+          created_at: daysAgo(10),
+          updated_at: daysAgo(10),
+        }],
       },
     }),
     expect: {
@@ -753,14 +639,14 @@ const scenarios = [
 
   // ── 20 ─────────────────────────────────────────────────────────────────────
   {
-    name: "PR: blocked, no prior check-in — check-in posted",
-    description: "Blocked PRs also receive the 30-day check-in.",
+    name: 'PR: blocked, no prior check-in — check-in posted',
+    description: 'Blocked PRs also receive the 30-day check-in.',
     github: createMockGithub({
       openPRs: [
         makePR(190, {
           createdAt: daysAgo(35),
-          assignees: ["olivia"],
-          authorLogin: "olivia",
+          assignees: ['olivia'],
+          authorLogin: 'olivia',
           labels: [LABELS.BLOCKED],
         }),
       ],
@@ -774,16 +660,11 @@ const scenarios = [
 
   // ── 21 ─────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: created 30 days ago but assigned 2 days ago — no action",
-    description:
-      "The inactivity clock starts from the assignment date, not creation date.",
+    name: 'Issue: created 30 days ago but assigned 2 days ago — no action',
+    description: 'The inactivity clock starts from the assignment date, not creation date.',
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(200, {
-          createdAt: daysAgo(30),
-          assignees: ["pat"],
-          labels: [LABELS.IN_PROGRESS],
-        }),
+        makeIssue(200, { createdAt: daysAgo(30), assignees: ['pat'], labels: [LABELS.IN_PROGRESS] }),
       ],
       eventsByNumber: {
         200: [makeAssignedEvent(daysAgo(2))],
@@ -799,16 +680,11 @@ const scenarios = [
 
   // ── 22 ─────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: no assigned event — skipped without error",
-    description:
-      "If the events API returns no assigned event, the issue is skipped entirely.",
+    name: 'Issue: no assigned event — skipped without error',
+    description: 'If the events API returns no assigned event, the issue is skipped entirely.',
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(210, {
-          createdAt: daysAgo(10),
-          assignees: ["quinn"],
-          labels: [LABELS.IN_PROGRESS],
-        }),
+        makeIssue(210, { createdAt: daysAgo(10), assignees: ['quinn'], labels: [LABELS.IN_PROGRESS] }),
       ],
       eventsByNumber: {
         210: [],
@@ -824,27 +700,22 @@ const scenarios = [
 
   // ── 23 ─────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: warning exists, activity happened after warning, now inactive again — new warning posted",
-    description:
-      "A fresh warning should be posted when the clock was reset after the previous warning.",
+    name: 'Issue: warning exists, activity happened after warning, now inactive again — new warning posted',
+    description: 'A fresh warning should be posted when the clock was reset after the previous warning.',
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(220, {
-          createdAt: daysAgo(14),
-          assignees: ["riley"],
-          labels: [LABELS.IN_PROGRESS],
-        }),
+        makeIssue(220, { createdAt: daysAgo(14), assignees: ['riley'], labels: [LABELS.IN_PROGRESS] }),
       ],
       commentsByNumber: {
         220: [
           {
             id: 9201,
-            user: { login: "github-actions[bot]", type: "Bot" },
-            body: "<!-- bot:inactivity-warning -->\n👋 Hey @riley! This issue has been inactive for 5 days.",
+            user: { login: 'github-actions[bot]', type: 'Bot' },
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @riley! This issue has been inactive for 5 days.',
             created_at: daysAgo(10),
             updated_at: daysAgo(10),
           },
-          makeComment("riley", daysAgo(6)),
+          makeComment('riley', daysAgo(6)),
         ],
       },
       eventsByNumber: {
@@ -863,23 +734,18 @@ const scenarios = [
 
   // ── 24 ─────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: warning exists, no activity since warning — no duplicate warning",
-    description:
-      "If no activity occurred after the existing warning, the bot should not post another warning.",
+    name: 'Issue: warning exists, no activity since warning — no duplicate warning',
+    description: 'If no activity occurred after the existing warning, the bot should not post another warning.',
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(230, {
-          createdAt: daysAgo(6),
-          assignees: ["sam"],
-          labels: [LABELS.IN_PROGRESS],
-        }),
+        makeIssue(230, { createdAt: daysAgo(6), assignees: ['sam'], labels: [LABELS.IN_PROGRESS] }),
       ],
       commentsByNumber: {
         230: [
           {
             id: 9301,
-            user: { login: "github-actions[bot]", type: "Bot" },
-            body: "<!-- bot:inactivity-warning -->\n👋 Hey @sam! This issue has been inactive for 5 days.",
+            user: { login: 'github-actions[bot]', type: 'Bot' },
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @sam! This issue has been inactive for 5 days.',
             created_at: daysAgo(5),
             updated_at: daysAgo(5),
           },
@@ -900,31 +766,26 @@ const scenarios = [
 
   // ── 25 ─────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: activity after warning but still under 5 days — no action",
-    description:
-      "If activity happens after the warning yet the item has not crossed 5 inactive days again, the bot should stay quiet.",
+    name: 'Issue: activity after warning but still under 5 days — no action',
+    description: 'If activity happens after the warning yet the item has not crossed 5 inactive days again, the bot should stay quiet.',
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(240, {
-          createdAt: daysAgo(6),
-          assignees: ["tom"],
-          labels: [LABELS.IN_PROGRESS],
-        }),
+        makeIssue(240, { createdAt: daysAgo(10), assignees: ['tom'], labels: [LABELS.IN_PROGRESS] }),
       ],
       commentsByNumber: {
         240: [
           {
             id: 9401,
-            user: { login: "github-actions[bot]", type: "Bot" },
-            body: "<!-- bot:inactivity-warning -->\n👋 Hey @tom! This issue has been inactive for 5 days.",
+            user: { login: 'github-actions[bot]', type: 'Bot' },
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @tom! This issue has been inactive for 5 days.',
             created_at: daysAgo(5),
             updated_at: daysAgo(5),
           },
-          makeComment("tom", daysAgo(4)),
+          makeComment('tom', daysAgo(4)),
         ],
       },
       eventsByNumber: {
-        240: [makeAssignedEvent(daysAgo(6))],
+        240: [makeAssignedEvent(daysAgo(10))],
       },
     }),
     expect: {
@@ -938,23 +799,18 @@ const scenarios = [
 
   // ── 26 ─────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: non-bot marker comment is ignored",
-    description:
-      "A user comment that happens to include the warning marker should not suppress the bot warning.",
+    name: 'Issue: non-bot marker comment is ignored',
+    description: 'A user comment that happens to include the warning marker should not suppress the bot warning.',
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(250, {
-          createdAt: daysAgo(6),
-          assignees: ["uma"],
-          labels: [LABELS.IN_PROGRESS],
-        }),
+        makeIssue(250, { createdAt: daysAgo(6), assignees: ['uma'], labels: [LABELS.IN_PROGRESS] }),
       ],
       commentsByNumber: {
         250: [
           {
             id: 9501,
-            user: { login: "maintainer", type: "User" },
-            body: "<!-- bot:inactivity-warning -->\nThis is a human comment with a marker.",
+            user: { login: 'maintainer', type: 'User' },
+            body: '<!-- bot:inactivity-warning -->\nThis is a human comment with a marker.',
             created_at: daysAgo(5),
             updated_at: daysAgo(5),
           },
@@ -976,32 +832,25 @@ const scenarios = [
 
   // ── 27 ─────────────────────────────────────────────────────────────────────
   {
-    name: "Issue: warning comment on second page is still found",
-    description:
-      "The bot should inspect paginated comments and respect a warning that lives on page 2.",
+    name: 'Issue: warning comment on second page is still found',
+    description: 'The bot should inspect paginated comments and respect a warning that lives on page 2.',
     github: createMockGithub({
       assignedIssues: [
-        makeIssue(260, {
-          createdAt: daysAgo(6),
-          assignees: ["vera"],
-          labels: [LABELS.IN_PROGRESS],
-        }),
+        makeIssue(260, { createdAt: daysAgo(6), assignees: ['vera'], labels: [LABELS.IN_PROGRESS] }),
       ],
       commentsByNumber: {
         260: [
-          ...Array(100)
-            .fill(null)
-            .map((_, i) => ({
-              id: 9600 + i,
-              user: { login: "user" + i, type: "User" },
-              body: "Comment " + i,
-              created_at: daysAgo(10 + i),
-              updated_at: daysAgo(10 + i),
-            })),
+          ...Array.from({ length: 100 }, (_, i) => ({
+            id: 26000 + i,
+            user: { login: 'user' + i, type: 'User' },
+            body: 'Comment ' + i,
+            created_at: daysAgo(5),
+            updated_at: daysAgo(5),
+          })),
           {
-            id: 9701,
-            user: { login: "github-actions[bot]", type: "Bot" },
-            body: "<!-- bot:inactivity-warning -->\n👋 Hey @vera! This issue has been inactive for 5 days.",
+            id: 26101,
+            user: { login: 'github-actions[bot]', type: 'Bot' },
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @vera! This issue has been inactive for 5 days.',
             created_at: daysAgo(5),
             updated_at: daysAgo(5),
           },
@@ -1022,30 +871,29 @@ const scenarios = [
 
   // ── 28 ─────────────────────────────────────────────────────────────────────
   {
-    name: "PR: warning exists, activity happened after warning, now inactive again — new warning posted",
-    description:
-      "A PR should receive a fresh warning when activity after the previous warning reset the clock.",
+    name: 'PR: warning exists, activity happened after warning, now inactive again — new warning posted',
+    description: 'A PR should receive a fresh warning when activity after the previous warning reset the clock.',
     github: createMockGithub({
       openPRs: [
         makePR(270, {
           createdAt: daysAgo(14),
-          assignees: ["will"],
-          authorLogin: "will",
+          assignees: ['will'],
+          authorLogin: 'will',
         }),
       ],
       commentsByNumber: {
         270: [
           {
             id: 9801,
-            user: { login: "github-actions[bot]", type: "Bot" },
-            body: "<!-- bot:inactivity-warning -->\n👋 Hey @will! This PR has been inactive for 5 days.",
+            user: { login: 'github-actions[bot]', type: 'Bot' },
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @will! This PR has been inactive for 5 days.',
             created_at: daysAgo(10),
             updated_at: daysAgo(10),
           },
         ],
       },
       commitsByPRNumber: {
-        270: [makeCommit("will", daysAgo(6))],
+        270: [makeCommit('will', daysAgo(6))],
       },
     }),
     expect: {
@@ -1060,23 +908,22 @@ const scenarios = [
 
   // ── 29 ─────────────────────────────────────────────────────────────────────
   {
-    name: "PR: warning exists, no activity since warning — no duplicate warning",
-    description:
-      "If no activity happened since an existing PR warning, the bot should not post another warning.",
+    name: 'PR: warning exists, no activity since warning — no duplicate warning',
+    description: 'If no activity happened since an existing PR warning, the bot should not post another warning.',
     github: createMockGithub({
       openPRs: [
         makePR(280, {
           createdAt: daysAgo(6),
-          assignees: ["xena"],
-          authorLogin: "xena",
+          assignees: ['xena'],
+          authorLogin: 'xena',
         }),
       ],
       commentsByNumber: {
         280: [
           {
             id: 9901,
-            user: { login: "github-actions[bot]", type: "Bot" },
-            body: "<!-- bot:inactivity-warning -->\n👋 Hey @xena! This PR has been inactive for 5 days.",
+            user: { login: 'github-actions[bot]', type: 'Bot' },
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @xena! This PR has been inactive for 5 days.',
             created_at: daysAgo(5),
             updated_at: daysAgo(5),
           },
@@ -1100,7 +947,7 @@ const scenarios = [
 async function runScenario(scenario, index) {
   const { name, description, github, expect: expected } = scenario;
 
-  console.log(`\n${"─".repeat(70)}`);
+  console.log(`\n${'─'.repeat(70)}`);
   console.log(`[${index}] ${name}`);
   if (description) console.log(`    ${description}`);
 
@@ -1118,13 +965,8 @@ async function runScenario(scenario, index) {
   // itemsClosed
   if (expected.itemsClosed !== undefined) {
     const closed = calls.itemsClosed;
-    if (
-      JSON.stringify(closed.sort()) !==
-      JSON.stringify(expected.itemsClosed.sort())
-    ) {
-      failures.push(
-        `itemsClosed: expected ${JSON.stringify(expected.itemsClosed)}, got ${JSON.stringify(closed)}`,
-      );
+    if (JSON.stringify(closed.sort()) !== JSON.stringify(expected.itemsClosed.sort())) {
+      failures.push(`itemsClosed: expected ${JSON.stringify(expected.itemsClosed)}, got ${JSON.stringify(closed)}`);
     }
   }
 
@@ -1132,29 +974,23 @@ async function runScenario(scenario, index) {
   if (expected.commentsCreated !== undefined) {
     const count = calls.commentsCreated.length + calls.commentsUpdated.length;
     if (count !== expected.commentsCreated) {
-      failures.push(
-        `comments posted: expected ${expected.commentsCreated}, got ${count}`,
-      );
+      failures.push(`comments posted: expected ${expected.commentsCreated}, got ${count}`);
     }
   }
 
   if (expected.commentsCreatedCount !== undefined) {
     const count = calls.commentsCreated.length;
     if (count !== expected.commentsCreatedCount) {
-      failures.push(
-        `commentsCreated count: expected ${expected.commentsCreatedCount}, got ${count}`,
-      );
+      failures.push(`commentsCreated count: expected ${expected.commentsCreatedCount}, got ${count}`);
     }
   }
 
   // warningPostedOn — check that warning marker appears in comments for these items
   if (expected.warningPostedOn) {
     for (const num of expected.warningPostedOn) {
-      const MARKER = "<!-- bot:inactivity-warning -->";
-      const found =
-        calls.commentsCreated.some(
-          (c) => c.issue_number === num && c.body.startsWith(MARKER),
-        ) || calls.commentsUpdated.some((c) => c.body.startsWith(MARKER));
+      const MARKER = '<!-- bot:inactivity-warning -->';
+      const found = calls.commentsCreated.some(c => c.issue_number === num && c.body.startsWith(MARKER))
+                 || calls.commentsUpdated.some(c => c.body.startsWith(MARKER));
       if (!found) {
         failures.push(`Expected warning comment on #${num}`);
       }
@@ -1164,9 +1000,7 @@ async function runScenario(scenario, index) {
   // closureCommentOn — check that PR closure comment appears for these items
   if (expected.closureCommentOn) {
     for (const num of expected.closureCommentOn) {
-      const found = calls.commentsCreated.some(
-        (c) => c.issue_number === num && c.body.includes("closed due to"),
-      );
+      const found = calls.commentsCreated.some(c => c.issue_number === num && c.body.includes('closed due to'));
       if (!found) {
         failures.push(`Expected closure comment on #${num}`);
       }
@@ -1176,10 +1010,7 @@ async function runScenario(scenario, index) {
   // resetCommentOn — check that issue reset comment appears for these items (not closed)
   if (expected.resetCommentOn) {
     for (const num of expected.resetCommentOn) {
-      const found = calls.commentsCreated.some(
-        (c) =>
-          c.issue_number === num && c.body.includes("unassigned and reset"),
-      );
+      const found = calls.commentsCreated.some(c => c.issue_number === num && c.body.includes('unassigned and reset'));
       if (!found) {
         failures.push(`Expected reset comment on #${num}`);
       }
@@ -1188,23 +1019,18 @@ async function runScenario(scenario, index) {
 
   // labelsAdded
   if (expected.labelsAdded !== undefined) {
-    if (typeof expected.labelsAdded === "number") {
+    if (typeof expected.labelsAdded === 'number') {
       if (calls.labelsAdded.length !== expected.labelsAdded) {
-        failures.push(
-          `labelsAdded count: expected ${expected.labelsAdded}, got ${calls.labelsAdded.length}`,
-        );
+        failures.push(`labelsAdded count: expected ${expected.labelsAdded}, got ${calls.labelsAdded.length}`);
       }
     } else if (Array.isArray(expected.labelsAdded)) {
       for (const exp of expected.labelsAdded) {
         const found = calls.labelsAdded.some(
-          (a) =>
-            a.issue_number === exp.issue_number &&
-            JSON.stringify(a.labels) === JSON.stringify(exp.labels),
+          a => a.issue_number === exp.issue_number &&
+               JSON.stringify(a.labels) === JSON.stringify(exp.labels)
         );
         if (!found) {
-          failures.push(
-            `Expected labels ${JSON.stringify(exp.labels)} added on #${exp.issue_number}`,
-          );
+          failures.push(`Expected labels ${JSON.stringify(exp.labels)} added on #${exp.issue_number}`);
         }
       }
     }
@@ -1212,21 +1038,17 @@ async function runScenario(scenario, index) {
 
   // labelsRemoved
   if (expected.labelsRemoved !== undefined) {
-    if (typeof expected.labelsRemoved === "number") {
+    if (typeof expected.labelsRemoved === 'number') {
       if (calls.labelsRemoved.length !== expected.labelsRemoved) {
-        failures.push(
-          `labelsRemoved count: expected ${expected.labelsRemoved}, got ${calls.labelsRemoved.length}`,
-        );
+        failures.push(`labelsRemoved count: expected ${expected.labelsRemoved}, got ${calls.labelsRemoved.length}`);
       }
     } else if (Array.isArray(expected.labelsRemoved)) {
       for (const exp of expected.labelsRemoved) {
         const found = calls.labelsRemoved.some(
-          (r) => r.issue_number === exp.issue_number && r.name === exp.name,
+          r => r.issue_number === exp.issue_number && r.name === exp.name
         );
         if (!found) {
-          failures.push(
-            `Expected label "${exp.name}" removed on #${exp.issue_number}`,
-          );
+          failures.push(`Expected label "${exp.name}" removed on #${exp.issue_number}`);
         }
       }
     }
@@ -1234,24 +1056,18 @@ async function runScenario(scenario, index) {
 
   // assigneesRemoved
   if (expected.assigneesRemoved !== undefined) {
-    if (typeof expected.assigneesRemoved === "number") {
+    if (typeof expected.assigneesRemoved === 'number') {
       if (calls.assigneesRemoved.length !== expected.assigneesRemoved) {
-        failures.push(
-          `assigneesRemoved count: expected ${expected.assigneesRemoved}, got ${calls.assigneesRemoved.length}`,
-        );
+        failures.push(`assigneesRemoved count: expected ${expected.assigneesRemoved}, got ${calls.assigneesRemoved.length}`);
       }
     } else if (Array.isArray(expected.assigneesRemoved)) {
       for (const exp of expected.assigneesRemoved) {
         const found = calls.assigneesRemoved.some(
-          (r) =>
-            r.issue_number === exp.issue_number &&
-            JSON.stringify(r.assignees.sort()) ===
-              JSON.stringify(exp.assignees.sort()),
+          r => r.issue_number === exp.issue_number &&
+               JSON.stringify(r.assignees.sort()) === JSON.stringify(exp.assignees.sort())
         );
         if (!found) {
-          failures.push(
-            `Expected assignees ${JSON.stringify(exp.assignees)} removed on #${exp.issue_number}`,
-          );
+          failures.push(`Expected assignees ${JSON.stringify(exp.assignees)} removed on #${exp.issue_number}`);
         }
       }
     }
@@ -1260,7 +1076,7 @@ async function runScenario(scenario, index) {
   // assigneesRemovedOn — just check items (not specific logins)
   if (expected.assigneesRemovedOn) {
     for (const num of expected.assigneesRemovedOn) {
-      const found = calls.assigneesRemoved.some((r) => r.issue_number === num);
+      const found = calls.assigneesRemoved.some(r => r.issue_number === num);
       if (!found) {
         failures.push(`Expected assignees removed on #${num}`);
       }
@@ -1270,31 +1086,19 @@ async function runScenario(scenario, index) {
   // linkedIssueCleaned — issue was reset (assignees removed AND ready-for-dev label added)
   if (expected.linkedIssueCleaned) {
     for (const num of expected.linkedIssueCleaned) {
-      const unassigned = calls.assigneesRemoved.some(
-        (r) => r.issue_number === num,
-      );
-      const relabeled = calls.labelsAdded.some(
-        (r) =>
-          r.issue_number === num && r.labels.includes(LABELS.READY_FOR_DEV),
-      );
-      if (!unassigned)
-        failures.push(`Expected assignees removed on linked issue #${num}`);
-      if (!relabeled)
-        failures.push(
-          `Expected "${LABELS.READY_FOR_DEV}" added on linked issue #${num}`,
-        );
+      const unassigned = calls.assigneesRemoved.some(r => r.issue_number === num);
+      const relabeled  = calls.labelsAdded.some(r => r.issue_number === num && r.labels.includes(LABELS.READY_FOR_DEV));
+      if (!unassigned) failures.push(`Expected assignees removed on linked issue #${num}`);
+      if (!relabeled)  failures.push(`Expected "${LABELS.READY_FOR_DEV}" added on linked issue #${num}`);
     }
   }
 
   // checkinPostedOn — blocked check-in marker appears in created or updated comments
   if (expected.checkinPostedOn) {
-    const CHECKIN_MARKER = "<!-- bot:blocked-checkin -->";
+    const CHECKIN_MARKER = '<!-- bot:blocked-checkin -->';
     for (const num of expected.checkinPostedOn) {
-      const found =
-        calls.commentsCreated.some(
-          (c) => c.issue_number === num && c.body.startsWith(CHECKIN_MARKER),
-        ) ||
-        calls.commentsUpdated.some((c) => c.body.startsWith(CHECKIN_MARKER));
+      const found = calls.commentsCreated.some(c => c.issue_number === num && c.body.startsWith(CHECKIN_MARKER))
+                 || calls.commentsUpdated.some(c => c.body.startsWith(CHECKIN_MARKER));
       if (!found) {
         failures.push(`Expected blocked check-in comment on #${num}`);
       }
@@ -1304,9 +1108,7 @@ async function runScenario(scenario, index) {
   // commentsUpdated count
   if (expected.commentsUpdated !== undefined) {
     if (calls.commentsUpdated.length !== expected.commentsUpdated) {
-      failures.push(
-        `commentsUpdated count: expected ${expected.commentsUpdated}, got ${calls.commentsUpdated.length}`,
-      );
+      failures.push(`commentsUpdated count: expected ${expected.commentsUpdated}, got ${calls.commentsUpdated.length}`);
     }
   }
 
@@ -1315,7 +1117,7 @@ async function runScenario(scenario, index) {
     return false;
   }
 
-  console.log("  ✅ All assertions passed");
+  console.log('  ✅ All assertions passed');
   return true;
 }
 
@@ -1323,4 +1125,4 @@ async function runScenario(scenario, index) {
 // ENTRY POINT
 // =============================================================================
 
-runTestSuite("INACTIVITY BOT TEST SUITE", scenarios, runScenario);
+runTestSuite('INACTIVITY BOT TEST SUITE', scenarios, runScenario);

--- a/.github/scripts/tests/test-inactivity-bot.js
+++ b/.github/scripts/tests/test-inactivity-bot.js
@@ -938,6 +938,52 @@ const scenarios = [
       assigneesRemoved: 0,
     },
   },
+
+  // ── 30 ─────────────────────────────────────────────────────────────────────
+  {
+    name: 'Issue: two prior warning comments — only the latest is used for activity comparison',
+    description: 'When multiple warning comments exist, getLatestBotMarkerComment must pick the most recent one or else activity timing is wrong. With recent warning (daysAgo(4)) and activity (daysAgo(6)) between the warnings, correct code finds activity BEFORE recent warning (no re-post); wrong code using old warning would find activity AFTER it (re-post bug).',
+    github: createMockGithub({
+      assignedIssues: [
+        makeIssue(290, { createdAt: daysAgo(10), assignees: ['yuki'], labels: [LABELS.IN_PROGRESS] }),
+      ],
+      commentsByNumber: {
+        290: [
+          {
+            id: 9501,
+            user: { login: 'github-actions[bot]', type: 'Bot' },
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @yuki! This issue has been inactive for 5 days.',
+            created_at: daysAgo(10),
+            updated_at: daysAgo(10),
+          },
+          {
+            id: 9502,
+            user: { login: 'yuki', type: 'User' },
+            body: 'Still working on this!',
+            created_at: daysAgo(6),
+            updated_at: daysAgo(6),
+          },
+          {
+            id: 9503,
+            user: { login: 'github-actions[bot]', type: 'Bot' },
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @yuki! This issue has been inactive for 5 days.',
+            created_at: daysAgo(4),
+            updated_at: daysAgo(4),
+          },
+        ],
+      },
+      eventsByNumber: {
+        290: [makeAssignedEvent(daysAgo(10))],
+      },
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreated: 0,
+      commentsUpdated: 0,
+      labelsAdded: 0,
+      assigneesRemoved: 0,
+    },
+  },
 ];
 
 // =============================================================================

--- a/.github/scripts/tests/test-inactivity-bot.js
+++ b/.github/scripts/tests/test-inactivity-bot.js
@@ -697,6 +697,72 @@ const scenarios = [
       assigneesRemoved: 0,
     },
   },
+
+  // ── 23 ─────────────────────────────────────────────────────────────────────
+  {
+    name: 'Issue: warning exists, activity happened after warning, now inactive again — new warning posted',
+    description: 'A fresh warning should be posted when the clock was reset after the previous warning.',
+    github: createMockGithub({
+      assignedIssues: [
+        makeIssue(220, { createdAt: daysAgo(14), assignees: ['riley'], labels: [LABELS.IN_PROGRESS] }),
+      ],
+      commentsByNumber: {
+        220: [
+          {
+            id: 9201,
+            user: { login: 'github-actions[bot]', type: 'Bot' },
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @riley! This issue has been inactive for 5 days.',
+            created_at: daysAgo(10),
+            updated_at: daysAgo(10),
+          },
+          makeComment('riley', daysAgo(6)),
+        ],
+      },
+      eventsByNumber: {
+        220: [makeAssignedEvent(daysAgo(14))],
+      },
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreatedCount: 1,
+      warningPostedOn: [220],
+      commentsUpdated: 0,
+      labelsAdded: 0,
+      assigneesRemoved: 0,
+    },
+  },
+
+  // ── 24 ─────────────────────────────────────────────────────────────────────
+  {
+    name: 'Issue: warning exists, no activity since warning — no duplicate warning',
+    description: 'If no activity occurred after the existing warning, the bot should not post another warning.',
+    github: createMockGithub({
+      assignedIssues: [
+        makeIssue(230, { createdAt: daysAgo(6), assignees: ['sam'], labels: [LABELS.IN_PROGRESS] }),
+      ],
+      commentsByNumber: {
+        230: [
+          {
+            id: 9301,
+            user: { login: 'github-actions[bot]', type: 'Bot' },
+            body: '<!-- bot:inactivity-warning -->\n👋 Hey @sam! This issue has been inactive for 5 days.',
+            created_at: daysAgo(5),
+            updated_at: daysAgo(5),
+          },
+        ],
+      },
+      eventsByNumber: {
+        230: [makeAssignedEvent(daysAgo(6))],
+      },
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreated: 0,
+      commentsUpdated: 0,
+      labelsAdded: 0,
+      assigneesRemoved: 0,
+    },
+  },
 ];
 
 // =============================================================================

--- a/.github/scripts/tests/test-on-pr-open-bot.js
+++ b/.github/scripts/tests/test-on-pr-open-bot.js
@@ -402,6 +402,7 @@ const scenarios = [
       existingComments: [
         {
           id: 999,
+          user: { login: 'github-actions[bot]', type: 'Bot' },
           body: `${MARKER}\n\nOld comment content`,
         },
       ],

--- a/.github/scripts/tests/test-on-pr-update-bot.js
+++ b/.github/scripts/tests/test-on-pr-update-bot.js
@@ -300,7 +300,7 @@ const syncScenarios = [
       commits: passingCommits(2),
       mergeable: true,
       comments: [
-        { id: 999, body: `${MARKER}\nOld content with DCO fail` },
+        { id: 999, user: { login: 'github-actions[bot]', type: 'Bot' }, body: `${MARKER}\nOld content with DCO fail` },
       ],
       prLabels: [{ name: LABELS.NEEDS_REVISION }],
       prUser: { login: 'henry', type: 'User' },
@@ -357,7 +357,7 @@ const syncScenarios = [
       commits: passingCommits(),
       mergeable: true,
       comments: [
-        { id: 111, body: `${MARKER}\nPrevious bot comment` },
+        { id: 111, user: { login: 'github-actions[bot]', type: 'Bot' }, body: `${MARKER}\nPrevious bot comment` },
       ],
       prLabels: [],
       prUser: { login: 'jane', type: 'User' },
@@ -733,7 +733,7 @@ const editScenarios = [
       issues: { 42: { title: 'Bug', assignees: [{ login: 'contributor' }] } },
       graphqlClosingIssues: [],
       existingComments: [
-        { id: 999, body: `${MARKER}\n\nOld comment content` },
+        { id: 999, user: { login: 'github-actions[bot]', type: 'Bot' }, body: `${MARKER}\n\nOld comment content` },
       ],
     },
     expect: {


### PR DESCRIPTION
**Description**:

Fix the inactivity bot so warning comments are posted again after a contributor becomes active and then goes inactive a second time. The bot now preserves prior warning comments instead of updating them in place, which ensures a fresh GitHub notification is sent each time the 5-day inactivity threshold is crossed after activity has reset the clock.

* Detect the latest inactivity warning comment by its HTML marker.
* Post a new warning comment when no prior warning exists.
* Post a new warning comment when activity occurred after the previous warning was posted.
* Skip posting a duplicate warning when no activity has occurred since the existing warning.
* Keep assignee mentions in warning comments so contributors still receive notifications.
* Add regression coverage for both the repost and idempotent no-duplicate paths.

**Related issue(s)**:

Fixes #1456

**Notes for reviewer**:

The fix is intentionally scoped to the inactivity warning path in `.github/scripts/bot-inactivity.js`. I did not change the shared `helpers/api.js` comment helper because it is still required for other bot flows, especially blocked-item check-ins, where update-in-place behavior remains correct.

Validation:
- Ran `.github/scripts/tests/test-inactivity-bot.js`
- Result: 24/24 tests passed

**Checklist**

- [x] Documented (Code comments)
- [x] Tested (unit, integration, etc.)