### PR TITLE
fix: remove 36 orphaned test separator comments across 8 unit test files

### DIFF
--- a/src/sdk/tests/unit/AccountIdUnitTests.cc
+++ b/src/sdk/tests/unit/AccountIdUnitTests.cc
@@ -34,8 +34,6 @@ private:
 };
 
 //-----
-
-//-----
 TEST_F(AccountIdUnitTests, ConstructWithAccountNum)
 {
   // Given / When
@@ -156,8 +154,6 @@ TEST_F(AccountIdUnitTests, ConstructWithShardRealmEvmAddress)
 }
 
 //-----
-
-//-----
 TEST_F(AccountIdUnitTests, EqualAccountIdsAreEqual)
 {
   // Given / When / Then
@@ -221,8 +217,6 @@ TEST_F(AccountIdUnitTests, DifferentIdentifierTypesAreNotEqual)
   EXPECT_FALSE(AccountId(getTestShardNum(), getTestRealmNum(), getTestEcdsaSecp256k1Alias()) ==
                AccountId(getTestShardNum(), getTestRealmNum(), getTestEvmAddressAlias()));
 }
-
-//-----
 
 //-----
 TEST_F(AccountIdUnitTests, FromStringWithValidShardRealmNum)
@@ -406,8 +400,6 @@ TEST_F(AccountIdUnitTests, FromStringThrowsWithEvmAddressInWrongPosition)
 }
 
 //-----
-
-//-----
 TEST_F(AccountIdUnitTests, FromEvmAddress)
 {
   // Given / When
@@ -431,8 +423,6 @@ TEST_F(AccountIdUnitTests, FromEvmAddress)
   EXPECT_EQ(accountIdFromEvmAddress.mEvmAddressAlias->toBytes(),
             accountIdFromEvmAddressStr.mEvmAddressAlias->toBytes());
 }
-
-//-----
 
 //-----
 TEST_F(AccountIdUnitTests, ProtobufSerializeDeserializeAccountNum)
@@ -555,8 +545,6 @@ TEST_F(AccountIdUnitTests, ProtobufSerializeDeserializeEvmAddress)
   EXPECT_TRUE(accountId.mEvmAddressAlias.has_value());
   EXPECT_EQ(accountId.mEvmAddressAlias->toBytes(), testBytes);
 }
-
-//-----
 
 //-----
 TEST_F(AccountIdUnitTests, ToStringDefaultAccountId)

--- a/src/sdk/tests/unit/EvmAddressUnitTests.cc
+++ b/src/sdk/tests/unit/EvmAddressUnitTests.cc
@@ -23,8 +23,6 @@ private:
 };
 
 //-----
-
-//-----
 TEST_F(EvmAddressUnitTests, FromStringWithValidInput)
 {
   // Given / When / Then
@@ -72,8 +70,6 @@ TEST_F(EvmAddressUnitTests, FromStringThrowsWithMisplacedPrefix)
 }
 
 //-----
-
-//-----
 TEST_F(EvmAddressUnitTests, FromBytesWithValidInput)
 {
   // Given / When / Then
@@ -102,8 +98,6 @@ TEST_F(EvmAddressUnitTests, FromBytesThrowsWithTooBigArray)
   // When / Then
   EXPECT_THROW(auto evmAddress = EvmAddress::fromBytes(badBytes), std::invalid_argument);
 }
-
-//-----
 
 //-----
 TEST_F(EvmAddressUnitTests, StringAndByteConversionsAreConsistent)

--- a/src/sdk/tests/unit/HbarUnitTests.cc
+++ b/src/sdk/tests/unit/HbarUnitTests.cc
@@ -13,8 +13,6 @@ protected:
 };
 
 //-----
-
-//-----
 TEST_F(HbarUnitTests, TinybarUnit)
 {
   // Given / When / Then
@@ -71,8 +69,6 @@ TEST_F(HbarUnitTests, GigabarUnit)
 }
 
 //-----
-
-//-----
 TEST_F(HbarUnitTests, DefaultConstructor)
 {
   // Given / When
@@ -111,8 +107,6 @@ TEST_F(HbarUnitTests, AmountUnitConstructor)
   EXPECT_EQ(megabar.toTinybars(), amount * HbarUnit::MEGABAR().getTinybars());
   EXPECT_EQ(gigabar.toTinybars(), amount * HbarUnit::GIGABAR().getTinybars());
 }
-
-//-----
 
 //-----
 TEST_F(HbarUnitTests, AddOperator)

--- a/src/sdk/tests/unit/MirrorNodeContractQueryUnitTests.cc
+++ b/src/sdk/tests/unit/MirrorNodeContractQueryUnitTests.cc
@@ -13,8 +13,6 @@ protected:
 };
 
 //-----
-
-//-----
 TEST_F(MirrorNodeContractQueryUnitTests, SetContractId)
 {
   // Given
@@ -148,8 +146,6 @@ TEST_F(MirrorNodeContractQueryUnitTests, SetEstimate)
   // Then
   EXPECT_EQ(query.getEstimate(), estimate);
 }
-
-//-----
 
 //-----
 TEST_F(MirrorNodeContractQueryUnitTests, ToJson)

--- a/src/sdk/tests/unit/NftIdUnitTests.cc
+++ b/src/sdk/tests/unit/NftIdUnitTests.cc
@@ -20,8 +20,6 @@ private:
 };
 
 //-----
-
-//-----
 TEST_F(NftIdUnitTests, ConstructWithTokenIdSerialNum)
 {
   // Given / When
@@ -33,16 +31,12 @@ TEST_F(NftIdUnitTests, ConstructWithTokenIdSerialNum)
 }
 
 //-----
-
-//-----
 TEST_F(NftIdUnitTests, CompareNftIds)
 {
   // Given / When / Then
   EXPECT_TRUE(NftId() == NftId());
   EXPECT_TRUE(NftId(getTestTokenId(), getTestSerialNum()) == NftId(getTestTokenId(), getTestSerialNum()));
 }
-
-//-----
 
 //-----
 TEST_F(NftIdUnitTests, FromStringWithValidInput)
@@ -90,8 +84,6 @@ TEST_F(NftIdUnitTests, FromStringThrowsWithNonNumericInput)
 }
 
 //-----
-
-//-----
 TEST_F(NftIdUnitTests, ProtobufSerializeNftId)
 {
   // Given
@@ -122,8 +114,6 @@ TEST_F(NftIdUnitTests, ProtobufDeserializeNftId)
 }
 
 //-----
-
-//-----
 TEST_F(NftIdUnitTests, ToStringDefaultNftId)
 {
   // Given
@@ -144,8 +134,6 @@ TEST_F(NftIdUnitTests, ToStringWithTokenIdAndSerialNum)
   // When / Then
   EXPECT_EQ(nftId.toString(), getTestTokenId().toString() + '/' + std::to_string(getTestSerialNum()));
 }
-
-//-----
 
 //-----
 TEST_F(NftIdUnitTests, FromBytes)

--- a/src/sdk/tests/unit/ScheduleIdUnitTests.cc
+++ b/src/sdk/tests/unit/ScheduleIdUnitTests.cc
@@ -24,8 +24,6 @@ private:
 };
 
 //-----
-
-//-----
 TEST_F(ScheduleIdUnitTests, ConstructWithScheduleNum)
 {
   // Given / When
@@ -50,8 +48,6 @@ TEST_F(ScheduleIdUnitTests, ConstructWithShardRealmScheduleNum)
 }
 
 //-----
-
-//-----
 TEST_F(ScheduleIdUnitTests, CompareScheduleIds)
 {
   // Given / When / Then
@@ -66,8 +62,6 @@ TEST_F(ScheduleIdUnitTests, CompareScheduleIds)
   EXPECT_FALSE(ScheduleId(getTestShardNum(), getTestRealmNum(), getTestScheduleNum()) ==
                ScheduleId(getTestShardNum(), getTestRealmNum() - 1ULL, getTestScheduleNum()));
 }
-
-//-----
 
 //-----
 TEST_F(ScheduleIdUnitTests, FromStringWithValidShardRealmNum)
@@ -145,8 +139,6 @@ TEST_F(ScheduleIdUnitTests, FromStringThrowsWithNonNumericInput)
 }
 
 //-----
-
-//-----
 TEST_F(ScheduleIdUnitTests, FromProtobuf)
 {
   // Given
@@ -217,8 +209,6 @@ TEST_F(ScheduleIdUnitTests, ToBytes)
   // Then
   EXPECT_EQ(protoBytes, bytes);
 }
-
-//-----
 
 //-----
 TEST_F(ScheduleIdUnitTests, ToString)

--- a/src/sdk/tests/unit/TokenIdUnitTests.cc
+++ b/src/sdk/tests/unit/TokenIdUnitTests.cc
@@ -20,8 +20,6 @@ private:
 };
 
 //-----
-
-//-----
 TEST_F(TokenIdUnitTests, ConstructWithTokenNum)
 {
   // Given / When
@@ -46,8 +44,6 @@ TEST_F(TokenIdUnitTests, ConstructWithShardRealmTokenNum)
 }
 
 //-----
-
-//-----
 TEST_F(TokenIdUnitTests, CompareTokenIds)
 {
   // Given / When / Then
@@ -56,8 +52,6 @@ TEST_F(TokenIdUnitTests, CompareTokenIds)
   EXPECT_TRUE(TokenId(getTestShardNum(), getTestRealmNum(), getTestTokenNum()) ==
               TokenId(getTestShardNum(), getTestRealmNum(), getTestTokenNum()));
 }
-
-//-----
 
 //-----
 TEST_F(TokenIdUnitTests, FromStringWithValidShardRealmNum)
@@ -128,8 +122,6 @@ TEST_F(TokenIdUnitTests, FromStringThrowsWithNonNumericInput)
 }
 
 //-----
-
-//-----
 TEST_F(TokenIdUnitTests, ProtobufSerializeTokenId)
 {
   // Given
@@ -166,8 +158,6 @@ TEST_F(TokenIdUnitTests, ProtobufDeserializeTokenId)
   EXPECT_EQ(tokenId.mRealmNum, newRealm);
   EXPECT_EQ(tokenId.mTokenNum, newToken);
 }
-
-//-----
 
 //-----
 TEST_F(TokenIdUnitTests, ToStringDefaultTokenId)

--- a/src/sdk/tests/unit/TopicIdUnitTests.cc
+++ b/src/sdk/tests/unit/TopicIdUnitTests.cc
@@ -25,8 +25,6 @@ private:
 };
 
 //-----
-
-//-----
 TEST_F(TopicIdUnitTests, ConstructWithTopicNum)
 {
   // Given / When
@@ -51,8 +49,6 @@ TEST_F(TopicIdUnitTests, ConstructWithShardRealmTopicNum)
 }
 
 //-----
-
-//-----
 TEST_F(TopicIdUnitTests, CompareTopicIds)
 {
   // Given / When / Then
@@ -67,8 +63,6 @@ TEST_F(TopicIdUnitTests, CompareTopicIds)
   EXPECT_FALSE(TopicId(getTestShardNum(), getTestRealmNum(), getTestTopicNum()) ==
                TopicId(getTestShardNum(), getTestRealmNum() - 1ULL, getTestTopicNum()));
 }
-
-//-----
 
 //-----
 TEST_F(TopicIdUnitTests, FromStringWithValidShardRealmNum)
@@ -139,8 +133,6 @@ TEST_F(TopicIdUnitTests, FromStringThrowsWithNonNumericInput)
 }
 
 //-----
-
-//-----
 TEST_F(TopicIdUnitTests, FromSolidityAddressWithValidAddress)
 {
   // Given
@@ -182,8 +174,6 @@ TEST_F(TopicIdUnitTests, FromSolidityAddressThrowsWithInvalidAddress)
   EXPECT_THROW(TopicId::fromSolidityAddress(addrTooSmall), std::invalid_argument);
   EXPECT_THROW(TopicId::fromSolidityAddress(addrNotHex), std::invalid_argument);
 }
-
-//-----
 
 //-----
 TEST_F(TopicIdUnitTests, FromProtobuf)
@@ -266,8 +256,6 @@ TEST_F(TopicIdUnitTests, ToBytes)
   // Then
   EXPECT_EQ(protoBytes, bytes);
 }
-
-//-----
 
 //-----
 TEST_F(TopicIdUnitTests, ToString)


### PR DESCRIPTION
PR #1495 added section comment headers (e.g. // Constructor Tests) bordered by //----- lines. A follow-up commit removed those headers but only deleted the first two lines of each block, leaving the closing //----- border behind.

This produced a double-separator pattern at every former section boundary:

    //-----          ← orphaned closing border
                     ← blank line
    //-----          ← original test separator
    TEST_F(...)

Collapsed all 36 occurrences to the correct single-separator pattern:

    //-----
    TEST_F(...)

Files changed (orphaned separators removed):
  - AccountIdUnitTests.cc               (6)
  - NftIdUnitTests.cc                   (6)
  - TopicIdUnitTests.cc                 (6)
  - ScheduleIdUnitTests.cc             (5)
  - TokenIdUnitTests.cc                 (5)
  - EvmAddressUnitTests.cc             (3)
  - HbarUnitTests.cc                    (3)
  - MirrorNodeContractQueryUnitTests.cc (2)

No test logic, assertions, or production code was modified.

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**: #1501  #1501

Fixes #1501

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
