### PR TITLE
fix(finalize-bot): remove kind label requirement

### DIFF
--- a/.github/scripts/commands/finalize.js
+++ b/.github/scripts/commands/finalize.js
@@ -119,8 +119,6 @@ function formatLabelList(labels) {
  *   - status: awaiting triage must be present
  *   - exactly 1 skill: label
  *   - exactly 1 priority: label
- *   - Bug / Task: exactly 1 kind: label
- *   - Feature: 0 kind: labels
  *   - issue type must be Bug, Feature, or Task
  *
  * @param {object} issue - The issue object from the GitHub payload.
@@ -131,7 +129,7 @@ function collectLabelViolations(issue) {
 
   const skillLabels = getLabelsByPrefix(issue, 'skill:');
   const priorityLabels = getLabelsByPrefix(issue, 'priority:');
-  const kindLabels = getLabelsByPrefix(issue, 'kind:');
+
   const issueTypeName = getIssueTypeName(issue);
 
   // 1. status: awaiting triage must be present
@@ -165,28 +163,11 @@ function collectLabelViolations(issue) {
     );
   }
 
-  // 4. Issue type + kind: label enforcement
+  // 4. Issue type must be recognized
   if (!issueTypeName) {
     errors.push(
       `The issue type (Bug, Feature, or Task) could not be determined. Ensure the issue was submitted using one of the official issue templates.`
     );
-  } else if (issueTypeName === 'Feature') {
-    if (kindLabels.length > 0) {
-      errors.push(
-        `Feature issues should not have a \`kind:\` label. Found: ${formatLabelList(kindLabels)}. Please remove it.`
-      );
-    }
-  } else {
-    // Bug or Task: exactly 1 kind: label required
-    if (kindLabels.length === 0) {
-      errors.push(
-        `${issueTypeName} issues require exactly one \`kind:\` label (e.g. \`kind: maintenance\`). None found.`
-      );
-    } else if (kindLabels.length > 1) {
-      errors.push(
-        `${issueTypeName} issues require exactly one \`kind:\` label. Found ${kindLabels.length}: ${formatLabelList(kindLabels)}. Please remove all but one.`
-      );
-    }
   }
 
   return errors;

--- a/.github/scripts/tests/test-finalize-bot.js
+++ b/.github/scripts/tests/test-finalize-bot.js
@@ -114,7 +114,6 @@ function makeIssue(overrides = {}) {
       { name: LABELS.AWAITING_TRIAGE },
       { name: LABELS.BEGINNER },
       { name: 'priority: medium' },
-      { name: 'kind: maintenance' },
     ],
     type: { name: 'Task' },
     assignees: [],
@@ -297,10 +296,7 @@ const ERR_MISSING_TRIAGE = `The \`status: awaiting triage\` label must be presen
 const ERR_NO_SKILL = `Exactly one \`skill:\` label is required (e.g. \`skill: beginner\`). None found. Choose from: \`skill: good first issue\`, \`skill: beginner\`, \`skill: intermediate\`, \`skill: advanced\`.`;
 const ERR_MULTIPLE_SKILLS = `Exactly one \`skill:\` label is required. Found 2: \`skill: beginner\`, \`skill: intermediate\`. Please remove all but one.`;
 const ERR_NO_PRIORITY = `Exactly one \`priority:\` label is required (e.g. \`priority: medium\`). None found.`;
-const ERR_TASK_NO_KIND = `Task issues require exactly one \`kind:\` label (e.g. \`kind: maintenance\`). None found.`;
-const ERR_BUG_NO_KIND = `Bug issues require exactly one \`kind:\` label (e.g. \`kind: maintenance\`). None found.`;
-const ERR_FEATURE_WITH_KIND_ENHANCEMENT = `Feature issues should not have a \`kind:\` label. Found: \`kind: enhancement\`. Please remove it.`;
-const ERR_FEATURE_WITH_KIND_MAINTENANCE = `Feature issues should not have a \`kind:\` label. Found: \`kind: maintenance\`. Please remove it.`;
+
 const ERR_UNKNOWN_TYPE = `The issue type (Bug, Feature, or Task) could not be determined. Ensure the issue was submitted using one of the official issue templates.`;
 
 // =============================================================================
@@ -361,7 +357,6 @@ const scenarios = [
         { name: LABELS.READY_FOR_DEV },
         { name: LABELS.BEGINNER },
         { name: 'priority: medium' },
-        { name: 'kind: maintenance' },
       ],
       type: { name: 'Task' },
     })),
@@ -380,7 +375,6 @@ const scenarios = [
       labels: [
         { name: LABELS.AWAITING_TRIAGE },
         { name: 'priority: medium' },
-        { name: 'kind: maintenance' },
       ],
       type: { name: 'Task' },
     })),
@@ -400,7 +394,6 @@ const scenarios = [
         { name: LABELS.BEGINNER },
         { name: LABELS.INTERMEDIATE },
         { name: 'priority: medium' },
-        { name: 'kind: maintenance' },
       ],
       type: { name: 'Task' },
     })),
@@ -418,7 +411,6 @@ const scenarios = [
       labels: [
         { name: LABELS.AWAITING_TRIAGE },
         { name: LABELS.BEGINNER },
-        { name: 'kind: maintenance' },
       ],
       type: { name: 'Task' },
     })),
@@ -430,72 +422,16 @@ const scenarios = [
   },
 
   {
-    name: 'Validation — Task missing kind label',
-    description: 'Task issues require exactly one kind: label',
-    context: makeContext(makeIssue({
-      labels: [
-        { name: LABELS.AWAITING_TRIAGE },
-        { name: LABELS.BEGINNER },
-        { name: 'priority: medium' },
-      ],
-      type: { name: 'Task' },
-    })),
-    githubOptions: { roleName: 'triage' },
-    expectedComments: [validationComment(ERR_TASK_NO_KIND)],
-    assertions: [
-      assert.noIssueUpdate(),
-    ],
-  },
-
-  {
-    name: 'Validation — Bug missing kind label',
-    description: 'Bug issues require exactly one kind: label',
-    context: makeContext(makeIssue({
-      labels: [
-        { name: LABELS.AWAITING_TRIAGE },
-        { name: LABELS.BEGINNER },
-        { name: 'priority: medium' },
-      ],
-      type: { name: 'Bug' },
-    })),
-    githubOptions: { roleName: 'triage' },
-    expectedComments: [validationComment(ERR_BUG_NO_KIND)],
-    assertions: [
-      assert.noIssueUpdate(),
-    ],
-  },
-
-  {
-    name: 'Validation — Feature with kind label',
-    description: 'Feature issues must NOT have a kind: label',
-    context: makeContext(makeIssue({
-      labels: [
-        { name: LABELS.AWAITING_TRIAGE },
-        { name: LABELS.BEGINNER },
-        { name: 'priority: medium' },
-        { name: 'kind: enhancement' },
-      ],
-      type: { name: 'Feature' },
-    })),
-    githubOptions: { roleName: 'triage' },
-    expectedComments: [validationComment(ERR_FEATURE_WITH_KIND_ENHANCEMENT)],
-    assertions: [
-      assert.noIssueUpdate(),
-    ],
-  },
-
-  {
     name: 'Validation — Multiple violations listed in one comment',
-    description: 'All violations (no skill, no priority, wrong kind for feature) reported together',
+    description: 'All violations (no skill, no priority) reported together',
     context: makeContext(makeIssue({
       labels: [
         { name: LABELS.AWAITING_TRIAGE },
-        { name: 'kind: maintenance' },
       ],
       type: { name: 'Feature' },
     })),
     githubOptions: { roleName: 'admin' },
-    expectedComments: [validationComment(ERR_NO_SKILL, ERR_NO_PRIORITY, ERR_FEATURE_WITH_KIND_MAINTENANCE)],
+    expectedComments: [validationComment(ERR_NO_SKILL, ERR_NO_PRIORITY)],
     assertions: [
       assert.noIssueUpdate(),
     ],
@@ -569,7 +505,6 @@ const scenarios = [
         { name: LABELS.AWAITING_TRIAGE },
         { name: LABELS.INTERMEDIATE },
         { name: 'priority: high' },
-        { name: 'kind: security' },
       ],
       type: { name: 'Bug' },
     })),
@@ -594,7 +529,6 @@ const scenarios = [
         { name: LABELS.AWAITING_TRIAGE },
         { name: LABELS.ADVANCED },
         { name: 'priority: medium' },
-        { name: 'kind: maintenance' },
         { name: 'scope: ci' },
       ],
       type: { name: 'Task' },
@@ -620,7 +554,6 @@ const scenarios = [
         { name: LABELS.AWAITING_TRIAGE },
         { name: LABELS.ADVANCED },
         { name: 'priority: medium' },
-        { name: 'kind: maintenance' },
       ],
       type: { name: 'Task' },
     })),
@@ -687,7 +620,6 @@ const scenarios = [
         { name: LABELS.AWAITING_TRIAGE },
         { name: LABELS.BEGINNER },
         { name: 'priority: medium' },
-        { name: 'kind: maintenance' },
       ],
       type: { name: 'Task' },
     })),

--- a/docs/contributing/issue-types.md
+++ b/docs/contributing/issue-types.md
@@ -68,10 +68,10 @@ A useful test: *Would this change appear in the SDK's public API documentation o
 
 ### Not a feature
 
-- An improvement to an existing feature → that's a **Task** (`kind: enhancement`)
+- An improvement to an existing feature → that's a **Task**
 - A fix for broken existing behavior → that's a **Bug**
-- A refactor that doesn't change the public API → that's a **Task** (`kind: refactor`)
-- A new bot command, CI workflow, issue template, or contributor tooling addition → that's a **Task** (`kind: maintenance`), even if it's genuinely "new" — it improves the development process, not the SDK's public capabilities
+- A refactor that doesn't change the public API → that's a **Task**
+- A new bot command, CI workflow, issue template, or contributor tooling addition → that's a **Task**, even if it's genuinely "new" — it improves the development process, not the SDK's public capabilities
 
 ### What makes a good feature request
 
@@ -92,21 +92,6 @@ or a [GitHub Discussion](https://github.com/hiero-ledger/hiero-sdk-cpp/discussio
 A **task** is maintenance, improvement, or operational work that keeps the SDK healthy and easy to contribute to.
 
 Use the **Task** template when the work isn't a bug fix and doesn't add new public API surface — it improves the existing codebase.
-
-### Examples of tasks
-
-| What you want to do | `kind:` label to use |
-|---|---|
-| Improve or clarify documentation or code comments | `kind: documentation` |
-| Refactor existing code without changing behavior | `kind: refactor` |
-| Update a dependency or build tooling | `kind: maintenance` |
-| Improve CI/CD pipelines or GitHub Actions workflows | `kind: maintenance` |
-| Add or improve tests | `kind: testing` |
-| Improve performance of existing functionality | `kind: enhancement` |
-| Improve an existing feature without adding new API | `kind: enhancement` |
-| Address a security concern that isn't a regression | `kind: security` |
-
-> **Note:** The `kind:` label is applied by maintainers during triage — you don't need to choose it when submitting. Just describe what needs to be done and why.
 
 ### Not a task
 
@@ -131,7 +116,7 @@ When you submit an issue using any of the three templates, it is automatically l
 A maintainer will then:
 
 1. Review the issue for completeness
-2. Apply the appropriate **skill level**, **priority**, **kind** (for bugs and tasks), and **scope** labels
+2. Apply the appropriate **skill level**, **priority**, and **scope** labels
 3. Run `/finalize`, which updates the issue title and description to the standard format and marks it `status: ready for dev`
 
 Once an issue is `status: ready for dev`, any contributor meeting the skill prerequisites can comment `/assign` to pick it up.

--- a/docs/maintainers/guidelines-triage.md
+++ b/docs/maintainers/guidelines-triage.md
@@ -35,7 +35,6 @@ All of the following must be applied before `/finalize` will succeed:
 |---|---|---|
 | `skill:` | **Exactly 1** — how hard is this to implement? | `skill: beginner`, `skill: advanced` |
 | `priority:` | **Exactly 1** — how urgently should this be done? | `priority: medium`, `priority: high` |
-| `kind:` | **Exactly 1** for Bug and Task; **0** for Feature | `kind: maintenance`, `kind: refactor` |
 | `scope:` | **0 or more** — which part of the SDK is affected? | `scope: api`, `scope: grpc` |
 
 > The `status:` label is managed automatically by the bot and should not be changed manually unless something goes wrong.
@@ -59,17 +58,6 @@ As a quick reference:
 | `skill: advanced` | 3+ days | Experienced contributors |
 
 > **Note:** Time estimates are rough orientation guides, not hard targets — a change's true complexity depends on the contributor's familiarity and the specifics of the issue. See the linked guidelines above for the full criteria used to assign each level.
-
-#### Choosing a kind label (for bugs and tasks)
-
-| Kind | When to use |
-|---|---|
-| `kind: enhancement` | Improving existing functionality without adding new public API |
-| `kind: documentation` | README, guides, API doc comments |
-| `kind: refactor` | Code restructuring without behavior change |
-| `kind: security` | Security-related improvements or hardening |
-| `kind: testing` | Adding or improving tests |
-| `kind: maintenance` | Dependencies, build system, CI/CD |
 
 ### 3. Edit the issue body if needed
 
@@ -114,8 +102,6 @@ Common fixes:
 | No `skill:` label | Apply one of the four skill labels |
 | Multiple `skill:` labels | Remove all but one |
 | No `priority:` label | Apply a priority label |
-| Bug/Task missing `kind:` label | Apply the appropriate kind label |
-| Feature has a `kind:` label | Remove the kind label |
 | `status: awaiting triage` not present | Check that the issue hasn't already been finalized |
 
 After fixing the labels, comment `/finalize` again.


### PR DESCRIPTION
**Description**:

Remove the `kind:` label enforcement from the `/finalize` bot and all supporting documentation. The bot now only checks that the base issue type (Bug, Feature, or Task) is valid without enforcing additional `kind:` prefixes.

* Simplify label violation validation in `.github/scripts/commands/finalize.js` to rely exclusively on the `issueTypeName` validation.
* Remove default `kind: maintenance` assertions and error constants from the finalize bot test suite (`test-finalize-bot.js`).
* Refactor existing integration tests by removing test cases strictly dependent on missing or invalid `kind:` labels.
* Audit and update the maintainer triage guidelines (`guidelines-triage.md`) to remove the `kind:` label assignment matrix.
* Audit and update contributor issue types documentation (`issue-types.md`) to strip all mention of `kind:` label sub-categories.

**Related issue(s)**:

Fixes #1443

**Notes for reviewer**:

The issue type validation (`Bug`, `Feature`, `Task`) acts as a standalone check, so removing the `kind:` label logic strictly cleans up the secondary validation tier. No other formatting logic or label requirements (`skill:`, `priority:`, `status:`) were affected.

Validation:
- Ran `node .github/scripts/tests/test-finalize-bot.js`
- Result: 32/32 tests passed (14 Unit Tests, 18 Integration Tests)

**Checklist**

- [x] Documented (Documentation Markdown files updated)
- [x] Tested (unit, integration, etc.)
