### PR TITLE
feat: add operator== for AccountInfo

### DIFF
--- a/src/sdk/main/include/AccountInfo.h
+++ b/src/sdk/main/include/AccountInfo.h
@@ -80,6 +80,15 @@ public:
   friend std::ostream& operator<<(std::ostream& os, const AccountInfo& info);
 
   /**
+   * Compare this AccountInfo to another AccountInfo and determine if they represent the same account info.
+   *
+   * @param lhs The first AccountInfo with which to compare.
+   * @param rhs The second AccountInfo with which to compare.
+   * @return \c TRUE if both AccountInfo objects are the same, otherwise \c FALSE.
+   */
+  [[nodiscard]] friend bool operator==(const AccountInfo& lhs, const AccountInfo& rhs);
+
+  /**
    * The ID of the queried account.
    */
   AccountId mAccountId;

--- a/src/sdk/main/include/AccountInfo.h
+++ b/src/sdk/main/include/AccountInfo.h
@@ -136,7 +136,7 @@ public:
    * The duration of time the queried account uses to automatically extend its expiration period. If it doesn't have
    * enough balance, it extends as long as possible. If it is empty when it expires, then it is deleted.
    */
-  std::chrono::system_clock::duration mAutoRenewPeriod;
+  std::chrono::system_clock::duration mAutoRenewPeriod = std::chrono::system_clock::duration::zero();
 
   /**
    * The queried account's memo.

--- a/src/sdk/main/src/AccountInfo.cc
+++ b/src/sdk/main/src/AccountInfo.cc
@@ -179,12 +179,12 @@ std::string AccountInfo::toString() const
 // concrete Key type, which is not available here.
 bool operator==(const AccountInfo& lhs, const AccountInfo& rhs)
 {
-  if ((lhs.mAccountId != rhs.mAccountId) || (lhs.mContractAccountId != rhs.mContractAccountId) ||
-      (lhs.mIsDeleted != rhs.mIsDeleted) || (lhs.mProxyReceived != rhs.mProxyReceived) ||
-      (lhs.mBalance != rhs.mBalance) || (lhs.mReceiverSignatureRequired != rhs.mReceiverSignatureRequired) ||
+  if (!(lhs.mAccountId == rhs.mAccountId) || (lhs.mContractAccountId != rhs.mContractAccountId) ||
+      (lhs.mIsDeleted != rhs.mIsDeleted) || !(lhs.mProxyReceived == rhs.mProxyReceived) ||
+      !(lhs.mBalance == rhs.mBalance) || (lhs.mReceiverSignatureRequired != rhs.mReceiverSignatureRequired) ||
       (lhs.mExpirationTime != rhs.mExpirationTime) || (lhs.mAutoRenewPeriod != rhs.mAutoRenewPeriod) ||
       (lhs.mMemo != rhs.mMemo) || (lhs.mOwnedNfts != rhs.mOwnedNfts) ||
-      (lhs.mMaxAutomaticTokenAssociations != rhs.mMaxAutomaticTokenAssociations) || (lhs.mLedgerId != rhs.mLedgerId))
+      (lhs.mMaxAutomaticTokenAssociations != rhs.mMaxAutomaticTokenAssociations) || !(lhs.mLedgerId == rhs.mLedgerId))
   {
     return false;
   }

--- a/src/sdk/main/src/AccountInfo.cc
+++ b/src/sdk/main/src/AccountInfo.cc
@@ -201,7 +201,7 @@ bool operator==(const AccountInfo& lhs, const AccountInfo& rhs)
   }
 
   // StakingInfo does not implement operator==, compare via serialized protobuf bytes.
-  if (lhs.mStakingInfo.toBytes() != rhs.mStakingInfo.toBytes())
+  if (lhs.mStakingInfo.toProtobuf()->SerializeAsString() != rhs.mStakingInfo.toProtobuf()->SerializeAsString())
   {
     return false;
   }

--- a/src/sdk/main/src/AccountInfo.cc
+++ b/src/sdk/main/src/AccountInfo.cc
@@ -174,6 +174,62 @@ std::string AccountInfo::toString() const
 }
 
 //-----
+// Note: mKey and mPublicKeyAlias (std::shared_ptr) are intentionally excluded to avoid
+// pointer identity comparison. Comparing the pointed-to values would require knowing the
+// concrete Key type, which is not available here.
+bool operator==(const AccountInfo& lhs, const AccountInfo& rhs)
+{
+  if ((lhs.mAccountId != rhs.mAccountId) || (lhs.mContractAccountId != rhs.mContractAccountId) ||
+      (lhs.mIsDeleted != rhs.mIsDeleted) || (lhs.mProxyReceived != rhs.mProxyReceived) ||
+      (lhs.mBalance != rhs.mBalance) || (lhs.mReceiverSignatureRequired != rhs.mReceiverSignatureRequired) ||
+      (lhs.mExpirationTime != rhs.mExpirationTime) || (lhs.mAutoRenewPeriod != rhs.mAutoRenewPeriod) ||
+      (lhs.mMemo != rhs.mMemo) || (lhs.mOwnedNfts != rhs.mOwnedNfts) ||
+      (lhs.mMaxAutomaticTokenAssociations != rhs.mMaxAutomaticTokenAssociations) || (lhs.mLedgerId != rhs.mLedgerId))
+  {
+    return false;
+  }
+
+  // EvmAddress does not implement operator==, compare via serialized bytes.
+  if (lhs.mEvmAddressAlias.has_value() != rhs.mEvmAddressAlias.has_value())
+  {
+    return false;
+  }
+
+  if (lhs.mEvmAddressAlias.has_value() && lhs.mEvmAddressAlias->toBytes() != rhs.mEvmAddressAlias->toBytes())
+  {
+    return false;
+  }
+
+  // StakingInfo does not implement operator==, compare via serialized protobuf bytes.
+  if (lhs.mStakingInfo.toBytes() != rhs.mStakingInfo.toBytes())
+  {
+    return false;
+  }
+
+  // TokenRelationship does not implement operator==, compare map entries via serialized protobuf bytes.
+  if (lhs.mTokenRelationships.size() != rhs.mTokenRelationships.size())
+  {
+    return false;
+  }
+
+  for (const auto& [tokenId, tokenRelationship] : lhs.mTokenRelationships)
+  {
+    const auto it = rhs.mTokenRelationships.find(tokenId);
+    if (it == rhs.mTokenRelationships.end())
+    {
+      return false;
+    }
+
+    if (tokenRelationship.toProtobuf()->SerializeAsString() != it->second.toProtobuf()->SerializeAsString())
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+//-----
 std::ostream& operator<<(std::ostream& os, const AccountInfo& info)
 {
   os << info.toString();

--- a/src/sdk/tests/unit/AccountInfoUnitTests.cc
+++ b/src/sdk/tests/unit/AccountInfoUnitTests.cc
@@ -157,3 +157,90 @@ TEST_F(AccountInfoUnitTests, ToString)
   EXPECT_NE(result.find(getTestBalance().toString()), std::string::npos);
   EXPECT_NE(result.find(getTestMemo()), std::string::npos);
 }
+
+//-----
+TEST_F(AccountInfoUnitTests, OperatorEqualsDefault)
+{
+  // Given
+  AccountInfo lhs;
+  AccountInfo rhs;
+
+  // Synchronize expiration times since default is system_clock::now()
+  rhs.mExpirationTime = lhs.mExpirationTime;
+
+  // Then
+  EXPECT_TRUE(lhs == rhs);
+}
+
+//-----
+TEST_F(AccountInfoUnitTests, OperatorEqualsSameValues)
+{
+  // Given
+  const auto now = std::chrono::system_clock::now();
+  const auto period = std::chrono::hours(4);
+
+  AccountInfo lhs;
+  lhs.mAccountId = getTestAccountId();
+  lhs.mContractAccountId = getTestContractAccountId();
+  lhs.mIsDeleted = getTestIsDeleted();
+  lhs.mProxyReceived = getTestProxyReceived();
+  lhs.mBalance = getTestBalance();
+  lhs.mReceiverSignatureRequired = getTestReceiverSignatureRequired();
+  lhs.mExpirationTime = now;
+  lhs.mAutoRenewPeriod = period;
+  lhs.mMemo = getTestMemo();
+  lhs.mOwnedNfts = getTestOwnedNfts();
+  lhs.mMaxAutomaticTokenAssociations = getTestMaxAutomaticTokenAssociations();
+  lhs.mLedgerId = getTestLedgerId();
+
+  AccountInfo rhs;
+  rhs.mAccountId = getTestAccountId();
+  rhs.mContractAccountId = getTestContractAccountId();
+  rhs.mIsDeleted = getTestIsDeleted();
+  rhs.mProxyReceived = getTestProxyReceived();
+  rhs.mBalance = getTestBalance();
+  rhs.mReceiverSignatureRequired = getTestReceiverSignatureRequired();
+  rhs.mExpirationTime = now;
+  rhs.mAutoRenewPeriod = period;
+  rhs.mMemo = getTestMemo();
+  rhs.mOwnedNfts = getTestOwnedNfts();
+  rhs.mMaxAutomaticTokenAssociations = getTestMaxAutomaticTokenAssociations();
+  rhs.mLedgerId = getTestLedgerId();
+
+  // Then
+  EXPECT_TRUE(lhs == rhs);
+}
+
+//-----
+TEST_F(AccountInfoUnitTests, OperatorNotEqualsDifferentMemo)
+{
+  // Given
+  AccountInfo lhs;
+  AccountInfo rhs;
+
+  // Synchronize expiration times since default is system_clock::now()
+  rhs.mExpirationTime = lhs.mExpirationTime;
+
+  lhs.mMemo = "memo A";
+  rhs.mMemo = "memo B";
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(AccountInfoUnitTests, OperatorNotEqualsDifferentOwnedNfts)
+{
+  // Given
+  AccountInfo lhs;
+  AccountInfo rhs;
+
+  // Synchronize expiration times since default is system_clock::now()
+  rhs.mExpirationTime = lhs.mExpirationTime;
+
+  lhs.mOwnedNfts = 10ULL;
+  rhs.mOwnedNfts = 20ULL;
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}

--- a/src/sdk/tests/unit/AccountInfoUnitTests.cc
+++ b/src/sdk/tests/unit/AccountInfoUnitTests.cc
@@ -244,3 +244,66 @@ TEST_F(AccountInfoUnitTests, OperatorNotEqualsDifferentOwnedNfts)
   // Then
   EXPECT_FALSE(lhs == rhs);
 }
+
+//-----
+TEST_F(AccountInfoUnitTests, OperatorNotEqualsDifferentEvmAddressAliasHasValue)
+{
+  // Given
+  AccountInfo lhs;
+  AccountInfo rhs;
+  rhs.mExpirationTime = lhs.mExpirationTime;
+
+  lhs.mEvmAddressAlias = EvmAddress::fromString("0000000000000000000000000000000000000001");
+  // rhs has no mEvmAddressAlias (nullopt)
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(AccountInfoUnitTests, OperatorNotEqualsDifferentEvmAddressAliasValue)
+{
+  // Given
+  AccountInfo lhs;
+  AccountInfo rhs;
+  rhs.mExpirationTime = lhs.mExpirationTime;
+
+  lhs.mEvmAddressAlias = EvmAddress::fromString("0000000000000000000000000000000000000001");
+  rhs.mEvmAddressAlias = EvmAddress::fromString("0000000000000000000000000000000000000002");
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(AccountInfoUnitTests, OperatorNotEqualsDifferentStakingInfo)
+{
+  // Given
+  AccountInfo lhs;
+  AccountInfo rhs;
+  rhs.mExpirationTime = lhs.mExpirationTime;
+
+  lhs.mStakingInfo.mDeclineRewards = true;
+  lhs.mStakingInfo.mPendingReward = Hbar(100LL);
+
+  rhs.mStakingInfo.mDeclineRewards = false;
+  rhs.mStakingInfo.mPendingReward = Hbar(200LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(AccountInfoUnitTests, OperatorNotEqualsDifferentTokenRelationships)
+{
+  // Given
+  AccountInfo lhs;
+  AccountInfo rhs;
+  rhs.mExpirationTime = lhs.mExpirationTime;
+
+  // lhs has one token relationship, rhs has none
+  lhs.mTokenRelationships[TokenId(1ULL, 2ULL, 3ULL)] = TokenRelationship();
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}


### PR DESCRIPTION
**Description**:

Add `operator==` for `AccountInfo` to allow direct value comparison.

* Declare `operator==` in `AccountInfo.h`
* Implement comparison in `AccountInfo.cc` for all relevant fields
* Use byte/protobuf comparison for fields without `operator==`
* Skip `mKey` and `mPublicKeyAlias` (shared_ptr) to avoid pointer comparison
* Add unit tests for equality and inequality cases

Fixes #1401

**Notes for reviewer**:

- Follows existing patterns for e.g `PendingAirdropId`
- Some fields use serialization for comparison since they lack `operator==`
- Shared pointer fields are intentionally excluded
- Changes are limited to the required files only

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)