### PR TITLE
fix: sort recommended issues by oldest created date

### DIFF
--- a/.github/scripts/commands/recommend-issues.js
+++ b/.github/scripts/commands/recommend-issues.js
@@ -110,6 +110,8 @@ async function fetchIssuesBatch(github, owner, repo) {
         const result = await github.rest.search.issuesAndPullRequests({
             q: query,
             per_page: 50,
+            sort: 'created',
+            order: 'asc',
         });
 
         return result.data.items || [];


### PR DESCRIPTION
**Description**:

* Add `sort: 'created'` to the GitHub search API call in `fetchIssuesBatch`
* Add `order: 'asc'` to ensure the oldest issues are returned first

**Related issue(s)**:

Fixes #1464

**Notes for reviewer**:
Verified the change by running the local test suite: `node .github/scripts/tests/test-recommend-issues-bot.js`. The search query parameters were updated to move away from the GitHub default relevance ranking, effectively preventing any single issue from sitting unnoticed indefinitely.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)