### PR TITLE
feat: post notification comment when merge conflict is newly introduced

### DIFF
--- a/.github/scripts/bot-on-pr-merged.js
+++ b/.github/scripts/bot-on-pr-merged.js
@@ -12,10 +12,11 @@ const {
   fetchOpenPRs, 
   getBotComment, 
   runAllChecksAndComment, 
-  swapStatusLabel 
+  swapStatusLabel,
+  postComment 
 } = require('./helpers');
 const { checkMergeConflict } = require('./helpers/checks');
-const { MARKER } = require('./helpers/comments');
+const { MARKER, buildMergeConflictNotificationComment } = require('./helpers/comments');
 
 const logger = createLogger('on-pr-merged');
 
@@ -52,6 +53,15 @@ async function checkSiblingConflictsOnMerge(globalBotContext) {
       logger.log(`PR #${pr.number} conflict status changed to ${actuallyHasConflict ? 'conflicted' : 'clean'}, updating...`);
       const { allPassed } = await runAllChecksAndComment(prContext, { merge: mergeResult });
       await swapStatusLabel(prContext, allPassed);
+
+      // Post a standalone notification when a conflict is newly introduced
+      if (!currentlyShowsConflict && actuallyHasConflict) {
+        const prAuthor = pr.user?.login;
+        if (prAuthor) {
+          const notification = buildMergeConflictNotificationComment(prAuthor, mergedPRNumber);
+          await postComment(prContext, notification);
+        }
+      }
     } else {
       logger.log(`PR #${pr.number} conflict status unchanged (${actuallyHasConflict ? 'conflicted' : 'clean'}), skipping...`);
     }

--- a/.github/scripts/helpers/comments.js
+++ b/.github/scripts/helpers/comments.js
@@ -94,6 +94,23 @@ function buildMergeSection(merge) {
 }
 
 /**
+ * Builds a standalone notification comment to alert a PR author that a
+ * recently merged PR has introduced a merge conflict in their PR.
+ * This is posted once when the conflict state changes from clean to
+ * conflicted — it does NOT replace the dashboard comment.
+ *
+ * @param {string} prAuthor - GitHub username of the PR author.
+ * @param {number} mergedPRNumber - The PR number whose merge caused the conflict.
+ * @returns {string}
+ */
+function buildMergeConflictNotificationComment(prAuthor, mergedPRNumber) {
+  return [
+    `Hi @${prAuthor} :wave: — the recent merge of PR #${mergedPRNumber} has introduced a merge conflict in this PR.`,
+    `Please resolve the merge conflict so that this PR can be reviewed again. Thank you!`,
+  ].join(' ');
+}
+
+/**
  * @param {{ passed: boolean, reason?: string, issues?: Array<{ number: number, title: string, isAssigned: boolean }>, error?: boolean, errorMessage?: string }} issueLink
  * @returns {string}
  */
@@ -189,4 +206,5 @@ module.exports = {
   buildBotComment,
   buildChecksSection,
   allChecksPassed,
+  buildMergeConflictNotificationComment,
 };

--- a/.github/scripts/tests/test-comments.js
+++ b/.github/scripts/tests/test-comments.js
@@ -6,7 +6,7 @@
 // Run with: node .github/scripts/tests/test-comments.js
 
 const { runTestSuite } = require('./test-utils');
-const { MARKER, buildBotComment, buildChecksSection, allChecksPassed } = require('../helpers/comments');
+const { MARKER, buildBotComment, buildChecksSection, allChecksPassed, buildMergeConflictNotificationComment } = require('../helpers/comments');
 
 // =============================================================================
 // TEST DATA HELPERS
@@ -396,6 +396,38 @@ const unitTests = [
       ];
       const { body } = buildBotComment({ prAuthor: 'multi', ...data });
       return body.includes('#1') && body.includes('#2') && body.includes('assigned to you');
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // buildMergeConflictNotificationComment
+  // ---------------------------------------------------------------------------
+  {
+    name: 'Notification comment contains @prAuthor mention',
+    test: () => {
+      const comment = buildMergeConflictNotificationComment('alice', 42);
+      return comment.includes('@alice');
+    },
+  },
+  {
+    name: 'Notification comment references merged PR number',
+    test: () => {
+      const comment = buildMergeConflictNotificationComment('bob', 123);
+      return comment.includes('#123');
+    },
+  },
+  {
+    name: 'Notification comment includes wave emoji',
+    test: () => {
+      const comment = buildMergeConflictNotificationComment('carol', 7);
+      return comment.includes(':wave:');
+    },
+  },
+  {
+    name: 'Notification comment asks to resolve merge conflict',
+    test: () => {
+      const comment = buildMergeConflictNotificationComment('dave', 99);
+      return comment.includes('resolve the merge conflict');
     },
   },
 ];

--- a/.github/scripts/tests/test-on-pr-merged-bot.js
+++ b/.github/scripts/tests/test-on-pr-merged-bot.js
@@ -8,7 +8,7 @@
 
 const { runTestSuite, createMockGithub } = require('./test-utils');
 const onPrMergedBot = require('../bot-on-pr-merged');
-const { MARKER, buildMergeConflictNotificationComment } = require('../helpers/comments');
+const { MARKER } = require('../helpers/comments');
 
 // =============================================================================
 // SCENARIOS

--- a/.github/scripts/tests/test-on-pr-merged-bot.js
+++ b/.github/scripts/tests/test-on-pr-merged-bot.js
@@ -8,7 +8,7 @@
 
 const { runTestSuite, createMockGithub } = require('./test-utils');
 const onPrMergedBot = require('../bot-on-pr-merged');
-const { MARKER } = require('../helpers/comments');
+const { MARKER, buildMergeConflictNotificationComment } = require('../helpers/comments');
 
 // =============================================================================
 // SCENARIOS
@@ -39,8 +39,8 @@ const scenarios = [
       // Override pulls.list to return PR 20 and 30
       mockGithub.rest.pulls.list = async () => ({
         data: [
-          { number: 20, draft: false },
-          { number: 30, draft: false },
+          { number: 20, draft: false, user: { login: 'contributor-20' } },
+          { number: 30, draft: false, user: { login: 'contributor-30' } },
           { number: 40, draft: true } // skipped
         ]
       });
@@ -77,14 +77,17 @@ const scenarios = [
 
       await onPrMergedBot({ github: mockGithub, context });
 
-      // What should happen?
-      // PR 20: mergeable=true. Comment body doesn't say "Merge Conflicts". Match! No update.
-      // PR 30: mergeable=false. Comment body doesn't say "Merge Conflicts". Mismatch! Update!
-      // Draft PR 40: Skipped.
-      
       // So commentsUpdated should have length 1, for PR 30
-      if (mockGithub.calls.commentsCreated.length > 0) {
-        console.log('Expected no comments created, got:', mockGithub.calls.commentsCreated);
+      // And commentsCreated should have length 1 (the notification for PR 30)
+      if (mockGithub.calls.commentsCreated.length !== 1) {
+        console.log('Expected 1 notification comment created, got:', mockGithub.calls.commentsCreated.length);
+        return false;
+      }
+
+      // Verify the notification mentions the PR author and merged PR number
+      const notification = mockGithub.calls.commentsCreated[0];
+      if (!notification.includes('@contributor-30') || !notification.includes('#10')) {
+        console.log('Notification should tag PR author and reference merged PR. Got:', notification);
         return false;
       }
 
@@ -243,6 +246,140 @@ const scenarios = [
       const update = mockGithub.calls.commentsUpdated[0];
       if (update.body.includes(':x: **Merge Conflicts**')) {
         console.log('Update body should NOT contain Merge Conflicts error. Got:', update.body);
+        return false;
+      }
+
+      return true;
+    }
+  },
+  {
+    name: 'New conflict detected → notification comment posted tagging PR author',
+    run: async () => {
+      const mockGithub = createMockGithub();
+
+      mockGithub.rest.pulls.list = async () => ({
+        data: [{ number: 80, draft: false, user: { login: 'alice' } }]
+      });
+
+      mockGithub.rest.pulls.get = async () => ({
+        data: { mergeable: false, mergeable_state: 'dirty' }
+      });
+
+      // Dashboard currently shows clean (no conflict marker)
+      mockGithub.rest.issues.listComments = async () => {
+        return { data: [{ id: 801, body: `${MARKER}\nAll good` }] };
+      };
+
+      const context = {
+        eventName: 'pull_request',
+        repo: { owner: 'test', repo: 'repo' },
+        payload: { pull_request: { number: 10, merged: true, user: { login: 'merger' } } }
+      };
+
+      await onPrMergedBot({ github: mockGithub, context });
+
+      // Dashboard should be updated
+      if (mockGithub.calls.commentsUpdated.length !== 1) {
+        console.log('Expected 1 comment updated, got:', mockGithub.calls.commentsUpdated.length);
+        return false;
+      }
+
+      // Notification comment should be posted
+      if (mockGithub.calls.commentsCreated.length !== 1) {
+        console.log('Expected 1 notification comment, got:', mockGithub.calls.commentsCreated.length);
+        return false;
+      }
+
+      const notification = mockGithub.calls.commentsCreated[0];
+      if (!notification.includes('@alice')) {
+        console.log('Notification should tag PR author @alice. Got:', notification);
+        return false;
+      }
+      if (!notification.includes('#10')) {
+        console.log('Notification should reference merged PR #10. Got:', notification);
+        return false;
+      }
+
+      return true;
+    }
+  },
+  {
+    name: 'Conflict resolving (dirty → clean) → no notification comment posted',
+    run: async () => {
+      const mockGithub = createMockGithub({
+        existingComments: [
+          { id: 901, body: `${MARKER}\n:x: **Merge Conflicts**` }
+        ],
+      });
+
+      mockGithub.rest.pulls.list = async () => ({
+        data: [{ number: 90, draft: false, user: { login: 'bob' } }]
+      });
+
+      mockGithub.rest.pulls.get = async () => ({
+        data: { mergeable: true, mergeable_state: 'clean' }
+      });
+
+      mockGithub.rest.issues.listComments = async () => {
+        return { data: [{ id: 901, body: `${MARKER}\n:x: **Merge Conflicts**` }] };
+      };
+
+      const context = {
+        eventName: 'pull_request',
+        repo: { owner: 'test', repo: 'repo' },
+        payload: { pull_request: { number: 10, merged: true, user: { login: 'merger' } } }
+      };
+
+      await onPrMergedBot({ github: mockGithub, context });
+
+      // Dashboard should be updated (conflict resolved)
+      if (mockGithub.calls.commentsUpdated.length !== 1) {
+        console.log('Expected 1 comment updated, got:', mockGithub.calls.commentsUpdated.length);
+        return false;
+      }
+
+      // NO notification comment should be posted for conflict resolution
+      if (mockGithub.calls.commentsCreated.length !== 0) {
+        console.log('Expected 0 notification comments for conflict resolution, got:', mockGithub.calls.commentsCreated.length);
+        return false;
+      }
+
+      return true;
+    }
+  },
+  {
+    name: 'Conflict status unchanged (still conflicted) → no notification comment',
+    run: async () => {
+      const mockGithub = createMockGithub();
+
+      mockGithub.rest.pulls.list = async () => ({
+        data: [{ number: 100, draft: false, user: { login: 'charlie' } }]
+      });
+
+      mockGithub.rest.pulls.get = async () => ({
+        data: { mergeable: false, mergeable_state: 'dirty' }
+      });
+
+      // Dashboard already shows conflict
+      mockGithub.rest.issues.listComments = async () => {
+        return { data: [{ id: 1001, body: `${MARKER}\n:x: **Merge Conflicts**` }] };
+      };
+
+      const context = {
+        eventName: 'pull_request',
+        repo: { owner: 'test', repo: 'repo' },
+        payload: { pull_request: { number: 10, merged: true, user: { login: 'merger' } } }
+      };
+
+      await onPrMergedBot({ github: mockGithub, context });
+
+      // No updates or notifications expected
+      if (mockGithub.calls.commentsUpdated.length !== 0) {
+        console.log('Expected 0 comment updates, got:', mockGithub.calls.commentsUpdated.length);
+        return false;
+      }
+      if (mockGithub.calls.commentsCreated.length !== 0) {
+        console.log('Expected 0 notification comments, got:', mockGithub.calls.commentsCreated.length);
         return false;
       }
 

--- a/.github/workflows/zxc-test-bot-scripts.yaml
+++ b/.github/workflows/zxc-test-bot-scripts.yaml
@@ -72,3 +72,6 @@ jobs:
         
       - name: Run On-PR-Review Bot Tests
         run: node .github/scripts/tests/test-on-pr-review-bot.js
+
+      - name: Run On-PR-Merged Bot Tests
+        run: node .github/scripts/tests/test-on-pr-merged-bot.js


### PR DESCRIPTION
**Description**:

Post a standalone notification comment tagging the PR author when a merge conflict is newly introduced by a merged PR.

* Add `buildMergeConflictNotificationComment(prAuthor, mergedPRNumber)` to `helpers/comments.js`
* Call `postComment()` in `bot-on-pr-merged.js` when conflict state changes from clean to conflicted
* Add 4 unit tests for the new comment builder in `test-comments.js`
* Add 3 integration scenarios + update existing scenario in `test-on-pr-merged-bot.js`

Fixes #1479

**Notes for reviewer**:

The notification is only posted when `!currentlyShowsConflict && actuallyHasConflict` i.e., only for newly introduced conflicts. The dashboard comment continues to be updated as before, this is an addition not a replacement.

All 12 existing test suites pass with 0 failures.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)