### PR TITLE
chore: narrow CODEOWNERS .github rule to yml/yaml files only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,8 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hiero-ledger/github-maintainers 
+/.github/**/*.yml                               @hiero-ledger/github-maintainers
+/.github/**/*.yaml                              @hiero-ledger/github-maintainers
 /.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
 
 # Cmake project files and inline plugins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,8 +11,8 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/**/*.yml                               @hiero-ledger/github-maintainers
-/.github/**/*.yaml                              @hiero-ledger/github-maintainers
+/.github/                                       @hiero-ledger/github-maintainers
+/.github/scripts/                               @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
 /.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
 
 # Cmake project files and inline plugins


### PR DESCRIPTION
## Summary

The previous `/.github/` CODEOWNERS rule required `@hiero-ledger/github-maintainers` as a required reviewer for **all** files under `.github/`, including the JavaScript bot automation scripts in `.github/scripts/`. This PR replaces that broad rule with two narrower patterns that match only `.yml` and `.yaml` files, so `github-maintainers` are no longer pulled in as required reviewers on JS-only changes.

**Key Changes:**
- Replace the broad `/.github/` rule with `/.github/**/*.yml` and `/.github/**/*.yaml`
- The `/.github/workflows/` rule is unchanged (still requires all three teams)

---

## Changes

### CODEOWNERS — `.github/CODEOWNERS`

The following rule was **removed**:

```
/.github/                                       @hiero-ledger/github-maintainers
```

And replaced with two narrower rules:

```
/.github/**/*.yml                               @hiero-ledger/github-maintainers
/.github/**/*.yaml                              @hiero-ledger/github-maintainers
```

**Effect by file type under `.github/`:**

| File | Before | After |
|------|--------|-------|
| `workflows/*.yml` | `github-maintainers` (via broad rule), then overridden by workflows rule | `github-maintainers` + `sdk-maintainers` + `sdk-committers` (workflows rule wins) |
| `dependabot.yml` | `github-maintainers` | `github-maintainers` ✅ retained |
| `scripts/*.js` | `github-maintainers` | Falls through to global `*` rule (maintainers + committers only) |

---

## Testing

This change affects GitHub's code review enforcement, not compiled code, so there are no test suite commands to run. Correctness can be verified by reviewing GitHub's CODEOWNERS evaluation against the [GitHub CODEOWNERS documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).

**Verification checklist:**
- [x] `/.github/**/*.yml` matches `dependabot.yml` — `github-maintainers` still required
- [x] `/.github/**/*.yml` matches workflow files — workflows rule (last match) still requires all three teams
- [x] `/.github/scripts/*.js` — no longer matches any `github-maintainers` rule; falls to global `*`
- [x] `**/codecov.yml` rule is unchanged and still requires `github-maintainers`

---

## Files Changed Summary

| File | Change |
|------|--------|
| `.github/CODEOWNERS` | Modified — replaced 1 broad rule with 2 narrower rules |

