### PR TITLE
docs: fix grammar in TransactionId.h

### DIFF
--- a/src/sdk/main/include/TransactionId.h
+++ b/src/sdk/main/include/TransactionId.h
@@ -361,7 +361,7 @@ public:
   /**
    * Get this TransactionId's nonce value.
    *
-   * @return The nonce value for of TransactionId.
+   * @return The nonce value of TransactionId.
    */
   [[nodiscard]] inline int getNonce() const { return mNonce; }
 


### PR DESCRIPTION
**Description**:
Fix a minor grammar issue in a doc comment within `TransactionId.h`.

* Remove word "for" from the phrase "value for of"

Fixes #1317

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)