### PR TITLE
refactor: convert const std::string& params to std::string_view

### DIFF
--- a/src/sdk/main/include/Hbar.h
+++ b/src/sdk/main/include/Hbar.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <regex>
 #include <string>
+#include <string_view>
 
 namespace Hiero
 {
@@ -98,7 +99,7 @@ public:
    * @throws std::invalid_argument If the input string can not be converted to Hbar unit.
    * @return An Hbar instance.
    */
-  [[nodiscard]] static Hbar fromString(const std::string& text);
+  [[nodiscard]] static Hbar fromString(std::string_view text);
 
   /**
    * Helper function to get the HbarUnit from the given symbol string.
@@ -107,7 +108,7 @@ public:
    * @return The corresponding HbarUnit.
    * @throws std::invalid_argument if the symbol is not recognized.
    */
-  [[nodiscard]] static HbarUnit getUnit(const std::string& symbolString);
+  [[nodiscard]] static HbarUnit getUnit(std::string_view symbolString);
 
   /**
    * Convert this Hbar value to tinybars.

--- a/src/sdk/main/include/impl/MirrorNodeContractQuery.h
+++ b/src/sdk/main/include/impl/MirrorNodeContractQuery.h
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <nlohmann/json.hpp>
@@ -99,7 +100,7 @@ public:
    * @param data The call data as a vector of bytes.
    * @return Reference to the updated object.
    */
-  MirrorNodeContractQuery& setFunction(const std::string& functionName,
+  MirrorNodeContractQuery& setFunction(std::string_view functionName,
                                        std::optional<ContractFunctionParameters>& parameters);
 
   /**

--- a/src/sdk/main/include/impl/MirrorNodeRouter.h
+++ b/src/sdk/main/include/impl/MirrorNodeRouter.h
@@ -14,10 +14,10 @@ namespace Hiero::internal::MirrorNodeGateway
 /**
  * Represents different mirror node query types.
  */
-static const std::string& ACCOUNT_INFO_QUERY = "accountInfoQuery";
-static const std::string& CONTRACT_INFO_QUERY = "contractInfoQuery";
-static const std::string& TOKEN_RELATIONSHIPS_QUERY = "tokenRelationshipsQuery";
-static const std::string& TOKEN_BALANCES_QUERY = "tokenBalancesQuery";
+static constexpr std::string_view ACCOUNT_INFO_QUERY = "accountInfoQuery";
+static constexpr std::string_view CONTRACT_INFO_QUERY = "contractInfoQuery";
+static constexpr std::string_view TOKEN_RELATIONSHIPS_QUERY = "tokenRelationshipsQuery";
+static constexpr std::string_view TOKEN_BALANCES_QUERY = "tokenBalancesQuery";
 
 /**
  * Class responsible for routing requests to different mirror node routes.
@@ -38,10 +38,10 @@ private:
    * Internal mapping of mirror node query types to their respective routes.
    */
   const std::unordered_map<std::string, std::string> routes = {
-    {ACCOUNT_INFO_QUERY,         "/api/v1/accounts/$"       },
-    { CONTRACT_INFO_QUERY,       "/api/v1/contracts/$"      },
-    { TOKEN_RELATIONSHIPS_QUERY, "/api/v1/accounts/$/tokens"},
-    { TOKEN_BALANCES_QUERY,      "/api/v1/tokens/$/balances"}
+    {std::string(ACCOUNT_INFO_QUERY),         "/api/v1/accounts/$"       },
+    { std::string(CONTRACT_INFO_QUERY),       "/api/v1/contracts/$"      },
+    { std::string(TOKEN_RELATIONSHIPS_QUERY), "/api/v1/accounts/$/tokens"},
+    { std::string(TOKEN_BALANCES_QUERY),      "/api/v1/tokens/$/balances"}
   };
 };
 

--- a/src/sdk/main/src/Hbar.cc
+++ b/src/sdk/main/src/Hbar.cc
@@ -5,6 +5,7 @@
 #include <regex>
 #include <sstream>
 #include <stdexcept>
+#include <string_view>
 
 // Define the pattern
 namespace Const
@@ -28,12 +29,14 @@ std::string Hbar::toString() const
 }
 
 //-----
-Hbar Hbar::fromString(const std::string& text)
+Hbar Hbar::fromString(std::string_view text)
 {
+  // std::regex_match requires a std::string, not std::string_view
+  const std::string textStr(text);
   std::smatch match;
-  if (!std::regex_match(text, match, Const::FROM_STRING_PATTERN))
+  if (!std::regex_match(textStr, match, Const::FROM_STRING_PATTERN))
   {
-    throw std::invalid_argument("Attempted to convert string to Hbar, but \"" + text +
+    throw std::invalid_argument("Attempted to convert string to Hbar, but \"" + textStr +
                                 "\" was not correctly formatted");
   }
 
@@ -53,7 +56,7 @@ Hbar Hbar::fromString(const std::string& text)
 }
 
 //-----
-HbarUnit Hbar::getUnit(const std::string& symbolString)
+HbarUnit Hbar::getUnit(std::string_view symbolString)
 {
   if (symbolString == HbarUnit::TINYBAR().getSymbol())
   {
@@ -84,7 +87,7 @@ HbarUnit Hbar::getUnit(const std::string& symbolString)
     return HbarUnit::GIGABAR();
   }
 
-  throw std::invalid_argument("Attempted to convert string to Hbar, but unit symbol \"" + symbolString +
+  throw std::invalid_argument("Attempted to convert string to Hbar, but unit symbol \"" + std::string(symbolString) +
                               "\" was not recognized");
 }
 

--- a/src/sdk/main/src/Mnemonic.cc
+++ b/src/sdk/main/src/Mnemonic.cc
@@ -293,7 +293,7 @@ std::vector<uint16_t> Mnemonic::wordsToIndices(const std::vector<std::string>& w
 {
   std::vector<uint16_t> output;
 
-  for (const std::string& word : words)
+  for (std::string_view word : words)
   {
     output.push_back(getIndexFromWordString(word));
   }

--- a/src/sdk/main/src/impl/MirrorNodeContractQuery.cc
+++ b/src/sdk/main/src/impl/MirrorNodeContractQuery.cc
@@ -4,6 +4,7 @@
 #include "impl/MirrorNodeGateway.h"
 
 #include "string"
+#include <string_view>
 
 namespace Hiero
 {
@@ -36,7 +37,7 @@ MirrorNodeContractQuery& MirrorNodeContractQuery::setSenderEvmAddress(const std:
 }
 
 //-----
-MirrorNodeContractQuery& MirrorNodeContractQuery::setFunction(const std::string& functionName,
+MirrorNodeContractQuery& MirrorNodeContractQuery::setFunction(std::string_view functionName,
                                                               std::optional<ContractFunctionParameters>& parameters)
 {
   mCallData = parameters.value_or(ContractFunctionParameters()).toBytes(functionName);

--- a/src/sdk/main/src/impl/MirrorNodeGateway.cc
+++ b/src/sdk/main/src/impl/MirrorNodeGateway.cc
@@ -72,7 +72,7 @@ std::string buildUrlForNetwork(std::string_view mirrorNodeUrl,
   MirrorNodeRouter router;
   std::string route = router.getRoute(queryType.data()).data();
   for_each(
-    params.begin(), params.end(), [&route](const std::string& replace) { replaceParameters(route, "$", replace); });
+    params.begin(), params.end(), [&route](std::string_view replace) { replaceParameters(route, "$", replace); });
   url += route;
   return url;
 }

--- a/src/sdk/main/src/impl/Network.cc
+++ b/src/sdk/main/src/impl/Network.cc
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <filesystem>
 #include <fstream>
+#include <string_view>
 
 namespace Hiero::internal
 {
@@ -26,16 +27,16 @@ namespace
  * @note This function ONLY maps specific local development Kubernetes service DNS names.
  *       All other addresses (testnet, mainnet, previewnet, custom networks) pass through unchanged.
  */
-std::string mapEndpointForLocalDevelopment(const std::string& endpoint)
+std::string mapEndpointForLocalDevelopment(std::string_view endpoint)
 {
   // Map network-node2 from port 50211 to 51211 for local port-forwarding
-  if (endpoint.find("network-node2-svc.solo.svc.cluster.local:50211") != std::string::npos)
+  if (endpoint.find("network-node2-svc.solo.svc.cluster.local:50211") != std::string_view::npos)
   {
     return "network-node2-svc.solo.svc.cluster.local:51211";
   }
 
   // All other addresses (including network-node1) pass through unchanged
-  return endpoint;
+  return std::string(endpoint);
 }
 } // anonymous namespace
 


### PR DESCRIPTION
**Description**:

I've converted the appropriate `const std::string&` parameters to `std::string_view` for consistency with existing patterns in the codebase and minor performance improvement.

* `Hbar::fromString` and `Hbar::getUnit` parameters to `std::string_view`
* `mapEndpointForLocalDevelopment` parameter to `std::string_view` in `Network.cc`
* lambda parameter in `MirrorNodeGateway::buildUrlForNetwork` to `std::string_view`
* `MirrorNodeContractQuery::setFunction` `functionName` parameter to `std::string_view`
* `static const std::string&` constants in `MirrorNodeRouter.h` with `static constexpr std::string_view` (also fixes latent undefined behaviour binding a reference to a temporary string literal)
* range-for loop variable in `Mnemonic::wordsToIndices` to `std::string_view`

Also the parameters that store the string into a member variable (`setTransactionMemo`, `setContractEvmAddress`, `setSenderEvmAddress`, `TokenRelationship` constructor, `getDomainName` return), I intentionally left them unchanged to avoid other lifetime issues.

Fixes #640

**Notes for reviewer**:

- `std::regex_match` does not accept `std::string_view`, so `Hbar::fromString` constructs a local `std::string` copy before passing to regex, so this is the minimal impact way to handle it.
- All header declarations and their implementations are kept in sync.
- No public API semantics are changed, only `std::string` and `const char*` callers are implicitly and safely converted it to `std::string_view`

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)