### PR TITLE
 chore: improve inactivity bot per-item activity summary logging

### DIFF
--- a/.github/scripts/bot-inactivity.js
+++ b/.github/scripts/bot-inactivity.js
@@ -444,8 +444,7 @@ async function handleStaleItem(github, owner, repo, item, lastActivityMs, itemTy
   const assigneeLogins = (item.assignees || []).map(a => a.login);
 
   if (elapsed >= CLOSE_AFTER_MS) {
-    if (itemType === 'issue') {
-    } else {
+    if (itemType === 'PR') {
       await closeItem(ctx);
     }
     await resetItem(github, owner, repo, item);

--- a/.github/scripts/bot-inactivity.js
+++ b/.github/scripts/bot-inactivity.js
@@ -399,6 +399,31 @@ async function resetItem(github, owner, repo, item) {
 // ─── Stale and blocked handlers ───────────────────────────────────────────────
 
 /**
+ * Formats a one-line per-item activity summary log.
+ *
+ * @param {object} item - Issue or PR object with .number and .assignees.
+ * @param {string} itemType - 'issue' or 'PR'
+ * @param {number} lastActivityMs - Timestamp of last meaningful activity.
+ * @param {number} nowMs - Current time in ms.
+ * @param {'closed'|'warned'|'none'} result
+ * @returns {string}
+ */
+function formatActivitySummary(item, itemType, lastActivityMs, nowMs, result) {
+  const days = Math.floor((nowMs - lastActivityMs) / (24 * 60 * 60 * 1000));
+  const assigneeLogins = (item.assignees || []).map(a => a.login);
+  const assignees = assigneeLogins.length > 0 ? assigneeLogins.join(', ') : 'none';
+
+  let action = 'no action needed';
+  if (result === 'warned') {
+    action = 'posting inactivity warning';
+  } else if (result === 'closed') {
+    action = itemType === 'PR' ? 'closing PR' : 'unassigning and resetting issue';
+  }
+
+  return `#${item.number} (${itemType}): last activity ${days}d ago (assigned: ${assignees}), ${action}`;
+}
+
+/**
  * Applies the appropriate stale action to an item.
  * - If >= 7 days inactive: close, post closure comment, reset.
  * - If >= 5 days inactive: post or update warning comment.
@@ -410,21 +435,17 @@ async function resetItem(github, owner, repo, item) {
  * @param {object} item - Issue or PR object.
  * @param {number} lastActivityMs - Timestamp of last meaningful activity.
  * @param {string} itemType - 'issue' or 'PR'
- * @param {object} logger
  * @param {number} nowMs - Current time in ms (injectable for testing).
  * @returns {Promise<'closed'|'warned'|'none'>}
  */
-async function handleStaleItem(github, owner, repo, item, lastActivityMs, itemType, logger, nowMs) {
+async function handleStaleItem(github, owner, repo, item, lastActivityMs, itemType, nowMs) {
   const ctx = buildCtx(github, owner, repo, item.number);
   const elapsed = nowMs - lastActivityMs;
-  const days = Math.floor(elapsed / (24 * 60 * 60 * 1000));
   const assigneeLogins = (item.assignees || []).map(a => a.login);
 
   if (elapsed >= CLOSE_AFTER_MS) {
     if (itemType === 'issue') {
-      logger.log(`#${item.number} (${itemType}): resetting after ${days} days inactive`);
     } else {
-      logger.log(`#${item.number} (${itemType}): closing after ${days} days inactive`);
       await closeItem(ctx);
     }
     await resetItem(github, owner, repo, item);
@@ -433,7 +454,6 @@ async function handleStaleItem(github, owner, repo, item, lastActivityMs, itemTy
   }
 
   if (elapsed >= WARN_AFTER_MS) {
-    logger.log(`#${item.number} (${itemType}): warning after ${days} days inactive`);
     await postOrUpdateComment(ctx, WARN_MARKER, buildWarningComment(assigneeLogins, itemType));
     return 'warned';
   }
@@ -610,7 +630,8 @@ module.exports = async function ({ github, context, getNow = () => Date.now() })
       lastActivity = await computePRLastActivity(github, owner, repo, pr);
     }
 
-    const result = await handleStaleItem(github, owner, repo, pr, lastActivity, 'PR', logger, nowMs);
+    const result = await handleStaleItem(github, owner, repo, pr, lastActivity, 'PR', nowMs);
+    logger.log(formatActivitySummary(pr, 'PR', lastActivity, nowMs, result));
 
     if (result === 'closed') {
       // Clean up issues linked to this PR immediately
@@ -652,7 +673,8 @@ module.exports = async function ({ github, context, getNow = () => Date.now() })
       logger.log(`#${issue.number}: skipping (no assigned event found)`);
       continue;
     }
-    await handleStaleItem(github, owner, repo, issue, lastActivity, 'issue', logger, nowMs);
+    const result = await handleStaleItem(github, owner, repo, issue, lastActivity, 'issue', nowMs);
+    logger.log(formatActivitySummary(issue, 'issue', lastActivity, nowMs, result));
   }
 
   logger.log('Inactivity check complete');

--- a/.github/scripts/commands/assign.js
+++ b/.github/scripts/commands/assign.js
@@ -11,7 +11,6 @@ const {
   ISSUE_STATE,
   createDelegatingLogger,
   isNonNegativeInteger,
-  isSafeSearchToken,
   hasLabel,
   swapLabels,
   addAssignees,

--- a/.github/scripts/tests/test-inactivity-bot.js
+++ b/.github/scripts/tests/test-inactivity-bot.js
@@ -253,6 +253,7 @@ const scenarios = [
       commentsCreated: 0,
       labelsAdded: 0,
       assigneesRemoved: 0,
+      summaryLogs: ['#10 (issue): last activity 3d ago (assigned: alice), no action needed'],
     },
   },
 
@@ -274,6 +275,7 @@ const scenarios = [
       warningPostedOn: [20],
       labelsAdded: 0,
       assigneesRemoved: 0,
+      summaryLogs: ['#20 (issue): last activity 6d ago (assigned: alice), posting inactivity warning'],
     },
   },
 
@@ -295,6 +297,7 @@ const scenarios = [
       labelsAdded: [{ issue_number: 30, labels: [LABELS.READY_FOR_DEV] }],
       labelsRemoved: [{ issue_number: 30, name: LABELS.IN_PROGRESS }],
       assigneesRemoved: [{ issue_number: 30, assignees: ['alice'] }],
+      summaryLogs: ['#30 (issue): last activity 8d ago (assigned: alice), unassigning and resetting issue'],
     },
   },
 
@@ -410,6 +413,7 @@ const scenarios = [
       warningPostedOn: [80],
       labelsAdded: 0,
       assigneesRemoved: 0,
+      summaryLogs: ['#80 (PR): last activity 6d ago (assigned: dave), posting inactivity warning'],
     },
   },
 
@@ -441,6 +445,7 @@ const scenarios = [
       closureCommentOn: [90],
       linkedIssueCleaned: [91],
       assigneesRemovedOn: [90, 91],
+      summaryLogs: ['#90 (PR): last activity 8d ago (assigned: eve), closing PR'],
     },
   },
 
@@ -870,13 +875,29 @@ async function runScenario(scenario, index) {
   console.log(`[${index}] ${name}`);
   if (description) console.log(`    ${description}`);
 
+  const capturedLogs = [];
+  const originalConsoleLog = console.log;
+  const originalConsoleError = console.error;
+  console.log = (...args) => {
+    capturedLogs.push(args.map(a => String(a)).join(' '));
+    originalConsoleLog(...args);
+  };
+  console.error = (...args) => {
+    capturedLogs.push(args.map(a => String(a)).join(' '));
+    originalConsoleError(...args);
+  };
+
   try {
     await script({ github, context: defaultContext, getNow: () => NOW });
   } catch (err) {
+    console.log = originalConsoleLog;
+    console.error = originalConsoleError;
     console.error(`❌ Script threw: ${err.message}`);
     console.error(err.stack);
     return false;
   }
+  console.log = originalConsoleLog;
+  console.error = originalConsoleError;
 
   const { calls } = github;
   const failures = [];
@@ -1028,6 +1049,15 @@ async function runScenario(scenario, index) {
   if (expected.commentsUpdated !== undefined) {
     if (calls.commentsUpdated.length !== expected.commentsUpdated) {
       failures.push(`commentsUpdated count: expected ${expected.commentsUpdated}, got ${calls.commentsUpdated.length}`);
+    }
+  }
+
+  if (expected.summaryLogs) {
+    for (const expectedLine of expected.summaryLogs) {
+      const found = capturedLogs.some(line => line.includes(expectedLine));
+      if (!found) {
+        failures.push(`Expected summary log line: ${expectedLine}`);
+      }
     }
   }
 

--- a/.github/scripts/tests/test-recommend-issues-bot.js
+++ b/.github/scripts/tests/test-recommend-issues-bot.js
@@ -63,7 +63,7 @@ function createMockBotContext(overrides = {}) {
  * Builds a mock of `github.rest.issues.listForRepo` used by
  * countIssuesByAssignee.
  *
- * For a given (state, assignee, label), the mock returns a list of synthetic
+ * For a given (assignee, label), the mock returns a list of synthetic
  * issues whose size is determined by `closedCounts["label:username"]`.
  *
  * Behavior:
@@ -79,7 +79,7 @@ function createMockBotContext(overrides = {}) {
  * function respects pagination limits.
  */
 function buildListForRepo(closedCounts) {
-  return async ({ state, assignee, labels, per_page }) => {
+  return async ({ assignee, labels, per_page }) => {
     // Simulate full API outage.
     if (closedCounts === null) {
       throw new Error('listForRepo API error');


### PR DESCRIPTION
**Description**:
 Improve inactivity bot logs by emitting a single per-item summary line after stale evaluation, so each run is 
easier to scan and action outcomes are clear.
 
 * Add `formatActivitySummary(...)` helper to build consistent summary output
 * Remove redundant stale-action log lines from `handleStaleItem`
 * Remove unused `logger` parameter from `handleStaleItem` and update call sites
 * Log one summary line per processed assigned PR and issue after stale handling
 * Add test assertions for summary log output covering `none`, `warned`, and `closed` outcomes
 
 **Related issue(s)**:
 
 Fixes #1475
 
 **Notes for reviewer**:
 Executed:
 - `node .github/scripts/tests/test-inactivity-bot.js`
 
 Summary log format introduced:
 - `#N (type): last activity Xd ago (assigned: ...), action`
 
 **Checklist**
 
 - [x] Documented (Code comments, README, etc.)
 - [x] Tested (unit, integration, etc.)