### PR TITLE
test: add ToString unit test for NetworkVersionInfo

### DIFF
--- a/src/sdk/tests/unit/NetworkVersionInfoUnitTests.cc
+++ b/src/sdk/tests/unit/NetworkVersionInfoUnitTests.cc
@@ -98,3 +98,18 @@ TEST_F(NetworkVersionInfoUnitTests, ToBytes)
   // Then
   EXPECT_EQ(bytes, internal::Utilities::stringToByteVector(networkVersionInfo.toProtobuf()->SerializeAsString()));
 }
+
+//-----
+TEST_F(NetworkVersionInfoUnitTests, ToString)
+{
+  // Given
+  const NetworkVersionInfo networkVersionInfo(getTestHapiVersion(), getTestServicesVersion());
+
+  // When
+  const std::string result = networkVersionInfo.toString();
+
+  // Then
+  EXPECT_FALSE(result.empty());
+  EXPECT_NE(result.find(getTestHapiVersion().toString()), std::string::npos);
+  EXPECT_NE(result.find(getTestServicesVersion().toString()), std::string::npos);
+}


### PR DESCRIPTION
**Description**:
Add a unit test for `NetworkVersionInfo::toString()` to ensure its output is properly validated.

* Add `ToString` test in `NetworkVersionInfoUnitTests.cc`
* Verify output is non empty
* Verify output contains both protobuf and services version strings
* Follow existing test patterns used in similar unit tests

Fixes #1351

**Notes for reviewer**:
- No production code changes
- Test follows the same structure as `TokenAssociationUnitTests` and `ExchangeRateUnitTests`
- Keeps validation minimal (no strict JSON comparison, only content checks)

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
