### PR TITLE
feat: implement priority-based sorting for issue recommendations

### DIFF
--- a/.github/scripts/bot/bot-recommend-issues.js
+++ b/.github/scripts/bot/bot-recommend-issues.js
@@ -17,6 +17,7 @@ const {
     getLogger,
     getHighestIssueSkillLevel,
     countIssuesByAssignee,
+    PRIORITY_HIERARCHY,
 } = require('../helpers');
 
 // Logger delegation 
@@ -344,6 +345,28 @@ async function detectUnlockedLevel(botContext, username, currentLevel) {
 }
 
 /**
+ * Sorts issues based on the PRIORITY_HIERARCHY.
+ * * If two issues have the same priority, the oldest (earlier created_at)
+ * comes first. Issues without priority labels are moved to the end.
+ *
+ * @param {Array<object>} issues
+ * @returns {Array<object>} Sorted copy of the issues.
+ */
+function sortByPriority(issues) {
+    return [...issues].sort((a, b) => {
+        const ai = PRIORITY_HIERARCHY.findIndex(p => hasLabel(a, p));
+        const bi = PRIORITY_HIERARCHY.findIndex(p => hasLabel(b, p));
+        const aRank = ai === -1 ? PRIORITY_HIERARCHY.length : ai;
+        const bRank = bi === -1 ? PRIORITY_HIERARCHY.length : bi;
+        if (aRank !== bRank) {
+            return aRank - bRank;
+        }
+        // Tiebreaker: Use the creation date (Oldest first)
+        return new Date(a.created_at) - new Date(b.created_at);
+    });
+}
+
+/**
  * Returns recommended issues for the contributor based on their true
  * eligibility level, determined by a history-based top-down walk.
  *
@@ -388,9 +411,10 @@ async function getRecommendedIssues(botContext, username, currentLevel) {
         );
         return null;
     }
-
+    // Sort issues by priority.
+    const sorted = sortByPriority(issues);
     // Filter issues to the resolved eligible level so all results are actionable.
-    const grouped = groupIssuesByLevel(issues, [eligibleLevel]);
+    const grouped = groupIssuesByLevel(sorted, [eligibleLevel]);
     return {
         issues: pickFirstAvailableLevel(grouped, [eligibleLevel]),
         unlockedLevel,

--- a/.github/scripts/helpers/constants.js
+++ b/.github/scripts/helpers/constants.js
@@ -26,6 +26,12 @@ const LABELS = Object.freeze({
   BEGINNER: 'skill: beginner',
   INTERMEDIATE: 'skill: intermediate',
   ADVANCED: 'skill: advanced',
+
+  // Priority labels
+  PRIORITY_CRITICAL: 'priority: critical',
+  PRIORITY_HIGH: 'priority: high',
+  PRIORITY_MEDIUM: 'priority: medium',
+  PRIORITY_LOW: 'priority: low',
 });
 
 /**
@@ -36,6 +42,16 @@ const SKILL_HIERARCHY = Object.freeze([
     LABELS.BEGINNER,
     LABELS.INTERMEDIATE,
     LABELS.ADVANCED,
+]);
+
+/**
+ * Priority hierarchy for issue recommendations.
+ */
+const PRIORITY_HIERARCHY = Object.freeze([
+    LABELS.PRIORITY_CRITICAL,
+    LABELS.PRIORITY_HIGH,
+    LABELS.PRIORITY_MEDIUM,
+    LABELS.PRIORITY_LOW,
 ]);
 
 /**
@@ -88,4 +104,5 @@ module.exports = {
   ISSUE_STATE,
   SKILL_HIERARCHY,
   SKILL_PREREQUISITES,
+  PRIORITY_HIERARCHY,
 };

--- a/.github/scripts/tests/test-recommend-issues-bot.js
+++ b/.github/scripts/tests/test-recommend-issues-bot.js
@@ -6,7 +6,7 @@
 // Run with: node .github/scripts/tests/test-recommend-issues-bot.js
 
 const { runTestSuite } = require('./test-utils');
-const { LABELS, SKILL_HIERARCHY, SKILL_PREREQUISITES, MAINTAINER_TEAM } = require('../helpers/constants');
+const { LABELS, SKILL_HIERARCHY, SKILL_PREREQUISITES, MAINTAINER_TEAM, PRIORITY_HIERARCHY } = require('../helpers/constants');
 const {
   handleRecommendIssues,
   getRecommendedIssues,
@@ -117,12 +117,13 @@ function buildListForRepo(closedCounts) {
  * Creates a minimal issue object with the given labels.
  * Matches the structure expected by recommendation logic.
  */
-function makeIssue(labels, number = 1) {
+function makeIssue(labels, number = 1, createdAt = '2026-03-01T00:00:00Z') {
   return {
     number,
     title: `Issue ${number}`,
     html_url: `https://github.com/test/repo/issues/${number}`,
     labels: labels.map((name) => ({ name })),
+    created_at: createdAt,
   };
 }
 
@@ -131,6 +132,12 @@ const GFI      = SKILL_HIERARCHY[0]; // good first issue (or equivalent)
 const BEGINNER = SKILL_HIERARCHY[1];
 const MID      = SKILL_HIERARCHY[2];
 const TOP      = SKILL_HIERARCHY[SKILL_HIERARCHY.length - 1];
+
+// Convenience: priority levels
+const CRITICAL = PRIORITY_HIERARCHY[0];
+const HIGH     = PRIORITY_HIERARCHY[1];
+const MEDIUM   = PRIORITY_HIERARCHY[2];
+const LOW      = PRIORITY_HIERARCHY[3];
 
 // =============================================================================
 // UNIT TESTS
@@ -413,6 +420,87 @@ const unitTests = [
       });
       const result = await getRecommendedIssues(botContext, 'contributor', GFI);
       return result !== null && result.unlockedLevel === null;
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // getRecommendedIssues — Priority and Tiebreaker logic
+  // ---------------------------------------------------------------------------
+  {
+    name: 'getRecommendedIssues: Critical > High priority at same level',
+    test: async () => {
+      const { botContext } = createMockBotContext({
+        sender: { login: 'user' },
+        closedCounts: { [`${MID}:user`]: 1 },
+        searchItems: [
+          makeIssue([MID, LABELS.READY_FOR_DEV, HIGH], 1),
+          makeIssue([MID, LABELS.READY_FOR_DEV, CRITICAL], 2),
+        ],
+      });
+      const result = await getRecommendedIssues(botContext, 'user', BEGINNER);
+      // Even though Issue 1 was "found" first by search, Issue 2 should be recommended first
+      return result.issues[0].number === 2 && result.issues[1].number === 1;
+    },
+  },
+  {
+    name: 'getRecommendedIssues: High > Medium priority at same level',
+    test: async () => {
+      const { botContext } = createMockBotContext({
+        sender: { login: 'user' },
+        closedCounts: { [`${MID}:user`]: 1 },
+        searchItems: [
+          makeIssue([MID, LABELS.READY_FOR_DEV, MEDIUM], 1),
+          makeIssue([MID, LABELS.READY_FOR_DEV, HIGH], 2),
+        ],
+      });
+      const result = await getRecommendedIssues(botContext, 'user', BEGINNER);
+      return result.issues[0].number === 2 && result.issues[1].number === 1;
+    },
+  },
+  {
+    name: 'getRecommendedIssues: Medium > Low priority at same level',
+    test: async () => {
+      const { botContext } = createMockBotContext({
+        sender: { login: 'user' },
+        closedCounts: { [`${MID}:user`]: 1 },
+        searchItems: [
+          makeIssue([MID, LABELS.READY_FOR_DEV, LOW], 1),
+          makeIssue([MID, LABELS.READY_FOR_DEV, MEDIUM], 2),
+        ],
+      });
+      const result = await getRecommendedIssues(botContext, 'user', BEGINNER);
+      return result.issues[0].number === 2 && result.issues[1].number === 1;
+    },
+  },
+  {
+    name: 'getRecommendedIssues: Unlabeled issues appear after all priority labels',
+    test: async () => {
+      const { botContext } = createMockBotContext({
+        sender: { login: 'user' },
+        closedCounts: { [`${MID}:user`]: 1 },
+        searchItems: [
+          makeIssue([MID, LABELS.READY_FOR_DEV], 1), // No priority label
+          makeIssue([MID, LABELS.READY_FOR_DEV, LOW], 2),
+        ],
+      });
+      const result = await getRecommendedIssues(botContext, 'user', BEGINNER);
+      return result.issues[0].number === 2 && result.issues[1].number === 1;
+    },
+  },
+  {
+    name: 'getRecommendedIssues: Same priority tiebreaker → older issue first',
+    test: async () => {
+      const { botContext } = createMockBotContext({
+        sender: { login: 'user' },
+        closedCounts: { [`${MID}:user`]: 1 },
+        searchItems: [
+          makeIssue([MID, LABELS.READY_FOR_DEV, HIGH], 1, '2026-04-01T00:00:00Z'), // Newer
+          makeIssue([MID, LABELS.READY_FOR_DEV, HIGH], 2, '2026-01-01T00:00:00Z'), // Older
+        ],
+      });
+      const result = await getRecommendedIssues(botContext, 'user', BEGINNER);
+      // Issue 2 is older, so it should be the top recommendation
+      return result.issues[0].number === 2 && result.issues[1].number === 1;
     },
   },
 


### PR DESCRIPTION
**Description**:
Enhance the issue recommendation bot to sort suggested issues by priority levels (critical to low) and creation date.

* Add `PRIORITY_HIERARCHY` constant to define label importance
* Implement `sortByPriority` helper with a creation-date tiebreaker
* Update `getRecommendedIssues` to apply local sorting before grouping
* Add unit tests covering priority ordering and same-priority tiebreakers

**Related issue(s)**:

Fixes #1493


The sorting logic follows a two-tier system:
1. **Priority Hierarchy**: Issues are ranked by labels in descending order: `priority: critical` → `priority: high` → `priority: medium` → `priority: low`.
2. **Date Tiebreaker**: For issues with the same priority, the **oldest** issue (earlier `created_at`) is prioritized to help address the project backlog.
3. **Unlabeled Fallback**: Any issue without a recognized priority label is moved to the end of the results.

All logic has been verified with 5 new test cases added to `test-recommend-issues-bot.js`, covering both the hierarchy and the tiebreaker scenarios.

**Checklist**

- [x] Documented (Code comments)
- [x] Tested (unit tests)