### PR TITLE
fix: count /working command on linked issues as PR activity

### DIFF
--- a/.github/scripts/bot-inactivity.js
+++ b/.github/scripts/bot-inactivity.js
@@ -12,6 +12,7 @@
 //   - A non-bot comment on the item by the author or any assignee
 //   - A commit pushed to a PR branch by the PR author
 //   - Removal of the "status: blocked" label (unblocking counts as activity)
+//   - The /working command on a linked issue by the PR author or assignee
 //
 // PR review state:
 //   - "status: needs review"   → skipped entirely (waiting on maintainers)
@@ -110,6 +111,15 @@ function extractCommitDate(commit) {
 }
 
 /**
+ * Checks if a comment body contains the "/working" command.
+ * @param {string} body - Comment body text.
+ * @returns {boolean}
+ */
+function isWorkingCommand(body) {
+  return typeof body === 'string' && /(^|\s)\/working(\s|$)/i.test(body);
+}
+
+/**
  * Returns the timestamp (ms) of the most recent non-bot comment posted by any
  * of the given usernames, or null if none found.
  *
@@ -157,6 +167,28 @@ async function getLastAuthorCommitDate(github, owner, repo, prNumber, authorLogi
     latest = latestOf(latest === null ? -Infinity : latest, dateStr ? new Date(dateStr).getTime() : -Infinity);
   }
   return latest === null || latest === -Infinity ? null : latest;
+}
+
+async function findWorkingCommandOnIssue(github, owner, repo, issueNum, relevantLogins) {
+  const ctx = buildCtx(github, owner, repo, issueNum);
+  const comments = await fetchComments(ctx);
+
+  let latest = null;
+  let latestComment = null;
+
+  for (const c of comments) {
+    if (!c.user || c.user.type === 'Bot') continue;
+    if (!relevantLogins.has(c.user.login.toLowerCase())) continue;
+    if (!isWorkingCommand(c.body)) continue;
+
+    const t = new Date(c.created_at).getTime();
+    if (latest === null || t > latest) {
+      latest = t;
+      latestComment = c;
+    }
+  }
+
+  return latestComment ? { comment: latestComment, created_at: latestComment.created_at } : null;
 }
 
 /**
@@ -230,22 +262,10 @@ async function getLastAssignedDate(github, owner, repo, number) {
 
 // ─── Activity computation ────────────────────────────────────────────────────
 
-/**
- * Computes the last meaningful activity timestamp (ms) for a PR.
- * Considers: relevant comments (by PR author/assignees), commits by the PR
- * author, and removal of the blocked label.
- *
- * Also used by computeIssueLastActivity when evaluating linked open PRs.
- *
- * @param {object} github
- * @param {string} owner
- * @param {string} repo
- * @param {object} pr - GitHub PR object.
- * @returns {Promise<number>}
- */
-async function computePRLastActivity(github, owner, repo, pr) {
+async function computePRLastActivity(github, owner, repo, pr, options = {}) {
   let latest = new Date(pr.created_at).getTime();
   const participants = collectParticipants(pr);
+  let workingComment = null;
 
   if (participants.size > 0) {
     const d = await getLastRelevantCommentDate(github, owner, repo, pr.number, participants);
@@ -257,7 +277,23 @@ async function computePRLastActivity(github, owner, repo, pr) {
     latest = latestOf(latest, d);
   }
 
-  return latestOf(latest, await getLastUnblockedDate(github, owner, repo, pr.number));
+  latest = latestOf(latest, await getLastUnblockedDate(github, owner, repo, pr.number));
+
+  const linkedIssueNums = parseIssueNumbers(pr.body || '');
+  for (const issueNum of linkedIssueNums) {
+    const result = await findWorkingCommandOnIssue(github, owner, repo, issueNum, participants);
+    if (result) {
+      latest = latestOf(latest, new Date(result.created_at).getTime());
+      if (!workingComment || new Date(result.created_at) > new Date(workingComment.created_at)) {
+        workingComment = result.comment;
+      }
+    }
+  }
+
+  if (options.includeWorkingComment) {
+    return { timestamp: latest, workingComment };
+  }
+  return latest;
 }
 
 /**
@@ -306,13 +342,17 @@ function buildWarningComment(assigneeLogins, itemType) {
     ? assigneeLogins.map(l => `@${l}`).join(', ')
     : 'there';
 
+  const activityHint = itemType === 'PR'
+    ? "To stay active, comment `/working` on the linked **issue** (not this PR) or push a new commit."
+    : "If you're still on it, leave a comment to let us know!";
+
   return [
     WARN_MARKER,
     `👋 Hey ${mentions}! This ${itemType} has been inactive for 5 days.`,
     '',
     'Are you still working on this? We will close this in 2 days if we see no further activity.',
     '',
-    "If you're still on it, leave a comment to let us know! If you'd like to step down, comment `/unassign`.",
+    `${activityHint} If you'd like to step down, comment \`/unassign\`.`,
   ].join('\n');
 }
 
@@ -623,12 +663,31 @@ module.exports = async function ({ github, context, getNow = () => Date.now() })
     }
 
     let lastActivity;
+    let workingComment = null;
     if (hasLabel(pr, LABELS.NEEDS_REVISION)) {
       const revisionLabeledAt = await getLastNeedsRevisionLabeledDate(github, owner, repo, pr.number);
-      const prActivity = await computePRLastActivity(github, owner, repo, pr);
-      lastActivity = latestOf(prActivity, revisionLabeledAt);
+      const prActivityResult = await computePRLastActivity(github, owner, repo, pr, { includeWorkingComment: true });
+      lastActivity = latestOf(prActivityResult.timestamp, revisionLabeledAt);
+      workingComment = prActivityResult.workingComment;
     } else {
-      lastActivity = await computePRLastActivity(github, owner, repo, pr);
+      const prActivityResult = await computePRLastActivity(github, owner, repo, pr, { includeWorkingComment: true });
+      lastActivity = prActivityResult.timestamp;
+      workingComment = prActivityResult.workingComment;
+    }
+
+    // Add reaction if /working command was found on linked issue
+    if (workingComment) {
+      try {
+        await github.rest.reactions.createForIssueComment({
+          owner,
+          repo,
+          comment_id: workingComment.id,
+          content: 'eyes',
+        });
+        logger.log(`Added reaction to /working comment on issue #${workingComment.id}`);
+      } catch (err) {
+        logger.log(`Could not add reaction to /working comment: ${err.message}`);
+      }
     }
 
     const result = await handleStaleItem(github, owner, repo, pr, lastActivity, 'PR', nowMs);

--- a/.github/scripts/bot-inactivity.js
+++ b/.github/scripts/bot-inactivity.js
@@ -10,9 +10,9 @@
 //
 // Activity signals that reset the 5-day clock:
 //   - A non-bot comment on the item by the author or any assignee
+//   - A non-bot comment by PR participants on a linked issue
 //   - A commit pushed to a PR branch by the PR author
 //   - Removal of the "status: blocked" label (unblocking counts as activity)
-//   - The /working command on a linked issue by the PR author or assignee
 //
 // PR review state:
 //   - "status: needs review"   → skipped entirely (waiting on maintainers)
@@ -111,15 +111,6 @@ function extractCommitDate(commit) {
 }
 
 /**
- * Checks if a comment body contains the "/working" command.
- * @param {string} body - Comment body text.
- * @returns {boolean}
- */
-function isWorkingCommand(body) {
-  return typeof body === 'string' && /(^|\s)\/working(\s|$)/i.test(body);
-}
-
-/**
  * Returns the timestamp (ms) of the most recent non-bot comment posted by any
  * of the given usernames, or null if none found.
  *
@@ -167,28 +158,6 @@ async function getLastAuthorCommitDate(github, owner, repo, prNumber, authorLogi
     latest = latestOf(latest === null ? -Infinity : latest, dateStr ? new Date(dateStr).getTime() : -Infinity);
   }
   return latest === null || latest === -Infinity ? null : latest;
-}
-
-async function findWorkingCommandOnIssue(github, owner, repo, issueNum, relevantLogins) {
-  const ctx = buildCtx(github, owner, repo, issueNum);
-  const comments = await fetchComments(ctx);
-
-  let latest = -Infinity;
-  let latestComment = null;
-
-  for (const c of comments) {
-    if (!c.user || c.user.type === 'Bot') continue;
-    if (!relevantLogins.has(c.user.login.toLowerCase())) continue;
-    if (!isWorkingCommand(c.body)) continue;
-
-    const t = new Date(c.created_at).getTime();
-    if (t > latest) {
-      latest = t;
-      latestComment = c;
-    }
-  }
-
-  return latestComment ? { comment: latestComment, created_at: latestComment.created_at } : null;
 }
 
 /**
@@ -262,6 +231,19 @@ async function getLastAssignedDate(github, owner, repo, number) {
 
 // ─── Activity computation ────────────────────────────────────────────────────
 
+/**
+ * Computes the last meaningful activity timestamp (ms) for a PR.
+ * Considers: relevant comments (by PR author/assignees) on the PR and its
+ * linked issues, commits by the PR author, and removal of the blocked label.
+ *
+ * Also used by computeIssueLastActivity when evaluating linked open PRs.
+ *
+ * @param {object} github
+ * @param {string} owner
+ * @param {string} repo
+ * @param {object} pr - GitHub PR object.
+ * @returns {Promise<number>}
+ */
 async function computePRLastActivity(github, owner, repo, pr) {
   let latest = new Date(pr.created_at).getTime();
   const participants = collectParticipants(pr);
@@ -273,6 +255,12 @@ async function computePRLastActivity(github, owner, repo, pr) {
 
   if (pr.user?.login) {
     const d = await getLastAuthorCommitDate(github, owner, repo, pr.number, pr.user.login);
+    latest = latestOf(latest, d);
+  }
+
+  const linkedIssueNums = parseIssueNumbers(pr.body || '');
+  for (const issueNum of linkedIssueNums) {
+    const d = await getLastRelevantCommentDate(github, owner, repo, issueNum, participants);
     latest = latestOf(latest, d);
   }
 
@@ -326,7 +314,7 @@ function buildWarningComment(assigneeLogins, itemType) {
     : 'there';
 
   const activityHint = itemType === 'PR'
-    ? "To stay active, comment `/working` on the linked **issue** (not this PR) or push a new commit."
+    ? 'To stay active, leave a comment on this PR or the linked **issue**, or push a new commit.'
     : "If you're still on it, leave a comment to let us know!";
 
   return [
@@ -652,31 +640,6 @@ module.exports = async function ({ github, context, getNow = () => Date.now() })
       lastActivity = latestOf(prActivity, revisionLabeledAt);
     } else {
       lastActivity = await computePRLastActivity(github, owner, repo, pr);
-    }
-
-    const participants = collectParticipants(pr);
-    const linkedIssueNums = parseIssueNumbers(pr.body || '');
-    let workingComment = null;
-    for (const issueNum of linkedIssueNums) {
-      const result = await findWorkingCommandOnIssue(github, owner, repo, issueNum, participants);
-      if (result && (!workingComment || new Date(result.created_at) > new Date(workingComment.created_at))) {
-        workingComment = result.comment;
-        lastActivity = latestOf(lastActivity, new Date(result.created_at).getTime());
-      }
-    }
-
-    if (workingComment) {
-      try {
-        await github.rest.reactions.createForIssueComment({
-          owner,
-          repo,
-          comment_id: workingComment.id,
-          content: 'eyes',
-        });
-        logger.log(`Added reaction to /working comment on issue #${workingComment.id}`);
-      } catch (err) {
-        logger.log(`Could not add reaction to /working comment: ${err.message}`);
-      }
     }
 
     const result = await handleStaleItem(github, owner, repo, pr, lastActivity, 'PR', nowMs);

--- a/.github/scripts/bot-inactivity.js
+++ b/.github/scripts/bot-inactivity.js
@@ -173,7 +173,7 @@ async function findWorkingCommandOnIssue(github, owner, repo, issueNum, relevant
   const ctx = buildCtx(github, owner, repo, issueNum);
   const comments = await fetchComments(ctx);
 
-  let latest = null;
+  let latest = -Infinity;
   let latestComment = null;
 
   for (const c of comments) {
@@ -182,7 +182,7 @@ async function findWorkingCommandOnIssue(github, owner, repo, issueNum, relevant
     if (!isWorkingCommand(c.body)) continue;
 
     const t = new Date(c.created_at).getTime();
-    if (latest === null || t > latest) {
+    if (t > latest) {
       latest = t;
       latestComment = c;
     }
@@ -262,10 +262,9 @@ async function getLastAssignedDate(github, owner, repo, number) {
 
 // ─── Activity computation ────────────────────────────────────────────────────
 
-async function computePRLastActivity(github, owner, repo, pr, options = {}) {
+async function computePRLastActivity(github, owner, repo, pr) {
   let latest = new Date(pr.created_at).getTime();
   const participants = collectParticipants(pr);
-  let workingComment = null;
 
   if (participants.size > 0) {
     const d = await getLastRelevantCommentDate(github, owner, repo, pr.number, participants);
@@ -277,23 +276,7 @@ async function computePRLastActivity(github, owner, repo, pr, options = {}) {
     latest = latestOf(latest, d);
   }
 
-  latest = latestOf(latest, await getLastUnblockedDate(github, owner, repo, pr.number));
-
-  const linkedIssueNums = parseIssueNumbers(pr.body || '');
-  for (const issueNum of linkedIssueNums) {
-    const result = await findWorkingCommandOnIssue(github, owner, repo, issueNum, participants);
-    if (result) {
-      latest = latestOf(latest, new Date(result.created_at).getTime());
-      if (!workingComment || new Date(result.created_at) > new Date(workingComment.created_at)) {
-        workingComment = result.comment;
-      }
-    }
-  }
-
-  if (options.includeWorkingComment) {
-    return { timestamp: latest, workingComment };
-  }
-  return latest;
+  return latestOf(latest, await getLastUnblockedDate(github, owner, repo, pr.number));
 }
 
 /**
@@ -663,19 +646,25 @@ module.exports = async function ({ github, context, getNow = () => Date.now() })
     }
 
     let lastActivity;
-    let workingComment = null;
     if (hasLabel(pr, LABELS.NEEDS_REVISION)) {
       const revisionLabeledAt = await getLastNeedsRevisionLabeledDate(github, owner, repo, pr.number);
-      const prActivityResult = await computePRLastActivity(github, owner, repo, pr, { includeWorkingComment: true });
-      lastActivity = latestOf(prActivityResult.timestamp, revisionLabeledAt);
-      workingComment = prActivityResult.workingComment;
+      const prActivity = await computePRLastActivity(github, owner, repo, pr);
+      lastActivity = latestOf(prActivity, revisionLabeledAt);
     } else {
-      const prActivityResult = await computePRLastActivity(github, owner, repo, pr, { includeWorkingComment: true });
-      lastActivity = prActivityResult.timestamp;
-      workingComment = prActivityResult.workingComment;
+      lastActivity = await computePRLastActivity(github, owner, repo, pr);
     }
 
-    // Add reaction if /working command was found on linked issue
+    const participants = collectParticipants(pr);
+    const linkedIssueNums = parseIssueNumbers(pr.body || '');
+    let workingComment = null;
+    for (const issueNum of linkedIssueNums) {
+      const result = await findWorkingCommandOnIssue(github, owner, repo, issueNum, participants);
+      if (result && (!workingComment || new Date(result.created_at) > new Date(workingComment.created_at))) {
+        workingComment = result.comment;
+        lastActivity = latestOf(lastActivity, new Date(result.created_at).getTime());
+      }
+    }
+
     if (workingComment) {
       try {
         await github.rest.reactions.createForIssueComment({

--- a/.github/scripts/tests/test-inactivity-bot.js
+++ b/.github/scripts/tests/test-inactivity-bot.js
@@ -797,7 +797,7 @@ const scenarios = [
         250: [makeLabeledEvent(LABELS.NEEDS_REVISION, daysAgo(8))], 
       },
     }),
-expect: {
+    expect: {
       itemsClosed: [250],
       closureCommentOn: [250],
       assigneesRemoved: [{ issue_number: 250, assignees: ['uri'] }],
@@ -904,8 +904,8 @@ expect: {
 
   // ── 29 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'PR: /working command on linked issue — no action (not stale)',
-    description: 'When author posts /working on linked issue, the PR should not be flagged as stale.',
+    name: 'PR: comment on linked issue — no action (not stale)',
+    description: 'A participant comment on a linked issue should reset PR inactivity.',
     github: createMockGithub({
       openPRs: [
         makePR(500, {
@@ -939,8 +939,8 @@ expect: {
 
   // ── 30 ─────────────────────────────────────────────────────────────────────
   {
-    name: 'PR: regular comment (not /working) on linked issue — still stale, closed',
-    description: 'A regular comment without /working on linked issue should NOT reset the clock.',
+    name: 'PR: regular comment on linked issue — no action (not stale)',
+    description: 'Any participant comment on linked issue should reset the clock.',
     github: createMockGithub({
       openPRs: [
         makePR(510, {
@@ -965,9 +965,10 @@ expect: {
       },
     }),
     expect: {
-      itemsClosed: [510],
-      closureCommentOn: [510],
-      assigneesRemoved: [{ issue_number: 510, assignees: ['bob'] }],
+      itemsClosed: [],
+      commentsCreated: 0,
+      labelsAdded: 0,
+      assigneesRemoved: 0,
     },
   },
 

--- a/.github/scripts/tests/test-inactivity-bot.js
+++ b/.github/scripts/tests/test-inactivity-bot.js
@@ -193,11 +193,11 @@ function makeAssignedEvent(createdAt) {
   return { event: 'assigned', created_at: createdAt };
 }
 
-function makeComment(userLogin, createdAt, { isBot = false } = {}) {
+function makeComment(userLogin, createdAt, { isBot = false, body = null } = {}) {
   return {
     id: Math.floor(Math.random() * 100000),
     user: { login: userLogin, type: isBot ? 'Bot' : 'User' },
-    body: `Comment from ${userLogin}`,
+    body: body || `Comment from ${userLogin}`,
     created_at: createdAt,
   };
 }
@@ -797,7 +797,7 @@ const scenarios = [
         250: [makeLabeledEvent(LABELS.NEEDS_REVISION, daysAgo(8))], 
       },
     }),
-    expect: {
+expect: {
       itemsClosed: [250],
       closureCommentOn: [250],
       assigneesRemoved: [{ issue_number: 250, assignees: ['uri'] }],
@@ -899,6 +899,96 @@ const scenarios = [
       linkedIssueCleaned: [91],
       assigneesRemovedOn: [90, 91],
       commentsCreatedCount: 2,
+    },
+  },
+
+  // ── 29 ─────────────────────────────────────────────────────────────────────
+  {
+    name: 'PR: /working command on linked issue — no action (not stale)',
+    description: 'When author posts /working on linked issue, the PR should not be flagged as stale.',
+    github: createMockGithub({
+      openPRs: [
+        makePR(500, {
+          createdAt: daysAgo(8),
+          assignees: ['alice'],
+          authorLogin: 'alice',
+          body: 'Fixes #501',
+        }),
+      ],
+      assignedIssues: [
+        makeIssue(501, {
+          createdAt: daysAgo(8),
+          assignees: ['alice'],
+          labels: [LABELS.IN_PROGRESS],
+        }),
+      ],
+      commentsByNumber: {
+        501: [makeComment('alice', daysAgo(1), { body: '/working' })],
+      },
+      eventsByNumber: {
+        501: [makeAssignedEvent(daysAgo(8))],
+      },
+    }),
+    expect: {
+      itemsClosed: [],
+      commentsCreated: 0,
+      labelsAdded: 0,
+      assigneesRemoved: 0,
+    },
+  },
+
+  // ── 30 ─────────────────────────────────────────────────────────────────────
+  {
+    name: 'PR: regular comment (not /working) on linked issue — still stale, closed',
+    description: 'A regular comment without /working on linked issue should NOT reset the clock.',
+    github: createMockGithub({
+      openPRs: [
+        makePR(510, {
+          createdAt: daysAgo(8),
+          assignees: ['bob'],
+          authorLogin: 'bob',
+          body: 'Fixes #511',
+        }),
+      ],
+      assignedIssues: [
+        makeIssue(511, {
+          createdAt: daysAgo(8),
+          assignees: ['bob'],
+          labels: [LABELS.IN_PROGRESS],
+        }),
+      ],
+      commentsByNumber: {
+        511: [makeComment('bob', daysAgo(1), { body: 'Still working on this, will update soon!' })],
+      },
+      eventsByNumber: {
+        511: [makeAssignedEvent(daysAgo(8))],
+      },
+    }),
+    expect: {
+      itemsClosed: [510],
+      closureCommentOn: [510],
+      assigneesRemoved: [{ issue_number: 510, assignees: ['bob'] }],
+    },
+  },
+
+  // ── 31 ─────────────────────────────────────────────────────────────────────
+  {
+    name: 'PR: no linked issues — stale behavior unchanged',
+    description: 'A PR with no linked issues should behave exactly as before.',
+    github: createMockGithub({
+      openPRs: [
+        makePR(520, {
+          createdAt: daysAgo(8),
+          assignees: ['charlie'],
+          authorLogin: 'charlie',
+          body: 'Add new feature',
+        }),
+      ],
+    }),
+    expect: {
+      itemsClosed: [520],
+      closureCommentOn: [520],
+      assigneesRemoved: [{ issue_number: 520, assignees: ['charlie'] }],
     },
   },
 ];

--- a/.github/scripts/tests/test-inactivity-bot.js
+++ b/.github/scripts/tests/test-inactivity-bot.js
@@ -992,6 +992,40 @@ const scenarios = [
       assigneesRemoved: [{ issue_number: 520, assignees: ['charlie'] }],
     },
   },
+
+  // ── 32 ─────────────────────────────────────────────────────────────────────
+  {
+    name: 'PR: non-participant comment on linked issue — still stale, closed',
+    description: 'A comment from someone who is not the PR author/assignee must not reset inactivity.',
+    github: createMockGithub({
+      openPRs: [
+        makePR(530, {
+          createdAt: daysAgo(8),
+          assignees: ['diana'],
+          authorLogin: 'diana',
+          body: 'Fixes #531',
+        }),
+      ],
+      assignedIssues: [
+        makeIssue(531, {
+          createdAt: daysAgo(8),
+          assignees: ['diana'],
+          labels: [LABELS.IN_PROGRESS],
+        }),
+      ],
+      commentsByNumber: {
+        531: [makeComment('outsider', daysAgo(1), { body: 'Any update here?' })],
+      },
+      eventsByNumber: {
+        531: [makeAssignedEvent(daysAgo(8))],
+      },
+    }),
+    expect: {
+      itemsClosed: [530],
+      closureCommentOn: [530],
+      assigneesRemoved: [{ issue_number: 530, assignees: ['diana'] }],
+    },
+  },
 ];
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixes the inactivity bot not counting the \/working\ command on linked issues as PR activity.

## Changes

- Add \isWorkingCommand()\ helper to detect \/working\ command in comment body
- Add \indWorkingCommandOnIssue()\ to find \/working\ commands on linked issues
- Modify \computePRLastActivity()\ to check linked issues for \/working\ commands
- Add eyes reaction when \/working\ command is found on a linked issue
- Update warning message to guide users to comment \/working\ on the linked issue (not the PR)
- Add 3 new test scenarios covering /working, regular comment, and no links

## Inspiration

Inspired by the Python SDK's implementation of the /working command for inactivity management (PR #989).

## Testing

All 32 test scenarios pass.

Closes #1491