### PR TITLE
feat(tck): implement createSchedule endpoint

### DIFF
--- a/src/tck/CMakeLists.txt
+++ b/src/tck/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(${TCK_SERVER_NAME}
         src/sdk/SdkClient.cc
         src/token/TokenService.cc
         src/topic/TopicService.cc
+        src/schedule/ScheduleService.cc
         src/main.cc
         src/TckServer.cc)
 

--- a/src/tck/include/schedule/ScheduleService.h
+++ b/src/tck/include/schedule/ScheduleService.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef HIERO_TCK_CPP_SCHEDULE_SERVICE_H_
+#define HIERO_TCK_CPP_SCHEDULE_SERVICE_H_
+
+#include <nlohmann/json_fwd.hpp>
+
+namespace Hiero::TCK::ScheduleService
+{
+/**
+ * Forward declarations.
+ */
+struct CreateScheduleParams;
+
+/**
+ * Create a schedule.
+ *
+ * @param params The parameters to use to create a schedule.
+ * @return A JSON response containing the status of the schedule creation and the new schedule's ID.
+ */
+nlohmann::json createSchedule(const CreateScheduleParams& params);
+
+} // namespace Hiero::TCK::ScheduleService
+
+#endif // HIERO_TCK_CPP_SCHEDULE_SERVICE_H_

--- a/src/tck/include/schedule/params/CreateScheduleParams.h
+++ b/src/tck/include/schedule/params/CreateScheduleParams.h
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef HIERO_TCK_CPP_CREATE_SCHEDULE_PARAMS_H_
+#define HIERO_TCK_CPP_CREATE_SCHEDULE_PARAMS_H_
+
+#include "common/CommonTransactionParams.h"
+#include "json/JsonUtils.h"
+#include "nlohmann/json.hpp"
+
+#include <optional>
+#include <string>
+
+namespace Hiero::TCK::ScheduleService
+{
+/**
+ * Struct to hold the arguments for a `createSchedule` JSON-RPC method call.
+ */
+struct CreateScheduleParams
+{
+  /**
+   * Nested JSON object describing the inner transaction to schedule.
+   */
+  nlohmann::json mScheduledTransaction;
+
+  /**
+   * Optional memo for the schedule.
+   */
+  std::optional<std::string> mMemo;
+
+  /**
+   * Optional admin key for the schedule.
+   */
+  std::optional<std::string> mAdminKey;
+
+  /**
+   * Optional account ID that will pay for the scheduled transaction.
+   */
+  std::optional<std::string> mPayerAccountId;
+
+  /**
+   * Optional expiration time for the schedule.
+   */
+  std::optional<std::string> mExpirationTime;
+
+  /**
+   * Optional flag to wait for expiry before executing the scheduled transaction.
+   */
+  std::optional<bool> mWaitForExpiry;
+
+  /**
+   * Any parameters common to all transaction types.
+   */
+  std::optional<CommonTransactionParams> mCommonTxParams;
+};
+
+} // namespace Hiero::TCK::ScheduleService
+
+namespace nlohmann
+{
+/**
+ * JSON serializer template specialization required to convert CreateScheduleParams arguments properly.
+ */
+template<>
+struct [[maybe_unused]] adl_serializer<Hiero::TCK::ScheduleService::CreateScheduleParams>
+{
+  /**
+   * Convert a Json Object to a CreateScheduleParams
+   *
+   * @param jsonFrom The json object which will fill the CreateScheduleParams.
+   * @param params The CreateScheduleParam to fill the json object.
+   */
+  static void from_json(const json& jsonFrom, Hiero::TCK::ScheduleService::CreateScheduleParams& params)
+  {
+    params.mScheduledTransaction = jsonFrom.at("scheduledTransaction");
+    params.mMemo = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "memo");
+    params.mAdminKey = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "adminKey");
+    params.mPayerAccountId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "payerAccountId");
+    params.mExpirationTime = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "expirationTime");
+    params.mWaitForExpiry = Hiero::TCK::getOptionalJsonParameter<bool>(jsonFrom, "waitForExpiry");
+    params.mCommonTxParams =
+      Hiero::TCK::getOptionalJsonParameter<Hiero::TCK::CommonTransactionParams>(jsonFrom, "commonTransactionParams");
+  }
+};
+
+} // namespace nlohmann
+
+#endif // HIERO_TCK_CPP_CREATE_SCHEDULE_PARAMS_H_

--- a/src/tck/include/schedule/params/CreateScheduleParams.h
+++ b/src/tck/include/schedule/params/CreateScheduleParams.h
@@ -3,8 +3,8 @@
 #define HIERO_TCK_CPP_CREATE_SCHEDULE_PARAMS_H_
 
 #include "common/CommonTransactionParams.h"
-#include "json/JsonUtils.h"
 #include "nlohmann/json.hpp"
+#include "json/JsonUtils.h"
 
 #include <optional>
 #include <string>

--- a/src/tck/src/TckServer.cc
+++ b/src/tck/src/TckServer.cc
@@ -57,6 +57,8 @@
 #include "topic/params/DeleteTopicParams.h"
 #include "topic/params/GetTopicInfoQueryParams.h"
 #include "topic/params/TopicMessageSubmitParams.h"
+#include "schedule/ScheduleService.h"
+#include "schedule/params/CreateScheduleParams.h"
 #include "json/JsonUtils.h"
 
 namespace Hiero::TCK
@@ -132,6 +134,9 @@ TckServer::TckServer(int port)
   mJsonRpcParser.addMethod("getFileContents", getHandle(FileService::getFileContents));
   mJsonRpcParser.addMethod("getFileInfo", getHandle(FileService::getFileInfo));
   mJsonRpcParser.addMethod("updateFile", getHandle(FileService::updateFile));
+
+  // Schedule Service
+  mJsonRpcParser.addMethod("createSchedule", getHandle(ScheduleService::createSchedule));
 
   setupHttpHandler();
   mServer.listen("localhost", port);
@@ -275,5 +280,7 @@ template TckServer::MethodHandle TckServer::getHandle<TopicService::GetTopicInfo
   nlohmann::json (*method)(const TopicService::GetTopicInfoQueryParams&));
 template TckServer::MethodHandle TckServer::getHandle<TopicService::TopicMessageSubmitParams>(
   nlohmann::json (*method)(const TopicService::TopicMessageSubmitParams&));
+template TckServer::MethodHandle TckServer::getHandle<ScheduleService::CreateScheduleParams>(
+  nlohmann::json (*method)(const ScheduleService::CreateScheduleParams&));
 
 } // namespace Hiero::TCK

--- a/src/tck/src/TckServer.cc
+++ b/src/tck/src/TckServer.cc
@@ -29,6 +29,8 @@
 #include "file/params/UpdateFileParams.h"
 #include "key/KeyService.h"
 #include "key/params/GenerateKeyParams.h"
+#include "schedule/ScheduleService.h"
+#include "schedule/params/CreateScheduleParams.h"
 #include "sdk/SdkClient.h"
 #include "sdk/params/ResetParams.h"
 #include "sdk/params/SetupParams.h"
@@ -57,8 +59,6 @@
 #include "topic/params/DeleteTopicParams.h"
 #include "topic/params/GetTopicInfoQueryParams.h"
 #include "topic/params/TopicMessageSubmitParams.h"
-#include "schedule/ScheduleService.h"
-#include "schedule/params/CreateScheduleParams.h"
 #include "json/JsonUtils.h"
 
 namespace Hiero::TCK

--- a/src/tck/src/schedule/ScheduleService.cc
+++ b/src/tck/src/schedule/ScheduleService.cc
@@ -1,28 +1,33 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "schedule/ScheduleService.h"
-
+#include "account/params/ApproveAllowanceParams.h"
 #include "account/params/CreateAccountParams.h"
 #include "account/params/DeleteAccountParams.h"
-#include "account/params/UpdateAccountParams.h"
 #include "account/params/TransferCryptoParams.h"
+#include "account/params/UpdateAccountParams.h"
 #include "common/transfer/TransferParams.h"
 #include "key/KeyService.h"
 #include "schedule/params/CreateScheduleParams.h"
 #include "sdk/SdkClient.h"
+#include "token/params/BurnTokenParams.h"
 #include "token/params/CreateTokenParams.h"
 #include "token/params/DeleteTokenParams.h"
+#include "token/params/MintTokenParams.h"
 #include "token/params/UpdateTokenParams.h"
 #include "topic/params/CreateTopicParams.h"
 #include "topic/params/DeleteTopicParams.h"
 #include "topic/params/TopicMessageSubmitParams.h"
 
+#include <AccountAllowanceApproveTransaction.h>
 #include <AccountCreateTransaction.h>
 #include <AccountDeleteTransaction.h>
 #include <AccountUpdateTransaction.h>
 #include <HbarUnit.h>
 #include <ScheduleCreateTransaction.h>
+#include <TokenBurnTransaction.h>
 #include <TokenCreateTransaction.h>
 #include <TokenDeleteTransaction.h>
+#include <TokenMintTransaction.h>
 #include <TokenUpdateTransaction.h>
 #include <TopicCreateTransaction.h>
 #include <TopicDeleteTransaction.h>
@@ -32,6 +37,7 @@
 #include <TransferTransaction.h>
 #include <WrappedTransaction.h>
 #include <impl/EntityIdHelper.h>
+#include <impl/HexConverter.h>
 
 #include <chrono>
 #include <functional>
@@ -106,8 +112,8 @@ void addNftTransfer(TransferTransaction& transaction, const TransferParams& txPa
 {
   const AccountId senderAccountId = AccountId::fromString(txParams.mNft->mSenderAccountId);
   const AccountId receiverAccountId = AccountId::fromString(txParams.mNft->mReceiverAccountId);
-  const NftId nftId = NftId(TokenId::fromString(txParams.mNft->mTokenId),
-                            internal::EntityIdHelper::getNum(txParams.mNft->mSerialNumber));
+  const NftId nftId =
+    NftId(TokenId::fromString(txParams.mNft->mTokenId), internal::EntityIdHelper::getNum(txParams.mNft->mSerialNumber));
   const bool approved = txParams.mApproved.has_value() && txParams.mApproved.value();
 
   approved ? transaction.addApprovedNftTransfer(nftId, senderAccountId, receiverAccountId)
@@ -126,9 +132,12 @@ WrappedTransaction translateTransferCrypto(const nlohmann::json& params)
   {
     for (const TransferParams& txParams : transferParams.mTransfers.value())
     {
-      if (txParams.mHbar.has_value()) addHbarTransfer(transaction, txParams);
-      else if (txParams.mToken.has_value()) addTokenTransfer(transaction, txParams);
-      else addNftTransfer(transaction, txParams);
+      if (txParams.mHbar.has_value())
+        addHbarTransfer(transaction, txParams);
+      else if (txParams.mToken.has_value())
+        addTokenTransfer(transaction, txParams);
+      else
+        addNftTransfer(transaction, txParams);
     }
   }
 
@@ -141,9 +150,12 @@ WrappedTransaction translateTransferCrypto(const nlohmann::json& params)
 template<typename T, typename P>
 void setAccountStaking(T& tx, const P& p)
 {
-  if (p.mStakedAccountId.has_value()) tx.setStakedAccountId(AccountId::fromString(p.mStakedAccountId.value()));
-  if (p.mStakedNodeId.has_value()) tx.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(p.mStakedNodeId.value()));
-  if (p.mDeclineStakingReward.has_value()) tx.setDeclineStakingReward(p.mDeclineStakingReward.value());
+  if (p.mStakedAccountId.has_value())
+    tx.setStakedAccountId(AccountId::fromString(p.mStakedAccountId.value()));
+  if (p.mStakedNodeId.has_value())
+    tx.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(p.mStakedNodeId.value()));
+  if (p.mDeclineStakingReward.has_value())
+    tx.setDeclineStakingReward(p.mDeclineStakingReward.value());
 }
 
 /**
@@ -154,14 +166,21 @@ WrappedTransaction translateCreateAccount(const nlohmann::json& params)
   const auto p = params.get<AccountService::CreateAccountParams>();
   AccountCreateTransaction tx;
 
-  if (p.mKey.has_value()) tx.setKeyWithoutAlias(KeyService::getHieroKey(p.mKey.value()));
+  if (p.mKey.has_value())
+    tx.setKeyWithoutAlias(KeyService::getHieroKey(p.mKey.value()));
   if (p.mInitialBalance.has_value())
-    tx.setInitialBalance(Hbar(internal::EntityIdHelper::getNum<int64_t>(p.mInitialBalance.value()), HbarUnit::TINYBAR()));
-  if (p.mReceiverSignatureRequired.has_value()) tx.setReceiverSignatureRequired(p.mReceiverSignatureRequired.value());
-  if (p.mAutoRenewPeriod.has_value()) tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
-  if (p.mMemo.has_value()) tx.setAccountMemo(p.mMemo.value());
-  if (p.mMaxAutoTokenAssociations.has_value()) tx.setMaxAutomaticTokenAssociations(p.mMaxAutoTokenAssociations.value());
-  if (p.mAlias.has_value()) tx.setAlias(EvmAddress::fromString(p.mAlias.value()));
+    tx.setInitialBalance(
+      Hbar(internal::EntityIdHelper::getNum<int64_t>(p.mInitialBalance.value()), HbarUnit::TINYBAR()));
+  if (p.mReceiverSignatureRequired.has_value())
+    tx.setReceiverSignatureRequired(p.mReceiverSignatureRequired.value());
+  if (p.mAutoRenewPeriod.has_value())
+    tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
+  if (p.mMemo.has_value())
+    tx.setAccountMemo(p.mMemo.value());
+  if (p.mMaxAutoTokenAssociations.has_value())
+    tx.setMaxAutomaticTokenAssociations(p.mMaxAutoTokenAssociations.value());
+  if (p.mAlias.has_value())
+    tx.setAlias(EvmAddress::fromString(p.mAlias.value()));
 
   setAccountStaking(tx, p);
   return WrappedTransaction(tx);
@@ -175,8 +194,10 @@ WrappedTransaction translateDeleteAccount(const nlohmann::json& params)
   const auto p = params.get<AccountService::DeleteAccountParams>();
   AccountDeleteTransaction tx;
 
-  if (p.mDeleteAccountId.has_value()) tx.setDeleteAccountId(AccountId::fromString(p.mDeleteAccountId.value()));
-  if (p.mTransferAccountId.has_value()) tx.setTransferAccountId(AccountId::fromString(p.mTransferAccountId.value()));
+  if (p.mDeleteAccountId.has_value())
+    tx.setDeleteAccountId(AccountId::fromString(p.mDeleteAccountId.value()));
+  if (p.mTransferAccountId.has_value())
+    tx.setTransferAccountId(AccountId::fromString(p.mTransferAccountId.value()));
 
   return WrappedTransaction(tx);
 }
@@ -189,13 +210,20 @@ WrappedTransaction translateUpdateAccount(const nlohmann::json& params)
   const auto p = params.get<AccountService::UpdateAccountParams>();
   AccountUpdateTransaction tx;
 
-  if (p.mAccountId.has_value()) tx.setAccountId(AccountId::fromString(p.mAccountId.value()));
-  if (p.mKey.has_value()) tx.setKey(KeyService::getHieroKey(p.mKey.value()));
-  if (p.mAutoRenewPeriod.has_value()) tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
-  if (p.mExpirationTime.has_value()) tx.setExpirationTime(parseTime(p.mExpirationTime));
-  if (p.mReceiverSignatureRequired.has_value()) tx.setReceiverSignatureRequired(p.mReceiverSignatureRequired.value());
-  if (p.mMemo.has_value()) tx.setAccountMemo(p.mMemo.value());
-  if (p.mMaxAutoTokenAssociations.has_value()) tx.setMaxAutomaticTokenAssociations(p.mMaxAutoTokenAssociations.value());
+  if (p.mAccountId.has_value())
+    tx.setAccountId(AccountId::fromString(p.mAccountId.value()));
+  if (p.mKey.has_value())
+    tx.setKey(KeyService::getHieroKey(p.mKey.value()));
+  if (p.mAutoRenewPeriod.has_value())
+    tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
+  if (p.mExpirationTime.has_value())
+    tx.setExpirationTime(parseTime(p.mExpirationTime));
+  if (p.mReceiverSignatureRequired.has_value())
+    tx.setReceiverSignatureRequired(p.mReceiverSignatureRequired.value());
+  if (p.mMemo.has_value())
+    tx.setAccountMemo(p.mMemo.value());
+  if (p.mMaxAutoTokenAssociations.has_value())
+    tx.setMaxAutomaticTokenAssociations(p.mMaxAutoTokenAssociations.value());
 
   setAccountStaking(tx, p);
   return WrappedTransaction(tx);
@@ -207,11 +235,16 @@ WrappedTransaction translateUpdateAccount(const nlohmann::json& params)
 template<typename T, typename P>
 void setTokenKeys(T& tx, const P& p)
 {
-  if (p.mAdminKey.has_value()) tx.setAdminKey(KeyService::getHieroKey(p.mAdminKey.value()));
-  if (p.mKycKey.has_value()) tx.setKycKey(KeyService::getHieroKey(p.mKycKey.value()));
-  if (p.mFreezeKey.has_value()) tx.setFreezeKey(KeyService::getHieroKey(p.mFreezeKey.value()));
-  if (p.mWipeKey.has_value()) tx.setWipeKey(KeyService::getHieroKey(p.mWipeKey.value()));
-  if (p.mSupplyKey.has_value()) tx.setSupplyKey(KeyService::getHieroKey(p.mSupplyKey.value()));
+  if (p.mAdminKey.has_value())
+    tx.setAdminKey(KeyService::getHieroKey(p.mAdminKey.value()));
+  if (p.mKycKey.has_value())
+    tx.setKycKey(KeyService::getHieroKey(p.mKycKey.value()));
+  if (p.mFreezeKey.has_value())
+    tx.setFreezeKey(KeyService::getHieroKey(p.mFreezeKey.value()));
+  if (p.mWipeKey.has_value())
+    tx.setWipeKey(KeyService::getHieroKey(p.mWipeKey.value()));
+  if (p.mSupplyKey.has_value())
+    tx.setSupplyKey(KeyService::getHieroKey(p.mSupplyKey.value()));
 }
 
 /**
@@ -220,9 +253,12 @@ void setTokenKeys(T& tx, const P& p)
 template<typename T, typename P>
 void setTokenRenewAndMemo(T& tx, const P& p)
 {
-  if (p.mAutoRenewAccountId.has_value()) tx.setAutoRenewAccountId(AccountId::fromString(p.mAutoRenewAccountId.value()));
-  if (p.mAutoRenewPeriod.has_value()) tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
-  if (p.mMemo.has_value()) tx.setTokenMemo(p.mMemo.value());
+  if (p.mAutoRenewAccountId.has_value())
+    tx.setAutoRenewAccountId(AccountId::fromString(p.mAutoRenewAccountId.value()));
+  if (p.mAutoRenewPeriod.has_value())
+    tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
+  if (p.mMemo.has_value())
+    tx.setTokenMemo(p.mMemo.value());
 }
 
 /**
@@ -233,13 +269,20 @@ WrappedTransaction translateCreateToken(const nlohmann::json& params)
   const auto p = params.get<TokenService::CreateTokenParams>();
   TokenCreateTransaction tx;
 
-  if (p.mName.has_value()) tx.setTokenName(p.mName.value());
-  if (p.mSymbol.has_value()) tx.setTokenSymbol(p.mSymbol.value());
-  if (p.mDecimals.has_value()) tx.setDecimals(p.mDecimals.value());
-  if (p.mInitialSupply.has_value()) tx.setInitialSupply(internal::EntityIdHelper::getNum<int64_t>(p.mInitialSupply.value()));
-  if (p.mTreasuryAccountId.has_value()) tx.setTreasuryAccountId(AccountId::fromString(p.mTreasuryAccountId.value()));
-  if (p.mFreezeDefault.has_value()) tx.setFreezeDefault(p.mFreezeDefault.value());
-  if (p.mExpirationTime.has_value()) tx.setExpirationTime(parseTime(p.mExpirationTime));
+  if (p.mName.has_value())
+    tx.setTokenName(p.mName.value());
+  if (p.mSymbol.has_value())
+    tx.setTokenSymbol(p.mSymbol.value());
+  if (p.mDecimals.has_value())
+    tx.setDecimals(p.mDecimals.value());
+  if (p.mInitialSupply.has_value())
+    tx.setInitialSupply(internal::EntityIdHelper::getNum<int64_t>(p.mInitialSupply.value()));
+  if (p.mTreasuryAccountId.has_value())
+    tx.setTreasuryAccountId(AccountId::fromString(p.mTreasuryAccountId.value()));
+  if (p.mFreezeDefault.has_value())
+    tx.setFreezeDefault(p.mFreezeDefault.value());
+  if (p.mExpirationTime.has_value())
+    tx.setExpirationTime(parseTime(p.mExpirationTime));
 
   setTokenKeys(tx, p);
   setTokenRenewAndMemo(tx, p);
@@ -254,7 +297,8 @@ WrappedTransaction translateDeleteToken(const nlohmann::json& params)
   const auto p = params.get<TokenService::DeleteTokenParams>();
   TokenDeleteTransaction tx;
 
-  if (p.mTokenId.has_value()) tx.setTokenId(TokenId::fromString(p.mTokenId.value()));
+  if (p.mTokenId.has_value())
+    tx.setTokenId(TokenId::fromString(p.mTokenId.value()));
 
   return WrappedTransaction(tx);
 }
@@ -267,14 +311,139 @@ WrappedTransaction translateUpdateToken(const nlohmann::json& params)
   const auto p = params.get<TokenService::UpdateTokenParams>();
   TokenUpdateTransaction tx;
 
-  if (p.mTokenId.has_value()) tx.setTokenId(TokenId::fromString(p.mTokenId.value()));
-  if (p.mSymbol.has_value()) tx.setTokenSymbol(p.mSymbol.value());
-  if (p.mName.has_value()) tx.setTokenName(p.mName.value());
-  if (p.mTreasuryAccountId.has_value()) tx.setTreasuryAccountId(AccountId::fromString(p.mTreasuryAccountId.value()));
-  if (p.mExpirationTime.has_value()) tx.setExpirationTime(parseTime(p.mExpirationTime));
+  if (p.mTokenId.has_value())
+    tx.setTokenId(TokenId::fromString(p.mTokenId.value()));
+  if (p.mSymbol.has_value())
+    tx.setTokenSymbol(p.mSymbol.value());
+  if (p.mName.has_value())
+    tx.setTokenName(p.mName.value());
+  if (p.mTreasuryAccountId.has_value())
+    tx.setTreasuryAccountId(AccountId::fromString(p.mTreasuryAccountId.value()));
+  if (p.mExpirationTime.has_value())
+    tx.setExpirationTime(parseTime(p.mExpirationTime));
 
   setTokenKeys(tx, p);
   setTokenRenewAndMemo(tx, p);
+  return WrappedTransaction(tx);
+}
+/**
+ * Translate a burnToken TCK JSON-RPC params into a WrappedTransaction.
+ */
+WrappedTransaction translateBurnToken(const nlohmann::json& params)
+{
+  const auto p = params.get<TokenService::BurnTokenParams>();
+  TokenBurnTransaction tx;
+
+  if (p.mTokenId.has_value())
+  {
+    tx.setTokenId(TokenId::fromString(p.mTokenId.value()));
+  }
+
+  if (p.mAmount.has_value())
+  {
+    tx.setAmount(internal::EntityIdHelper::getNum(p.mAmount.value()));
+  }
+
+  if (p.mSerialNumbers.has_value())
+  {
+    std::vector<uint64_t> serialNumbers;
+    for (const std::string& serialNumber : p.mSerialNumbers.value())
+    {
+      serialNumbers.push_back(internal::EntityIdHelper::getNum(serialNumber));
+    }
+
+    tx.setSerialNumbers(serialNumbers);
+  }
+
+  return WrappedTransaction(tx);
+}
+
+/**
+ * Translate a mintToken TCK JSON-RPC params into a WrappedTransaction.
+ */
+WrappedTransaction translateMintToken(const nlohmann::json& params)
+{
+  const auto p = params.get<TokenService::MintTokenParams>();
+  TokenMintTransaction tx;
+
+  if (p.mTokenId.has_value())
+  {
+    tx.setTokenId(TokenId::fromString(p.mTokenId.value()));
+  }
+
+  if (p.mAmount.has_value())
+  {
+    tx.setAmount(internal::EntityIdHelper::getNum(p.mAmount.value()));
+  }
+
+  if (p.mMetadata.has_value())
+  {
+    std::vector<std::vector<std::byte>> allMetadata;
+    for (const std::string& metadata : p.mMetadata.value())
+    {
+      allMetadata.push_back(internal::HexConverter::hexToBytes(metadata));
+    }
+
+    tx.setMetadata(allMetadata);
+  }
+
+  return WrappedTransaction(tx);
+}
+
+/**
+ * Translate an approveAllowance TCK JSON-RPC params into a WrappedTransaction.
+ */
+WrappedTransaction translateApproveAllowance(const nlohmann::json& params)
+{
+  const auto p = params.get<AccountService::ApproveAllowanceParams>();
+  AccountAllowanceApproveTransaction tx;
+
+  for (const AccountService::AllowanceParams& allowance : p.mAllowances)
+  {
+    const AccountId owner = AccountId::fromString(allowance.mOwnerAccountId);
+    const AccountId spender = AccountId::fromString(allowance.mSpenderAccountId);
+
+    if (allowance.mHbar.has_value())
+    {
+      tx.approveHbarAllowance(
+        owner, spender, Hbar::fromTinybars(internal::EntityIdHelper::getNum<int64_t>(allowance.mHbar->mAmount)));
+    }
+    else if (allowance.mToken.has_value())
+    {
+      tx.approveTokenAllowance(TokenId::fromString(allowance.mToken->mTokenId),
+                               owner,
+                               spender,
+                               internal::EntityIdHelper::getNum<int64_t>(allowance.mToken->mAmount));
+    }
+    else
+    {
+      if (allowance.mNft->mSerialNumbers.has_value())
+      {
+        for (const std::string& serialNumber : allowance.mNft->mSerialNumbers.value())
+        {
+          tx.approveTokenNftAllowance(
+            NftId(TokenId::fromString(allowance.mNft->mTokenId), internal::EntityIdHelper::getNum(serialNumber)),
+            owner,
+            spender,
+            (allowance.mNft->mDelegateSpenderAccountId.has_value())
+              ? AccountId::fromString(allowance.mNft->mDelegateSpenderAccountId.value())
+              : AccountId());
+        }
+      }
+      else
+      {
+        if (allowance.mNft->mApprovedForAll.value())
+        {
+          tx.approveNftAllowanceAllSerials(TokenId::fromString(allowance.mNft->mTokenId), owner, spender);
+        }
+        else
+        {
+          tx.deleteNftAllowanceAllSerials(TokenId::fromString(allowance.mNft->mTokenId), owner, spender);
+        }
+      }
+    }
+  }
+
   return WrappedTransaction(tx);
 }
 
@@ -286,11 +455,16 @@ WrappedTransaction translateCreateTopic(const nlohmann::json& params)
   const auto p = params.get<TopicService::CreateTopicParams>();
   TopicCreateTransaction tx;
 
-  if (p.mMemo.has_value()) tx.setMemo(p.mMemo.value());
-  if (p.mAdminKey.has_value()) tx.setAdminKey(KeyService::getHieroKey(p.mAdminKey.value()));
-  if (p.mSubmitKey.has_value()) tx.setSubmitKey(KeyService::getHieroKey(p.mSubmitKey.value()));
-  if (p.mAutoRenewPeriod.has_value()) tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
-  if (p.mAutoRenewAccount.has_value()) tx.setAutoRenewAccountId(AccountId::fromString(p.mAutoRenewAccount.value()));
+  if (p.mMemo.has_value())
+    tx.setMemo(p.mMemo.value());
+  if (p.mAdminKey.has_value())
+    tx.setAdminKey(KeyService::getHieroKey(p.mAdminKey.value()));
+  if (p.mSubmitKey.has_value())
+    tx.setSubmitKey(KeyService::getHieroKey(p.mSubmitKey.value()));
+  if (p.mAutoRenewPeriod.has_value())
+    tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
+  if (p.mAutoRenewAccount.has_value())
+    tx.setAutoRenewAccountId(AccountId::fromString(p.mAutoRenewAccount.value()));
 
   return WrappedTransaction(tx);
 }
@@ -303,7 +477,8 @@ WrappedTransaction translateDeleteTopic(const nlohmann::json& params)
   const auto p = params.get<TopicService::DeleteTopicParams>();
   TopicDeleteTransaction tx;
 
-  if (p.mTopicId.has_value()) tx.setTopicId(TopicId::fromString(p.mTopicId.value()));
+  if (p.mTopicId.has_value())
+    tx.setTopicId(TopicId::fromString(p.mTopicId.value()));
 
   return WrappedTransaction(tx);
 }
@@ -316,9 +491,12 @@ WrappedTransaction translateSubmitTopicMessage(const nlohmann::json& params)
   const auto p = params.get<TopicService::TopicMessageSubmitParams>();
   TopicMessageSubmitTransaction tx;
 
-  if (p.mTopicId.has_value()) tx.setTopicId(TopicId::fromString(p.mTopicId.value()));
-  if (p.mMessage.has_value()) tx.setMessage(p.mMessage.value());
-  if (p.mMaxChunks.has_value()) tx.setMaxChunks(static_cast<int>(p.mMaxChunks.value()));
+  if (p.mTopicId.has_value())
+    tx.setTopicId(TopicId::fromString(p.mTopicId.value()));
+  if (p.mMessage.has_value())
+    tx.setMessage(p.mMessage.value());
+  if (p.mMaxChunks.has_value())
+    tx.setMaxChunks(static_cast<int>(p.mMaxChunks.value()));
 
   return WrappedTransaction(tx);
 }
@@ -329,16 +507,19 @@ WrappedTransaction translateSubmitTopicMessage(const nlohmann::json& params)
 WrappedTransaction translateScheduledTransaction(const nlohmann::json& json)
 {
   static const std::unordered_map<std::string, std::function<WrappedTransaction(const nlohmann::json&)>> dispatcher = {
-    {"transferCrypto",       translateTransferCrypto     },
-    { "createAccount",       translateCreateAccount      },
-    { "deleteAccount",       translateDeleteAccount      },
-    { "updateAccount",       translateUpdateAccount      },
-    { "createToken",         translateCreateToken        },
-    { "deleteToken",         translateDeleteToken        },
-    { "updateToken",         translateUpdateToken        },
-    { "createTopic",         translateCreateTopic        },
-    { "deleteTopic",         translateDeleteTopic        },
-    { "submitTopicMessage",  translateSubmitTopicMessage }
+    {"transferCrypto",    translateTransferCrypto    },
+    { "createAccount",    translateCreateAccount     },
+    { "deleteAccount",    translateDeleteAccount     },
+    { "updateAccount",    translateUpdateAccount     },
+    { "createToken",      translateCreateToken       },
+    { "deleteToken",      translateDeleteToken       },
+    { "updateToken",      translateUpdateToken       },
+    { "burnToken",        translateBurnToken         },
+    { "mintToken",        translateMintToken         },
+    { "approveAllowance", translateApproveAllowance  },
+    { "createTopic",      translateCreateTopic       },
+    { "deleteTopic",      translateDeleteTopic       },
+    { "submitMessage",    translateSubmitTopicMessage}
   };
 
   const std::string method = json.at("method").get<std::string>();
@@ -359,12 +540,16 @@ nlohmann::json createSchedule(const CreateScheduleParams& params)
   ScheduleCreateTransaction scheduleCreateTransaction;
   scheduleCreateTransaction.setGrpcDeadline(SdkClient::DEFAULT_TCK_REQUEST_TIMEOUT);
 
-  if (params.mMemo.has_value()) scheduleCreateTransaction.setScheduleMemo(params.mMemo.value());
-  if (params.mAdminKey.has_value()) scheduleCreateTransaction.setAdminKey(KeyService::getHieroKey(params.mAdminKey.value()));
+  if (params.mMemo.has_value())
+    scheduleCreateTransaction.setScheduleMemo(params.mMemo.value());
+  if (params.mAdminKey.has_value())
+    scheduleCreateTransaction.setAdminKey(KeyService::getHieroKey(params.mAdminKey.value()));
   if (params.mPayerAccountId.has_value())
     scheduleCreateTransaction.setPayerAccountId(AccountId::fromString(params.mPayerAccountId.value()));
-  if (params.mExpirationTime.has_value()) scheduleCreateTransaction.setExpirationTime(parseTime(params.mExpirationTime));
-  if (params.mWaitForExpiry.has_value()) scheduleCreateTransaction.setWaitForExpiry(params.mWaitForExpiry.value());
+  if (params.mExpirationTime.has_value())
+    scheduleCreateTransaction.setExpirationTime(parseTime(params.mExpirationTime));
+  if (params.mWaitForExpiry.has_value())
+    scheduleCreateTransaction.setWaitForExpiry(params.mWaitForExpiry.value());
 
   scheduleCreateTransaction.setScheduledTransaction(translateScheduledTransaction(params.mScheduledTransaction));
 
@@ -377,8 +562,8 @@ nlohmann::json createSchedule(const CreateScheduleParams& params)
     scheduleCreateTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient());
 
   return {
-    {"status",     gStatusToString.at(txReceipt.mStatus)   },
-    {"scheduleId", txReceipt.mScheduleId.value().toString()}
+    {"status",      gStatusToString.at(txReceipt.mStatus)   },
+    { "scheduleId", txReceipt.mScheduleId.value().toString()}
   };
 }
 

--- a/src/tck/src/schedule/ScheduleService.cc
+++ b/src/tck/src/schedule/ScheduleService.cc
@@ -34,18 +34,88 @@
 #include <impl/EntityIdHelper.h>
 
 #include <chrono>
+#include <functional>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <unordered_map>
 
 namespace Hiero::TCK::ScheduleService
 {
 namespace
 {
+// Helper to parse seconds from string
+std::chrono::seconds parseSeconds(const std::optional<std::string>& secondsStr)
+{
+  return std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(secondsStr.value()));
+}
+
+// Helper to parse time from seconds string
+std::chrono::system_clock::time_point parseTime(const std::optional<std::string>& secondsStr)
+{
+  return std::chrono::system_clock::from_time_t(0) + parseSeconds(secondsStr);
+}
+
+/**
+ * Helper to add an Hbar transfer to a transaction.
+ */
+void addHbarTransfer(TransferTransaction& transaction, const TransferParams& txParams)
+{
+  const Hbar amount = Hbar::fromTinybars(internal::EntityIdHelper::getNum<int64_t>(txParams.mHbar->mAmount));
+  const bool approved = txParams.mApproved.has_value() && txParams.mApproved.value();
+
+  if (txParams.mHbar->mAccountId.has_value())
+  {
+    const AccountId accountId = AccountId::fromString(txParams.mHbar->mAccountId.value());
+    approved ? transaction.addApprovedHbarTransfer(accountId, amount) : transaction.addHbarTransfer(accountId, amount);
+  }
+  else
+  {
+    const EvmAddress evmAddress = EvmAddress::fromString(txParams.mHbar->mEvmAddress.value());
+    approved ? transaction.addApprovedHbarTransfer(AccountId::fromEvmAddress(evmAddress), amount)
+             : transaction.addHbarTransfer(evmAddress, amount);
+  }
+}
+
+/**
+ * Helper to add a Token transfer to a transaction.
+ */
+void addTokenTransfer(TransferTransaction& transaction, const TransferParams& txParams)
+{
+  const AccountId accountId = AccountId::fromString(txParams.mToken->mAccountId);
+  const TokenId tokenId = TokenId::fromString(txParams.mToken->mTokenId);
+  const auto amount = internal::EntityIdHelper::getNum<int64_t>(txParams.mToken->mAmount);
+  const bool approved = txParams.mApproved.has_value() && txParams.mApproved.value();
+
+  if (txParams.mToken->mDecimals.has_value())
+  {
+    const uint32_t decimals = txParams.mToken->mDecimals.value();
+    approved ? transaction.addApprovedTokenTransferWithDecimals(tokenId, accountId, amount, decimals)
+             : transaction.addTokenTransferWithDecimals(tokenId, accountId, amount, decimals);
+  }
+  else
+  {
+    approved ? transaction.addApprovedTokenTransfer(tokenId, accountId, amount)
+             : transaction.addTokenTransfer(tokenId, accountId, amount);
+  }
+}
+
+/**
+ * Helper to add an NFT transfer to a transaction.
+ */
+void addNftTransfer(TransferTransaction& transaction, const TransferParams& txParams)
+{
+  const AccountId senderAccountId = AccountId::fromString(txParams.mNft->mSenderAccountId);
+  const AccountId receiverAccountId = AccountId::fromString(txParams.mNft->mReceiverAccountId);
+  const NftId nftId = NftId(TokenId::fromString(txParams.mNft->mTokenId),
+                            internal::EntityIdHelper::getNum(txParams.mNft->mSerialNumber));
+  const bool approved = txParams.mApproved.has_value() && txParams.mApproved.value();
+
+  approved ? transaction.addApprovedNftTransfer(nftId, senderAccountId, receiverAccountId)
+           : transaction.addNftTransfer(nftId, senderAccountId, receiverAccountId);
+}
+
 /**
  * Translate a transferCrypto TCK JSON-RPC params into a WrappedTransaction.
- *
- * @param params The JSON object containing the params for the transferCrypto transaction.
- * @return The translated WrappedTransaction.
  */
 WrappedTransaction translateTransferCrypto(const nlohmann::json& params)
 {
@@ -56,84 +126,17 @@ WrappedTransaction translateTransferCrypto(const nlohmann::json& params)
   {
     for (const TransferParams& txParams : transferParams.mTransfers.value())
     {
-      const bool approved = txParams.mApproved.has_value() && txParams.mApproved.value();
-
       if (txParams.mHbar.has_value())
       {
-        const Hbar amount = Hbar::fromTinybars(internal::EntityIdHelper::getNum<int64_t>(txParams.mHbar->mAmount));
-
-        if (txParams.mHbar->mAccountId.has_value())
-        {
-          const AccountId accountId = AccountId::fromString(txParams.mHbar->mAccountId.value());
-
-          if (approved)
-          {
-            transaction.addApprovedHbarTransfer(accountId, amount);
-          }
-          else
-          {
-            transaction.addHbarTransfer(accountId, amount);
-          }
-        }
-        else
-        {
-          const EvmAddress evmAddress = EvmAddress::fromString(txParams.mHbar->mEvmAddress.value());
-
-          if (approved)
-          {
-            transaction.addApprovedHbarTransfer(AccountId::fromEvmAddress(evmAddress), amount);
-          }
-          else
-          {
-            transaction.addHbarTransfer(evmAddress, amount);
-          }
-        }
+        addHbarTransfer(transaction, txParams);
       }
       else if (txParams.mToken.has_value())
       {
-        const AccountId accountId = AccountId::fromString(txParams.mToken->mAccountId);
-        const TokenId tokenId = TokenId::fromString(txParams.mToken->mTokenId);
-        const auto amount = internal::EntityIdHelper::getNum<int64_t>(txParams.mToken->mAmount);
-
-        if (txParams.mToken->mDecimals.has_value())
-        {
-          const uint32_t decimals = txParams.mToken->mDecimals.value();
-          if (approved)
-          {
-            transaction.addApprovedTokenTransferWithDecimals(tokenId, accountId, amount, decimals);
-          }
-          else
-          {
-            transaction.addTokenTransferWithDecimals(tokenId, accountId, amount, decimals);
-          }
-        }
-        else
-        {
-          if (approved)
-          {
-            transaction.addApprovedTokenTransfer(tokenId, accountId, amount);
-          }
-          else
-          {
-            transaction.addTokenTransfer(tokenId, accountId, amount);
-          }
-        }
+        addTokenTransfer(transaction, txParams);
       }
       else
       {
-        const AccountId senderAccountId = AccountId::fromString(txParams.mNft->mSenderAccountId);
-        const AccountId receiverAccountId = AccountId::fromString(txParams.mNft->mReceiverAccountId);
-        const NftId nftId = NftId(TokenId::fromString(txParams.mNft->mTokenId),
-                                  internal::EntityIdHelper::getNum(txParams.mNft->mSerialNumber));
-
-        if (approved)
-        {
-          transaction.addApprovedNftTransfer(nftId, senderAccountId, receiverAccountId);
-        }
-        else
-        {
-          transaction.addNftTransfer(nftId, senderAccountId, receiverAccountId);
-        }
+        addNftTransfer(transaction, txParams);
       }
     }
   }
@@ -143,501 +146,197 @@ WrappedTransaction translateTransferCrypto(const nlohmann::json& params)
 
 /**
  * Translate a createAccount TCK JSON-RPC params into a WrappedTransaction.
- *
- * @param params The JSON object containing the params for the createAccount transaction.
- * @return The translated WrappedTransaction.
  */
 WrappedTransaction translateCreateAccount(const nlohmann::json& params)
 {
-  const auto createAccountParams = params.get<AccountService::CreateAccountParams>();
-  AccountCreateTransaction transaction;
+  const auto p = params.get<AccountService::CreateAccountParams>();
+  AccountCreateTransaction tx;
 
-  if (createAccountParams.mKey.has_value())
-  {
-    transaction.setKeyWithoutAlias(KeyService::getHieroKey(createAccountParams.mKey.value()));
-  }
+  if (p.mKey.has_value()) tx.setKeyWithoutAlias(KeyService::getHieroKey(p.mKey.value()));
+  if (p.mInitialBalance.has_value())
+    tx.setInitialBalance(Hbar(internal::EntityIdHelper::getNum<int64_t>(p.mInitialBalance.value()), HbarUnit::TINYBAR()));
+  if (p.mReceiverSignatureRequired.has_value()) tx.setReceiverSignatureRequired(p.mReceiverSignatureRequired.value());
+  if (p.mAutoRenewPeriod.has_value()) tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
+  if (p.mMemo.has_value()) tx.setAccountMemo(p.mMemo.value());
+  if (p.mMaxAutoTokenAssociations.has_value()) tx.setMaxAutomaticTokenAssociations(p.mMaxAutoTokenAssociations.value());
+  if (p.mStakedAccountId.has_value()) tx.setStakedAccountId(AccountId::fromString(p.mStakedAccountId.value()));
+  if (p.mStakedNodeId.has_value()) tx.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(p.mStakedNodeId.value()));
+  if (p.mDeclineStakingReward.has_value()) tx.setDeclineStakingReward(p.mDeclineStakingReward.value());
+  if (p.mAlias.has_value()) tx.setAlias(EvmAddress::fromString(p.mAlias.value()));
 
-  if (createAccountParams.mInitialBalance.has_value())
-  {
-    transaction.setInitialBalance(
-      Hbar(internal::EntityIdHelper::getNum<int64_t>(createAccountParams.mInitialBalance.value()), HbarUnit::TINYBAR()));
-  }
-
-  if (createAccountParams.mReceiverSignatureRequired.has_value())
-  {
-    transaction.setReceiverSignatureRequired(createAccountParams.mReceiverSignatureRequired.value());
-  }
-
-  if (createAccountParams.mAutoRenewPeriod.has_value())
-  {
-    transaction.setAutoRenewPeriod(
-      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createAccountParams.mAutoRenewPeriod.value())));
-  }
-
-  if (createAccountParams.mMemo.has_value())
-  {
-    transaction.setAccountMemo(createAccountParams.mMemo.value());
-  }
-
-  if (createAccountParams.mMaxAutoTokenAssociations.has_value())
-  {
-    transaction.setMaxAutomaticTokenAssociations(createAccountParams.mMaxAutoTokenAssociations.value());
-  }
-
-  if (createAccountParams.mStakedAccountId.has_value())
-  {
-    transaction.setStakedAccountId(AccountId::fromString(createAccountParams.mStakedAccountId.value()));
-  }
-
-  if (createAccountParams.mStakedNodeId.has_value())
-  {
-    transaction.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(createAccountParams.mStakedNodeId.value()));
-  }
-
-  if (createAccountParams.mDeclineStakingReward.has_value())
-  {
-    transaction.setDeclineStakingReward(createAccountParams.mDeclineStakingReward.value());
-  }
-
-  if (createAccountParams.mAlias.has_value())
-  {
-    transaction.setAlias(EvmAddress::fromString(createAccountParams.mAlias.value()));
-  }
-
-  return WrappedTransaction(transaction);
+  return WrappedTransaction(tx);
 }
 
 /**
  * Translate a deleteAccount TCK JSON-RPC params into a WrappedTransaction.
- *
- * @param params The JSON object containing the params for the deleteAccount transaction.
- * @return The translated WrappedTransaction.
  */
 WrappedTransaction translateDeleteAccount(const nlohmann::json& params)
 {
-  const auto deleteAccountParams = params.get<AccountService::DeleteAccountParams>();
-  AccountDeleteTransaction transaction;
+  const auto p = params.get<AccountService::DeleteAccountParams>();
+  AccountDeleteTransaction tx;
 
-  if (deleteAccountParams.mDeleteAccountId.has_value())
-  {
-    transaction.setDeleteAccountId(AccountId::fromString(deleteAccountParams.mDeleteAccountId.value()));
-  }
+  if (p.mDeleteAccountId.has_value()) tx.setDeleteAccountId(AccountId::fromString(p.mDeleteAccountId.value()));
+  if (p.mTransferAccountId.has_value()) tx.setTransferAccountId(AccountId::fromString(p.mTransferAccountId.value()));
 
-  if (deleteAccountParams.mTransferAccountId.has_value())
-  {
-    transaction.setTransferAccountId(AccountId::fromString(deleteAccountParams.mTransferAccountId.value()));
-  }
-
-  return WrappedTransaction(transaction);
+  return WrappedTransaction(tx);
 }
 
 /**
  * Translate an updateAccount TCK JSON-RPC params into a WrappedTransaction.
- *
- * @param params The JSON object containing the params for the updateAccount transaction.
- * @return The translated WrappedTransaction.
  */
 WrappedTransaction translateUpdateAccount(const nlohmann::json& params)
 {
-  const auto updateAccountParams = params.get<AccountService::UpdateAccountParams>();
-  AccountUpdateTransaction transaction;
+  const auto p = params.get<AccountService::UpdateAccountParams>();
+  AccountUpdateTransaction tx;
 
-  if (updateAccountParams.mAccountId.has_value())
-  {
-    transaction.setAccountId(AccountId::fromString(updateAccountParams.mAccountId.value()));
-  }
+  if (p.mAccountId.has_value()) tx.setAccountId(AccountId::fromString(p.mAccountId.value()));
+  if (p.mKey.has_value()) tx.setKey(KeyService::getHieroKey(p.mKey.value()));
+  if (p.mAutoRenewPeriod.has_value()) tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
+  if (p.mExpirationTime.has_value()) tx.setExpirationTime(parseTime(p.mExpirationTime));
+  if (p.mReceiverSignatureRequired.has_value()) tx.setReceiverSignatureRequired(p.mReceiverSignatureRequired.value());
+  if (p.mMemo.has_value()) tx.setAccountMemo(p.mMemo.value());
+  if (p.mMaxAutoTokenAssociations.has_value()) tx.setMaxAutomaticTokenAssociations(p.mMaxAutoTokenAssociations.value());
+  if (p.mStakedAccountId.has_value()) tx.setStakedAccountId(AccountId::fromString(p.mStakedAccountId.value()));
+  if (p.mStakedNodeId.has_value()) tx.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(p.mStakedNodeId.value()));
+  if (p.mDeclineStakingReward.has_value()) tx.setDeclineStakingReward(p.mDeclineStakingReward.value());
 
-  if (updateAccountParams.mKey.has_value())
-  {
-    transaction.setKey(KeyService::getHieroKey(updateAccountParams.mKey.value()));
-  }
-
-  if (updateAccountParams.mAutoRenewPeriod.has_value())
-  {
-    transaction.setAutoRenewPeriod(
-      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateAccountParams.mAutoRenewPeriod.value())));
-  }
-
-  if (updateAccountParams.mExpirationTime.has_value())
-  {
-    transaction.setExpirationTime(
-      std::chrono::system_clock::from_time_t(0) +
-      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateAccountParams.mExpirationTime.value())));
-  }
-
-  if (updateAccountParams.mReceiverSignatureRequired.has_value())
-  {
-    transaction.setReceiverSignatureRequired(updateAccountParams.mReceiverSignatureRequired.value());
-  }
-
-  if (updateAccountParams.mMemo.has_value())
-  {
-    transaction.setAccountMemo(updateAccountParams.mMemo.value());
-  }
-
-  if (updateAccountParams.mMaxAutoTokenAssociations.has_value())
-  {
-    transaction.setMaxAutomaticTokenAssociations(updateAccountParams.mMaxAutoTokenAssociations.value());
-  }
-
-  if (updateAccountParams.mStakedAccountId.has_value())
-  {
-    transaction.setStakedAccountId(AccountId::fromString(updateAccountParams.mStakedAccountId.value()));
-  }
-
-  if (updateAccountParams.mStakedNodeId.has_value())
-  {
-    transaction.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(updateAccountParams.mStakedNodeId.value()));
-  }
-
-  if (updateAccountParams.mDeclineStakingReward.has_value())
-  {
-    transaction.setDeclineStakingReward(updateAccountParams.mDeclineStakingReward.value());
-  }
-
-  return WrappedTransaction(transaction);
+  return WrappedTransaction(tx);
 }
 
 /**
  * Translate a createToken TCK JSON-RPC params into a WrappedTransaction.
- *
- * @param params The JSON object containing the params for the createToken transaction.
- * @return The translated WrappedTransaction.
  */
 WrappedTransaction translateCreateToken(const nlohmann::json& params)
 {
-  const auto createTokenParams = params.get<TokenService::CreateTokenParams>();
-  TokenCreateTransaction transaction;
+  const auto p = params.get<TokenService::CreateTokenParams>();
+  TokenCreateTransaction tx;
 
-  if (createTokenParams.mName.has_value())
-  {
-    transaction.setTokenName(createTokenParams.mName.value());
-  }
+  if (p.mName.has_value()) tx.setTokenName(p.mName.value());
+  if (p.mSymbol.has_value()) tx.setTokenSymbol(p.mSymbol.value());
+  if (p.mDecimals.has_value()) tx.setDecimals(p.mDecimals.value());
+  if (p.mInitialSupply.has_value()) tx.setInitialSupply(internal::EntityIdHelper::getNum<int64_t>(p.mInitialSupply.value()));
+  if (p.mTreasuryAccountId.has_value()) tx.setTreasuryAccountId(AccountId::fromString(p.mTreasuryAccountId.value()));
+  if (p.mAdminKey.has_value()) tx.setAdminKey(KeyService::getHieroKey(p.mAdminKey.value()));
+  if (p.mKycKey.has_value()) tx.setKycKey(KeyService::getHieroKey(p.mKycKey.value()));
+  if (p.mFreezeKey.has_value()) tx.setFreezeKey(KeyService::getHieroKey(p.mFreezeKey.value()));
+  if (p.mWipeKey.has_value()) tx.setWipeKey(KeyService::getHieroKey(p.mWipeKey.value()));
+  if (p.mSupplyKey.has_value()) tx.setSupplyKey(KeyService::getHieroKey(p.mSupplyKey.value()));
+  if (p.mFreezeDefault.has_value()) tx.setFreezeDefault(p.mFreezeDefault.value());
+  if (p.mExpirationTime.has_value()) tx.setExpirationTime(parseTime(p.mExpirationTime));
+  if (p.mAutoRenewAccountId.has_value()) tx.setAutoRenewAccountId(AccountId::fromString(p.mAutoRenewAccountId.value()));
+  if (p.mAutoRenewPeriod.has_value()) tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
+  if (p.mMemo.has_value()) tx.setTokenMemo(p.mMemo.value());
 
-  if (createTokenParams.mSymbol.has_value())
-  {
-    transaction.setTokenSymbol(createTokenParams.mSymbol.value());
-  }
-
-  if (createTokenParams.mDecimals.has_value())
-  {
-    transaction.setDecimals(createTokenParams.mDecimals.value());
-  }
-
-  if (createTokenParams.mInitialSupply.has_value())
-  {
-    transaction.setInitialSupply(internal::EntityIdHelper::getNum<int64_t>(createTokenParams.mInitialSupply.value()));
-  }
-
-  if (createTokenParams.mTreasuryAccountId.has_value())
-  {
-    transaction.setTreasuryAccountId(AccountId::fromString(createTokenParams.mTreasuryAccountId.value()));
-  }
-
-  if (createTokenParams.mAdminKey.has_value())
-  {
-    transaction.setAdminKey(KeyService::getHieroKey(createTokenParams.mAdminKey.value()));
-  }
-
-  if (createTokenParams.mKycKey.has_value())
-  {
-    transaction.setKycKey(KeyService::getHieroKey(createTokenParams.mKycKey.value()));
-  }
-
-  if (createTokenParams.mFreezeKey.has_value())
-  {
-    transaction.setFreezeKey(KeyService::getHieroKey(createTokenParams.mFreezeKey.value()));
-  }
-
-  if (createTokenParams.mWipeKey.has_value())
-  {
-    transaction.setWipeKey(KeyService::getHieroKey(createTokenParams.mWipeKey.value()));
-  }
-
-  if (createTokenParams.mSupplyKey.has_value())
-  {
-    transaction.setSupplyKey(KeyService::getHieroKey(createTokenParams.mSupplyKey.value()));
-  }
-
-  if (createTokenParams.mFreezeDefault.has_value())
-  {
-    transaction.setFreezeDefault(createTokenParams.mFreezeDefault.value());
-  }
-
-  if (createTokenParams.mExpirationTime.has_value())
-  {
-    transaction.setExpirationTime(
-      std::chrono::system_clock::from_time_t(0) +
-      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createTokenParams.mExpirationTime.value())));
-  }
-
-  if (createTokenParams.mAutoRenewAccountId.has_value())
-  {
-    transaction.setAutoRenewAccountId(AccountId::fromString(createTokenParams.mAutoRenewAccountId.value()));
-  }
-
-  if (createTokenParams.mAutoRenewPeriod.has_value())
-  {
-    transaction.setAutoRenewPeriod(
-      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createTokenParams.mAutoRenewPeriod.value())));
-  }
-
-  if (createTokenParams.mMemo.has_value())
-  {
-    transaction.setTokenMemo(createTokenParams.mMemo.value());
-  }
-
-  return WrappedTransaction(transaction);
+  return WrappedTransaction(tx);
 }
 
 /**
  * Translate a deleteToken TCK JSON-RPC params into a WrappedTransaction.
- *
- * @param params The JSON object containing the params for the deleteToken transaction.
- * @return The translated WrappedTransaction.
  */
 WrappedTransaction translateDeleteToken(const nlohmann::json& params)
 {
-  const auto deleteTokenParams = params.get<TokenService::DeleteTokenParams>();
-  TokenDeleteTransaction transaction;
+  const auto p = params.get<TokenService::DeleteTokenParams>();
+  TokenDeleteTransaction tx;
 
-  if (deleteTokenParams.mTokenId.has_value())
-  {
-    transaction.setTokenId(TokenId::fromString(deleteTokenParams.mTokenId.value()));
-  }
+  if (p.mTokenId.has_value()) tx.setTokenId(TokenId::fromString(p.mTokenId.value()));
 
-  return WrappedTransaction(transaction);
+  return WrappedTransaction(tx);
 }
 
 /**
  * Translate an updateToken TCK JSON-RPC params into a WrappedTransaction.
- *
- * @param params The JSON object containing the params for the updateToken transaction.
- * @return The translated WrappedTransaction.
  */
 WrappedTransaction translateUpdateToken(const nlohmann::json& params)
 {
-  const auto updateTokenParams = params.get<TokenService::UpdateTokenParams>();
-  TokenUpdateTransaction transaction;
+  const auto p = params.get<TokenService::UpdateTokenParams>();
+  TokenUpdateTransaction tx;
 
-  if (updateTokenParams.mTokenId.has_value())
-  {
-    transaction.setTokenId(TokenId::fromString(updateTokenParams.mTokenId.value()));
-  }
+  if (p.mTokenId.has_value()) tx.setTokenId(TokenId::fromString(p.mTokenId.value()));
+  if (p.mSymbol.has_value()) tx.setTokenSymbol(p.mSymbol.value());
+  if (p.mName.has_value()) tx.setTokenName(p.mName.value());
+  if (p.mTreasuryAccountId.has_value()) tx.setTreasuryAccountId(AccountId::fromString(p.mTreasuryAccountId.value()));
+  if (p.mAdminKey.has_value()) tx.setAdminKey(KeyService::getHieroKey(p.mAdminKey.value()));
+  if (p.mKycKey.has_value()) tx.setKycKey(KeyService::getHieroKey(p.mKycKey.value()));
+  if (p.mFreezeKey.has_value()) tx.setFreezeKey(KeyService::getHieroKey(p.mFreezeKey.value()));
+  if (p.mWipeKey.has_value()) tx.setWipeKey(KeyService::getHieroKey(p.mWipeKey.value()));
+  if (p.mSupplyKey.has_value()) tx.setSupplyKey(KeyService::getHieroKey(p.mSupplyKey.value()));
+  if (p.mAutoRenewAccountId.has_value()) tx.setAutoRenewAccountId(AccountId::fromString(p.mAutoRenewAccountId.value()));
+  if (p.mAutoRenewPeriod.has_value()) tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
+  if (p.mExpirationTime.has_value()) tx.setExpirationTime(parseTime(p.mExpirationTime));
+  if (p.mMemo.has_value()) tx.setTokenMemo(p.mMemo.value());
 
-  if (updateTokenParams.mSymbol.has_value())
-  {
-    transaction.setTokenSymbol(updateTokenParams.mSymbol.value());
-  }
-
-  if (updateTokenParams.mName.has_value())
-  {
-    transaction.setTokenName(updateTokenParams.mName.value());
-  }
-
-  if (updateTokenParams.mTreasuryAccountId.has_value())
-  {
-    transaction.setTreasuryAccountId(AccountId::fromString(updateTokenParams.mTreasuryAccountId.value()));
-  }
-
-  if (updateTokenParams.mAdminKey.has_value())
-  {
-    transaction.setAdminKey(KeyService::getHieroKey(updateTokenParams.mAdminKey.value()));
-  }
-
-  if (updateTokenParams.mKycKey.has_value())
-  {
-    transaction.setKycKey(KeyService::getHieroKey(updateTokenParams.mKycKey.value()));
-  }
-
-  if (updateTokenParams.mFreezeKey.has_value())
-  {
-    transaction.setFreezeKey(KeyService::getHieroKey(updateTokenParams.mFreezeKey.value()));
-  }
-
-  if (updateTokenParams.mWipeKey.has_value())
-  {
-    transaction.setWipeKey(KeyService::getHieroKey(updateTokenParams.mWipeKey.value()));
-  }
-
-  if (updateTokenParams.mSupplyKey.has_value())
-  {
-    transaction.setSupplyKey(KeyService::getHieroKey(updateTokenParams.mSupplyKey.value()));
-  }
-
-  if (updateTokenParams.mAutoRenewAccountId.has_value())
-  {
-    transaction.setAutoRenewAccountId(AccountId::fromString(updateTokenParams.mAutoRenewAccountId.value()));
-  }
-
-  if (updateTokenParams.mAutoRenewPeriod.has_value())
-  {
-    transaction.setAutoRenewPeriod(
-      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateTokenParams.mAutoRenewPeriod.value())));
-  }
-
-  if (updateTokenParams.mExpirationTime.has_value())
-  {
-    transaction.setExpirationTime(
-      std::chrono::system_clock::from_time_t(0) +
-      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateTokenParams.mExpirationTime.value())));
-  }
-
-  if (updateTokenParams.mMemo.has_value())
-  {
-    transaction.setTokenMemo(updateTokenParams.mMemo.value());
-  }
-
-  return WrappedTransaction(transaction);
+  return WrappedTransaction(tx);
 }
 
 /**
  * Translate a createTopic TCK JSON-RPC params into a WrappedTransaction.
- *
- * @param params The JSON object containing the params for the createTopic transaction.
- * @return The translated WrappedTransaction.
  */
 WrappedTransaction translateCreateTopic(const nlohmann::json& params)
 {
-  const auto createTopicParams = params.get<TopicService::CreateTopicParams>();
-  TopicCreateTransaction transaction;
+  const auto p = params.get<TopicService::CreateTopicParams>();
+  TopicCreateTransaction tx;
 
-  if (createTopicParams.mMemo.has_value())
-  {
-    transaction.setMemo(createTopicParams.mMemo.value());
-  }
+  if (p.mMemo.has_value()) tx.setMemo(p.mMemo.value());
+  if (p.mAdminKey.has_value()) tx.setAdminKey(KeyService::getHieroKey(p.mAdminKey.value()));
+  if (p.mSubmitKey.has_value()) tx.setSubmitKey(KeyService::getHieroKey(p.mSubmitKey.value()));
+  if (p.mAutoRenewPeriod.has_value()) tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
+  if (p.mAutoRenewAccount.has_value()) tx.setAutoRenewAccountId(AccountId::fromString(p.mAutoRenewAccount.value()));
 
-  if (createTopicParams.mAdminKey.has_value())
-  {
-    transaction.setAdminKey(KeyService::getHieroKey(createTopicParams.mAdminKey.value()));
-  }
-
-  if (createTopicParams.mSubmitKey.has_value())
-  {
-    transaction.setSubmitKey(KeyService::getHieroKey(createTopicParams.mSubmitKey.value()));
-  }
-
-  if (createTopicParams.mAutoRenewPeriod.has_value())
-  {
-    transaction.setAutoRenewPeriod(
-      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createTopicParams.mAutoRenewPeriod.value())));
-  }
-
-  if (createTopicParams.mAutoRenewAccount.has_value())
-  {
-    transaction.setAutoRenewAccountId(AccountId::fromString(createTopicParams.mAutoRenewAccount.value()));
-  }
-
-  return WrappedTransaction(transaction);
+  return WrappedTransaction(tx);
 }
 
 /**
  * Translate a deleteTopic TCK JSON-RPC params into a WrappedTransaction.
- *
- * @param params The JSON object containing the params for the deleteTopic transaction.
- * @return The translated WrappedTransaction.
  */
 WrappedTransaction translateDeleteTopic(const nlohmann::json& params)
 {
-  const auto deleteTopicParams = params.get<TopicService::DeleteTopicParams>();
-  TopicDeleteTransaction transaction;
+  const auto p = params.get<TopicService::DeleteTopicParams>();
+  TopicDeleteTransaction tx;
 
-  if (deleteTopicParams.mTopicId.has_value())
-  {
-    transaction.setTopicId(TopicId::fromString(deleteTopicParams.mTopicId.value()));
-  }
+  if (p.mTopicId.has_value()) tx.setId(TopicId::fromString(p.mTopicId.value()));
 
-  return WrappedTransaction(transaction);
+  return WrappedTransaction(tx);
 }
 
 /**
  * Translate a submitTopicMessage TCK JSON-RPC params into a WrappedTransaction.
- *
- * @param params The JSON object containing the params for the submitTopicMessage transaction.
- * @return The translated WrappedTransaction.
  */
 WrappedTransaction translateSubmitTopicMessage(const nlohmann::json& params)
 {
-  const auto submitParams = params.get<TopicService::TopicMessageSubmitParams>();
-  TopicMessageSubmitTransaction transaction;
+  const auto p = params.get<TopicService::TopicMessageSubmitParams>();
+  TopicMessageSubmitTransaction tx;
 
-  if (submitParams.mTopicId.has_value())
-  {
-    transaction.setTopicId(TopicId::fromString(submitParams.mTopicId.value()));
-  }
+  if (p.mTopicId.has_value()) tx.setTopicId(TopicId::fromString(p.mTopicId.value()));
+  if (p.mMessage.has_value()) tx.setMessage(p.mMessage.value());
+  if (p.mMaxChunks.has_value()) tx.setMaxChunks(static_cast<int>(p.mMaxChunks.value()));
 
-  if (submitParams.mMessage.has_value())
-  {
-    transaction.setMessage(submitParams.mMessage.value());
-  }
-
-  if (submitParams.mMaxChunks.has_value())
-  {
-    transaction.setMaxChunks(static_cast<int>(submitParams.mMaxChunks.value()));
-  }
-
-  return WrappedTransaction(transaction);
+  return WrappedTransaction(tx);
 }
 
 /**
  * Translate a TCK JSON-RPC scheduled transaction into a WrappedTransaction.
- *
- * @param json The JSON object containing the method and params for the scheduled transaction.
- * @return The translated WrappedTransaction.
  */
 WrappedTransaction translateScheduledTransaction(const nlohmann::json& json)
 {
+  static const std::unordered_map<std::string, std::function<WrappedTransaction(const nlohmann::json&)>> dispatcher = {
+    {"transferCrypto",       translateTransferCrypto     },
+    { "createAccount",       translateCreateAccount      },
+    { "deleteAccount",       translateDeleteAccount      },
+    { "updateAccount",       translateUpdateAccount      },
+    { "createToken",         translateCreateToken        },
+    { "deleteToken",         translateDeleteToken        },
+    { "updateToken",         translateUpdateToken        },
+    { "createTopic",         translateCreateTopic        },
+    { "deleteTopic",         translateDeleteTopic        },
+    { "submitTopicMessage",  translateSubmitTopicMessage }
+  };
+
   const std::string method = json.at("method").get<std::string>();
-  const nlohmann::json params = json.at("params");
+  const auto it = dispatcher.find(method);
 
-  if (method == "transferCrypto")
+  if (it != dispatcher.end())
   {
-    return translateTransferCrypto(params);
-  }
-
-  if (method == "createAccount")
-  {
-    return translateCreateAccount(params);
-  }
-
-  if (method == "deleteAccount")
-  {
-    return translateDeleteAccount(params);
-  }
-
-  if (method == "updateAccount")
-  {
-    return translateUpdateAccount(params);
-  }
-
-  if (method == "createToken")
-  {
-    return translateCreateToken(params);
-  }
-
-  if (method == "deleteToken")
-  {
-    return translateDeleteToken(params);
-  }
-
-  if (method == "updateToken")
-  {
-    return translateUpdateToken(params);
-  }
-
-  if (method == "createTopic")
-  {
-    return translateCreateTopic(params);
-  }
-
-  if (method == "deleteTopic")
-  {
-    return translateDeleteTopic(params);
-  }
-
-  if (method == "submitTopicMessage")
-  {
-    return translateSubmitTopicMessage(params);
+    return it->second(json.at("params"));
   }
 
   throw std::invalid_argument("Unsupported scheduled transaction method: " + method);
@@ -650,32 +349,12 @@ nlohmann::json createSchedule(const CreateScheduleParams& params)
   ScheduleCreateTransaction scheduleCreateTransaction;
   scheduleCreateTransaction.setGrpcDeadline(SdkClient::DEFAULT_TCK_REQUEST_TIMEOUT);
 
-  if (params.mMemo.has_value())
-  {
-    scheduleCreateTransaction.setScheduleMemo(params.mMemo.value());
-  }
-
-  if (params.mAdminKey.has_value())
-  {
-    scheduleCreateTransaction.setAdminKey(KeyService::getHieroKey(params.mAdminKey.value()));
-  }
-
+  if (params.mMemo.has_value()) scheduleCreateTransaction.setScheduleMemo(params.mMemo.value());
+  if (params.mAdminKey.has_value()) scheduleCreateTransaction.setAdminKey(KeyService::getHieroKey(params.mAdminKey.value()));
   if (params.mPayerAccountId.has_value())
-  {
     scheduleCreateTransaction.setPayerAccountId(AccountId::fromString(params.mPayerAccountId.value()));
-  }
-
-  if (params.mExpirationTime.has_value())
-  {
-    scheduleCreateTransaction.setExpirationTime(
-      std::chrono::system_clock::from_time_t(0) +
-      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(params.mExpirationTime.value())));
-  }
-
-  if (params.mWaitForExpiry.has_value())
-  {
-    scheduleCreateTransaction.setWaitForExpiry(params.mWaitForExpiry.value());
-  }
+  if (params.mExpirationTime.has_value()) scheduleCreateTransaction.setExpirationTime(parseTime(params.mExpirationTime));
+  if (params.mWaitForExpiry.has_value()) scheduleCreateTransaction.setWaitForExpiry(params.mWaitForExpiry.value());
 
   scheduleCreateTransaction.setScheduledTransaction(translateScheduledTransaction(params.mScheduledTransaction));
 

--- a/src/tck/src/schedule/ScheduleService.cc
+++ b/src/tck/src/schedule/ScheduleService.cc
@@ -42,6 +42,544 @@ namespace Hiero::TCK::ScheduleService
 namespace
 {
 /**
+ * Translate a transferCrypto TCK JSON-RPC params into a WrappedTransaction.
+ *
+ * @param params The JSON object containing the params for the transferCrypto transaction.
+ * @return The translated WrappedTransaction.
+ */
+WrappedTransaction translateTransferCrypto(const nlohmann::json& params)
+{
+  const auto transferParams = params.get<AccountService::TransferCryptoParams>();
+  TransferTransaction transaction;
+
+  if (transferParams.mTransfers.has_value())
+  {
+    for (const TransferParams& txParams : transferParams.mTransfers.value())
+    {
+      const bool approved = txParams.mApproved.has_value() && txParams.mApproved.value();
+
+      if (txParams.mHbar.has_value())
+      {
+        const Hbar amount = Hbar::fromTinybars(internal::EntityIdHelper::getNum<int64_t>(txParams.mHbar->mAmount));
+
+        if (txParams.mHbar->mAccountId.has_value())
+        {
+          const AccountId accountId = AccountId::fromString(txParams.mHbar->mAccountId.value());
+
+          if (approved)
+          {
+            transaction.addApprovedHbarTransfer(accountId, amount);
+          }
+          else
+          {
+            transaction.addHbarTransfer(accountId, amount);
+          }
+        }
+        else
+        {
+          const EvmAddress evmAddress = EvmAddress::fromString(txParams.mHbar->mEvmAddress.value());
+
+          if (approved)
+          {
+            transaction.addApprovedHbarTransfer(AccountId::fromEvmAddress(evmAddress), amount);
+          }
+          else
+          {
+            transaction.addHbarTransfer(evmAddress, amount);
+          }
+        }
+      }
+      else if (txParams.mToken.has_value())
+      {
+        const AccountId accountId = AccountId::fromString(txParams.mToken->mAccountId);
+        const TokenId tokenId = TokenId::fromString(txParams.mToken->mTokenId);
+        const auto amount = internal::EntityIdHelper::getNum<int64_t>(txParams.mToken->mAmount);
+
+        if (txParams.mToken->mDecimals.has_value())
+        {
+          const uint32_t decimals = txParams.mToken->mDecimals.value();
+          if (approved)
+          {
+            transaction.addApprovedTokenTransferWithDecimals(tokenId, accountId, amount, decimals);
+          }
+          else
+          {
+            transaction.addTokenTransferWithDecimals(tokenId, accountId, amount, decimals);
+          }
+        }
+        else
+        {
+          if (approved)
+          {
+            transaction.addApprovedTokenTransfer(tokenId, accountId, amount);
+          }
+          else
+          {
+            transaction.addTokenTransfer(tokenId, accountId, amount);
+          }
+        }
+      }
+      else
+      {
+        const AccountId senderAccountId = AccountId::fromString(txParams.mNft->mSenderAccountId);
+        const AccountId receiverAccountId = AccountId::fromString(txParams.mNft->mReceiverAccountId);
+        const NftId nftId = NftId(TokenId::fromString(txParams.mNft->mTokenId),
+                                  internal::EntityIdHelper::getNum(txParams.mNft->mSerialNumber));
+
+        if (approved)
+        {
+          transaction.addApprovedNftTransfer(nftId, senderAccountId, receiverAccountId);
+        }
+        else
+        {
+          transaction.addNftTransfer(nftId, senderAccountId, receiverAccountId);
+        }
+      }
+    }
+  }
+
+  return WrappedTransaction(transaction);
+}
+
+/**
+ * Translate a createAccount TCK JSON-RPC params into a WrappedTransaction.
+ *
+ * @param params The JSON object containing the params for the createAccount transaction.
+ * @return The translated WrappedTransaction.
+ */
+WrappedTransaction translateCreateAccount(const nlohmann::json& params)
+{
+  const auto createAccountParams = params.get<AccountService::CreateAccountParams>();
+  AccountCreateTransaction transaction;
+
+  if (createAccountParams.mKey.has_value())
+  {
+    transaction.setKeyWithoutAlias(KeyService::getHieroKey(createAccountParams.mKey.value()));
+  }
+
+  if (createAccountParams.mInitialBalance.has_value())
+  {
+    transaction.setInitialBalance(
+      Hbar(internal::EntityIdHelper::getNum<int64_t>(createAccountParams.mInitialBalance.value()), HbarUnit::TINYBAR()));
+  }
+
+  if (createAccountParams.mReceiverSignatureRequired.has_value())
+  {
+    transaction.setReceiverSignatureRequired(createAccountParams.mReceiverSignatureRequired.value());
+  }
+
+  if (createAccountParams.mAutoRenewPeriod.has_value())
+  {
+    transaction.setAutoRenewPeriod(
+      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createAccountParams.mAutoRenewPeriod.value())));
+  }
+
+  if (createAccountParams.mMemo.has_value())
+  {
+    transaction.setAccountMemo(createAccountParams.mMemo.value());
+  }
+
+  if (createAccountParams.mMaxAutoTokenAssociations.has_value())
+  {
+    transaction.setMaxAutomaticTokenAssociations(createAccountParams.mMaxAutoTokenAssociations.value());
+  }
+
+  if (createAccountParams.mStakedAccountId.has_value())
+  {
+    transaction.setStakedAccountId(AccountId::fromString(createAccountParams.mStakedAccountId.value()));
+  }
+
+  if (createAccountParams.mStakedNodeId.has_value())
+  {
+    transaction.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(createAccountParams.mStakedNodeId.value()));
+  }
+
+  if (createAccountParams.mDeclineStakingReward.has_value())
+  {
+    transaction.setDeclineStakingReward(createAccountParams.mDeclineStakingReward.value());
+  }
+
+  if (createAccountParams.mAlias.has_value())
+  {
+    transaction.setAlias(EvmAddress::fromString(createAccountParams.mAlias.value()));
+  }
+
+  return WrappedTransaction(transaction);
+}
+
+/**
+ * Translate a deleteAccount TCK JSON-RPC params into a WrappedTransaction.
+ *
+ * @param params The JSON object containing the params for the deleteAccount transaction.
+ * @return The translated WrappedTransaction.
+ */
+WrappedTransaction translateDeleteAccount(const nlohmann::json& params)
+{
+  const auto deleteAccountParams = params.get<AccountService::DeleteAccountParams>();
+  AccountDeleteTransaction transaction;
+
+  if (deleteAccountParams.mDeleteAccountId.has_value())
+  {
+    transaction.setDeleteAccountId(AccountId::fromString(deleteAccountParams.mDeleteAccountId.value()));
+  }
+
+  if (deleteAccountParams.mTransferAccountId.has_value())
+  {
+    transaction.setTransferAccountId(AccountId::fromString(deleteAccountParams.mTransferAccountId.value()));
+  }
+
+  return WrappedTransaction(transaction);
+}
+
+/**
+ * Translate an updateAccount TCK JSON-RPC params into a WrappedTransaction.
+ *
+ * @param params The JSON object containing the params for the updateAccount transaction.
+ * @return The translated WrappedTransaction.
+ */
+WrappedTransaction translateUpdateAccount(const nlohmann::json& params)
+{
+  const auto updateAccountParams = params.get<AccountService::UpdateAccountParams>();
+  AccountUpdateTransaction transaction;
+
+  if (updateAccountParams.mAccountId.has_value())
+  {
+    transaction.setAccountId(AccountId::fromString(updateAccountParams.mAccountId.value()));
+  }
+
+  if (updateAccountParams.mKey.has_value())
+  {
+    transaction.setKey(KeyService::getHieroKey(updateAccountParams.mKey.value()));
+  }
+
+  if (updateAccountParams.mAutoRenewPeriod.has_value())
+  {
+    transaction.setAutoRenewPeriod(
+      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateAccountParams.mAutoRenewPeriod.value())));
+  }
+
+  if (updateAccountParams.mExpirationTime.has_value())
+  {
+    transaction.setExpirationTime(
+      std::chrono::system_clock::from_time_t(0) +
+      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateAccountParams.mExpirationTime.value())));
+  }
+
+  if (updateAccountParams.mReceiverSignatureRequired.has_value())
+  {
+    transaction.setReceiverSignatureRequired(updateAccountParams.mReceiverSignatureRequired.value());
+  }
+
+  if (updateAccountParams.mMemo.has_value())
+  {
+    transaction.setAccountMemo(updateAccountParams.mMemo.value());
+  }
+
+  if (updateAccountParams.mMaxAutoTokenAssociations.has_value())
+  {
+    transaction.setMaxAutomaticTokenAssociations(updateAccountParams.mMaxAutoTokenAssociations.value());
+  }
+
+  if (updateAccountParams.mStakedAccountId.has_value())
+  {
+    transaction.setStakedAccountId(AccountId::fromString(updateAccountParams.mStakedAccountId.value()));
+  }
+
+  if (updateAccountParams.mStakedNodeId.has_value())
+  {
+    transaction.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(updateAccountParams.mStakedNodeId.value()));
+  }
+
+  if (updateAccountParams.mDeclineStakingReward.has_value())
+  {
+    transaction.setDeclineStakingReward(updateAccountParams.mDeclineStakingReward.value());
+  }
+
+  return WrappedTransaction(transaction);
+}
+
+/**
+ * Translate a createToken TCK JSON-RPC params into a WrappedTransaction.
+ *
+ * @param params The JSON object containing the params for the createToken transaction.
+ * @return The translated WrappedTransaction.
+ */
+WrappedTransaction translateCreateToken(const nlohmann::json& params)
+{
+  const auto createTokenParams = params.get<TokenService::CreateTokenParams>();
+  TokenCreateTransaction transaction;
+
+  if (createTokenParams.mName.has_value())
+  {
+    transaction.setTokenName(createTokenParams.mName.value());
+  }
+
+  if (createTokenParams.mSymbol.has_value())
+  {
+    transaction.setTokenSymbol(createTokenParams.mSymbol.value());
+  }
+
+  if (createTokenParams.mDecimals.has_value())
+  {
+    transaction.setDecimals(createTokenParams.mDecimals.value());
+  }
+
+  if (createTokenParams.mInitialSupply.has_value())
+  {
+    transaction.setInitialSupply(internal::EntityIdHelper::getNum<int64_t>(createTokenParams.mInitialSupply.value()));
+  }
+
+  if (createTokenParams.mTreasuryAccountId.has_value())
+  {
+    transaction.setTreasuryAccountId(AccountId::fromString(createTokenParams.mTreasuryAccountId.value()));
+  }
+
+  if (createTokenParams.mAdminKey.has_value())
+  {
+    transaction.setAdminKey(KeyService::getHieroKey(createTokenParams.mAdminKey.value()));
+  }
+
+  if (createTokenParams.mKycKey.has_value())
+  {
+    transaction.setKycKey(KeyService::getHieroKey(createTokenParams.mKycKey.value()));
+  }
+
+  if (createTokenParams.mFreezeKey.has_value())
+  {
+    transaction.setFreezeKey(KeyService::getHieroKey(createTokenParams.mFreezeKey.value()));
+  }
+
+  if (createTokenParams.mWipeKey.has_value())
+  {
+    transaction.setWipeKey(KeyService::getHieroKey(createTokenParams.mWipeKey.value()));
+  }
+
+  if (createTokenParams.mSupplyKey.has_value())
+  {
+    transaction.setSupplyKey(KeyService::getHieroKey(createTokenParams.mSupplyKey.value()));
+  }
+
+  if (createTokenParams.mFreezeDefault.has_value())
+  {
+    transaction.setFreezeDefault(createTokenParams.mFreezeDefault.value());
+  }
+
+  if (createTokenParams.mExpirationTime.has_value())
+  {
+    transaction.setExpirationTime(
+      std::chrono::system_clock::from_time_t(0) +
+      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createTokenParams.mExpirationTime.value())));
+  }
+
+  if (createTokenParams.mAutoRenewAccountId.has_value())
+  {
+    transaction.setAutoRenewAccountId(AccountId::fromString(createTokenParams.mAutoRenewAccountId.value()));
+  }
+
+  if (createTokenParams.mAutoRenewPeriod.has_value())
+  {
+    transaction.setAutoRenewPeriod(
+      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createTokenParams.mAutoRenewPeriod.value())));
+  }
+
+  if (createTokenParams.mMemo.has_value())
+  {
+    transaction.setTokenMemo(createTokenParams.mMemo.value());
+  }
+
+  return WrappedTransaction(transaction);
+}
+
+/**
+ * Translate a deleteToken TCK JSON-RPC params into a WrappedTransaction.
+ *
+ * @param params The JSON object containing the params for the deleteToken transaction.
+ * @return The translated WrappedTransaction.
+ */
+WrappedTransaction translateDeleteToken(const nlohmann::json& params)
+{
+  const auto deleteTokenParams = params.get<TokenService::DeleteTokenParams>();
+  TokenDeleteTransaction transaction;
+
+  if (deleteTokenParams.mTokenId.has_value())
+  {
+    transaction.setTokenId(TokenId::fromString(deleteTokenParams.mTokenId.value()));
+  }
+
+  return WrappedTransaction(transaction);
+}
+
+/**
+ * Translate an updateToken TCK JSON-RPC params into a WrappedTransaction.
+ *
+ * @param params The JSON object containing the params for the updateToken transaction.
+ * @return The translated WrappedTransaction.
+ */
+WrappedTransaction translateUpdateToken(const nlohmann::json& params)
+{
+  const auto updateTokenParams = params.get<TokenService::UpdateTokenParams>();
+  TokenUpdateTransaction transaction;
+
+  if (updateTokenParams.mTokenId.has_value())
+  {
+    transaction.setTokenId(TokenId::fromString(updateTokenParams.mTokenId.value()));
+  }
+
+  if (updateTokenParams.mSymbol.has_value())
+  {
+    transaction.setTokenSymbol(updateTokenParams.mSymbol.value());
+  }
+
+  if (updateTokenParams.mName.has_value())
+  {
+    transaction.setTokenName(updateTokenParams.mName.value());
+  }
+
+  if (updateTokenParams.mTreasuryAccountId.has_value())
+  {
+    transaction.setTreasuryAccountId(AccountId::fromString(updateTokenParams.mTreasuryAccountId.value()));
+  }
+
+  if (updateTokenParams.mAdminKey.has_value())
+  {
+    transaction.setAdminKey(KeyService::getHieroKey(updateTokenParams.mAdminKey.value()));
+  }
+
+  if (updateTokenParams.mKycKey.has_value())
+  {
+    transaction.setKycKey(KeyService::getHieroKey(updateTokenParams.mKycKey.value()));
+  }
+
+  if (updateTokenParams.mFreezeKey.has_value())
+  {
+    transaction.setFreezeKey(KeyService::getHieroKey(updateTokenParams.mFreezeKey.value()));
+  }
+
+  if (updateTokenParams.mWipeKey.has_value())
+  {
+    transaction.setWipeKey(KeyService::getHieroKey(updateTokenParams.mWipeKey.value()));
+  }
+
+  if (updateTokenParams.mSupplyKey.has_value())
+  {
+    transaction.setSupplyKey(KeyService::getHieroKey(updateTokenParams.mSupplyKey.value()));
+  }
+
+  if (updateTokenParams.mAutoRenewAccountId.has_value())
+  {
+    transaction.setAutoRenewAccountId(AccountId::fromString(updateTokenParams.mAutoRenewAccountId.value()));
+  }
+
+  if (updateTokenParams.mAutoRenewPeriod.has_value())
+  {
+    transaction.setAutoRenewPeriod(
+      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateTokenParams.mAutoRenewPeriod.value())));
+  }
+
+  if (updateTokenParams.mExpirationTime.has_value())
+  {
+    transaction.setExpirationTime(
+      std::chrono::system_clock::from_time_t(0) +
+      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateTokenParams.mExpirationTime.value())));
+  }
+
+  if (updateTokenParams.mMemo.has_value())
+  {
+    transaction.setTokenMemo(updateTokenParams.mMemo.value());
+  }
+
+  return WrappedTransaction(transaction);
+}
+
+/**
+ * Translate a createTopic TCK JSON-RPC params into a WrappedTransaction.
+ *
+ * @param params The JSON object containing the params for the createTopic transaction.
+ * @return The translated WrappedTransaction.
+ */
+WrappedTransaction translateCreateTopic(const nlohmann::json& params)
+{
+  const auto createTopicParams = params.get<TopicService::CreateTopicParams>();
+  TopicCreateTransaction transaction;
+
+  if (createTopicParams.mMemo.has_value())
+  {
+    transaction.setMemo(createTopicParams.mMemo.value());
+  }
+
+  if (createTopicParams.mAdminKey.has_value())
+  {
+    transaction.setAdminKey(KeyService::getHieroKey(createTopicParams.mAdminKey.value()));
+  }
+
+  if (createTopicParams.mSubmitKey.has_value())
+  {
+    transaction.setSubmitKey(KeyService::getHieroKey(createTopicParams.mSubmitKey.value()));
+  }
+
+  if (createTopicParams.mAutoRenewPeriod.has_value())
+  {
+    transaction.setAutoRenewPeriod(
+      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createTopicParams.mAutoRenewPeriod.value())));
+  }
+
+  if (createTopicParams.mAutoRenewAccount.has_value())
+  {
+    transaction.setAutoRenewAccountId(AccountId::fromString(createTopicParams.mAutoRenewAccount.value()));
+  }
+
+  return WrappedTransaction(transaction);
+}
+
+/**
+ * Translate a deleteTopic TCK JSON-RPC params into a WrappedTransaction.
+ *
+ * @param params The JSON object containing the params for the deleteTopic transaction.
+ * @return The translated WrappedTransaction.
+ */
+WrappedTransaction translateDeleteTopic(const nlohmann::json& params)
+{
+  const auto deleteTopicParams = params.get<TopicService::DeleteTopicParams>();
+  TopicDeleteTransaction transaction;
+
+  if (deleteTopicParams.mTopicId.has_value())
+  {
+    transaction.setTopicId(TopicId::fromString(deleteTopicParams.mTopicId.value()));
+  }
+
+  return WrappedTransaction(transaction);
+}
+
+/**
+ * Translate a submitTopicMessage TCK JSON-RPC params into a WrappedTransaction.
+ *
+ * @param params The JSON object containing the params for the submitTopicMessage transaction.
+ * @return The translated WrappedTransaction.
+ */
+WrappedTransaction translateSubmitTopicMessage(const nlohmann::json& params)
+{
+  const auto submitParams = params.get<TopicService::TopicMessageSubmitParams>();
+  TopicMessageSubmitTransaction transaction;
+
+  if (submitParams.mTopicId.has_value())
+  {
+    transaction.setTopicId(TopicId::fromString(submitParams.mTopicId.value()));
+  }
+
+  if (submitParams.mMessage.has_value())
+  {
+    transaction.setMessage(submitParams.mMessage.value());
+  }
+
+  if (submitParams.mMaxChunks.has_value())
+  {
+    transaction.setMaxChunks(static_cast<int>(submitParams.mMaxChunks.value()));
+  }
+
+  return WrappedTransaction(transaction);
+}
+
+/**
  * Translate a TCK JSON-RPC scheduled transaction into a WrappedTransaction.
  *
  * @param json The JSON object containing the method and params for the scheduled transaction.
@@ -54,479 +592,52 @@ WrappedTransaction translateScheduledTransaction(const nlohmann::json& json)
 
   if (method == "transferCrypto")
   {
-    const auto transferParams = params.get<AccountService::TransferCryptoParams>();
-    TransferTransaction transaction;
-
-    if (transferParams.mTransfers.has_value())
-    {
-      for (const TransferParams& txParams : transferParams.mTransfers.value())
-      {
-        const bool approved = txParams.mApproved.has_value() && txParams.mApproved.value();
-
-        if (txParams.mHbar.has_value())
-        {
-          const Hbar amount = Hbar::fromTinybars(internal::EntityIdHelper::getNum<int64_t>(txParams.mHbar->mAmount));
-
-          if (txParams.mHbar->mAccountId.has_value())
-          {
-            const AccountId accountId = AccountId::fromString(txParams.mHbar->mAccountId.value());
-
-            if (approved)
-            {
-              transaction.addApprovedHbarTransfer(accountId, amount);
-            }
-            else
-            {
-              transaction.addHbarTransfer(accountId, amount);
-            }
-          }
-          else
-          {
-            const EvmAddress evmAddress = EvmAddress::fromString(txParams.mHbar->mEvmAddress.value());
-
-            if (approved)
-            {
-              transaction.addApprovedHbarTransfer(AccountId::fromEvmAddress(evmAddress), amount);
-            }
-            else
-            {
-              transaction.addHbarTransfer(evmAddress, amount);
-            }
-          }
-        }
-        else if (txParams.mToken.has_value())
-        {
-          const AccountId accountId = AccountId::fromString(txParams.mToken->mAccountId);
-          const TokenId tokenId = TokenId::fromString(txParams.mToken->mTokenId);
-          const auto amount = internal::EntityIdHelper::getNum<int64_t>(txParams.mToken->mAmount);
-
-          if (txParams.mToken->mDecimals.has_value())
-          {
-            const uint32_t decimals = txParams.mToken->mDecimals.value();
-            if (approved)
-            {
-              transaction.addApprovedTokenTransferWithDecimals(tokenId, accountId, amount, decimals);
-            }
-            else
-            {
-              transaction.addTokenTransferWithDecimals(tokenId, accountId, amount, decimals);
-            }
-          }
-          else
-          {
-            if (approved)
-            {
-              transaction.addApprovedTokenTransfer(tokenId, accountId, amount);
-            }
-            else
-            {
-              transaction.addTokenTransfer(tokenId, accountId, amount);
-            }
-          }
-        }
-        else
-        {
-          const AccountId senderAccountId = AccountId::fromString(txParams.mNft->mSenderAccountId);
-          const AccountId receiverAccountId = AccountId::fromString(txParams.mNft->mReceiverAccountId);
-          const NftId nftId = NftId(TokenId::fromString(txParams.mNft->mTokenId),
-                                    internal::EntityIdHelper::getNum(txParams.mNft->mSerialNumber));
-
-          if (approved)
-          {
-            transaction.addApprovedNftTransfer(nftId, senderAccountId, receiverAccountId);
-          }
-          else
-          {
-            transaction.addNftTransfer(nftId, senderAccountId, receiverAccountId);
-          }
-        }
-      }
-    }
-
-    return WrappedTransaction(transaction);
+    return translateTransferCrypto(params);
   }
 
   if (method == "createAccount")
   {
-    const auto createAccountParams = params.get<AccountService::CreateAccountParams>();
-    AccountCreateTransaction transaction;
-
-    if (createAccountParams.mKey.has_value())
-    {
-      transaction.setKeyWithoutAlias(KeyService::getHieroKey(createAccountParams.mKey.value()));
-    }
-
-    if (createAccountParams.mInitialBalance.has_value())
-    {
-      transaction.setInitialBalance(Hbar(internal::EntityIdHelper::getNum<int64_t>(createAccountParams.mInitialBalance.value()), HbarUnit::TINYBAR()));
-    }
-
-    if (createAccountParams.mReceiverSignatureRequired.has_value())
-    {
-      transaction.setReceiverSignatureRequired(createAccountParams.mReceiverSignatureRequired.value());
-    }
-
-    if (createAccountParams.mAutoRenewPeriod.has_value())
-    {
-      transaction.setAutoRenewPeriod(
-        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createAccountParams.mAutoRenewPeriod.value())));
-    }
-
-    if (createAccountParams.mMemo.has_value())
-    {
-      transaction.setAccountMemo(createAccountParams.mMemo.value());
-    }
-
-    if (createAccountParams.mMaxAutoTokenAssociations.has_value())
-    {
-      transaction.setMaxAutomaticTokenAssociations(createAccountParams.mMaxAutoTokenAssociations.value());
-    }
-
-    if (createAccountParams.mStakedAccountId.has_value())
-    {
-      transaction.setStakedAccountId(AccountId::fromString(createAccountParams.mStakedAccountId.value()));
-    }
-
-    if (createAccountParams.mStakedNodeId.has_value())
-    {
-      transaction.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(createAccountParams.mStakedNodeId.value()));
-    }
-
-    if (createAccountParams.mDeclineStakingReward.has_value())
-    {
-      transaction.setDeclineStakingReward(createAccountParams.mDeclineStakingReward.value());
-    }
-
-    if (createAccountParams.mAlias.has_value())
-    {
-      transaction.setAlias(EvmAddress::fromString(createAccountParams.mAlias.value()));
-    }
-
-    return WrappedTransaction(transaction);
+    return translateCreateAccount(params);
   }
 
   if (method == "deleteAccount")
   {
-    const auto deleteAccountParams = params.get<AccountService::DeleteAccountParams>();
-    AccountDeleteTransaction transaction;
-
-    if (deleteAccountParams.mDeleteAccountId.has_value())
-    {
-      transaction.setDeleteAccountId(AccountId::fromString(deleteAccountParams.mDeleteAccountId.value()));
-    }
-
-    if (deleteAccountParams.mTransferAccountId.has_value())
-    {
-      transaction.setTransferAccountId(AccountId::fromString(deleteAccountParams.mTransferAccountId.value()));
-    }
-
-    return WrappedTransaction(transaction);
+    return translateDeleteAccount(params);
   }
 
   if (method == "updateAccount")
   {
-    const auto updateAccountParams = params.get<AccountService::UpdateAccountParams>();
-    AccountUpdateTransaction transaction;
-
-    if (updateAccountParams.mAccountId.has_value())
-    {
-      transaction.setAccountId(AccountId::fromString(updateAccountParams.mAccountId.value()));
-    }
-
-    if (updateAccountParams.mKey.has_value())
-    {
-      transaction.setKey(KeyService::getHieroKey(updateAccountParams.mKey.value()));
-    }
-
-    if (updateAccountParams.mAutoRenewPeriod.has_value())
-    {
-      transaction.setAutoRenewPeriod(
-        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateAccountParams.mAutoRenewPeriod.value())));
-    }
-
-    if (updateAccountParams.mExpirationTime.has_value())
-    {
-      transaction.setExpirationTime(
-        std::chrono::system_clock::from_time_t(0) +
-        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateAccountParams.mExpirationTime.value())));
-    }
-
-    if (updateAccountParams.mReceiverSignatureRequired.has_value())
-    {
-      transaction.setReceiverSignatureRequired(updateAccountParams.mReceiverSignatureRequired.value());
-    }
-
-    if (updateAccountParams.mMemo.has_value())
-    {
-      transaction.setAccountMemo(updateAccountParams.mMemo.value());
-    }
-
-    if (updateAccountParams.mMaxAutoTokenAssociations.has_value())
-    {
-      transaction.setMaxAutomaticTokenAssociations(updateAccountParams.mMaxAutoTokenAssociations.value());
-    }
-
-    if (updateAccountParams.mStakedAccountId.has_value())
-    {
-      transaction.setStakedAccountId(AccountId::fromString(updateAccountParams.mStakedAccountId.value()));
-    }
-
-    if (updateAccountParams.mStakedNodeId.has_value())
-    {
-      transaction.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(updateAccountParams.mStakedNodeId.value()));
-    }
-
-    if (updateAccountParams.mDeclineStakingReward.has_value())
-    {
-      transaction.setDeclineStakingReward(updateAccountParams.mDeclineStakingReward.value());
-    }
-
-    return WrappedTransaction(transaction);
+    return translateUpdateAccount(params);
   }
 
   if (method == "createToken")
   {
-    const auto createTokenParams = params.get<TokenService::CreateTokenParams>();
-    TokenCreateTransaction transaction;
-
-    if (createTokenParams.mName.has_value())
-    {
-      transaction.setTokenName(createTokenParams.mName.value());
-    }
-
-    if (createTokenParams.mSymbol.has_value())
-    {
-      transaction.setTokenSymbol(createTokenParams.mSymbol.value());
-    }
-
-    if (createTokenParams.mDecimals.has_value())
-    {
-      transaction.setDecimals(createTokenParams.mDecimals.value());
-    }
-
-    if (createTokenParams.mInitialSupply.has_value())
-    {
-      transaction.setInitialSupply(internal::EntityIdHelper::getNum<int64_t>(createTokenParams.mInitialSupply.value()));
-    }
-
-    if (createTokenParams.mTreasuryAccountId.has_value())
-    {
-      transaction.setTreasuryAccountId(AccountId::fromString(createTokenParams.mTreasuryAccountId.value()));
-    }
-
-    if (createTokenParams.mAdminKey.has_value())
-    {
-      transaction.setAdminKey(KeyService::getHieroKey(createTokenParams.mAdminKey.value()));
-    }
-
-    if (createTokenParams.mKycKey.has_value())
-    {
-      transaction.setKycKey(KeyService::getHieroKey(createTokenParams.mKycKey.value()));
-    }
-
-    if (createTokenParams.mFreezeKey.has_value())
-    {
-      transaction.setFreezeKey(KeyService::getHieroKey(createTokenParams.mFreezeKey.value()));
-    }
-
-    if (createTokenParams.mWipeKey.has_value())
-    {
-      transaction.setWipeKey(KeyService::getHieroKey(createTokenParams.mWipeKey.value()));
-    }
-
-    if (createTokenParams.mSupplyKey.has_value())
-    {
-      transaction.setSupplyKey(KeyService::getHieroKey(createTokenParams.mSupplyKey.value()));
-    }
-
-    if (createTokenParams.mFreezeDefault.has_value())
-    {
-      transaction.setFreezeDefault(createTokenParams.mFreezeDefault.value());
-    }
-
-    if (createTokenParams.mExpirationTime.has_value())
-    {
-      transaction.setExpirationTime(
-        std::chrono::system_clock::from_time_t(0) +
-        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createTokenParams.mExpirationTime.value())));
-    }
-
-    if (createTokenParams.mAutoRenewAccountId.has_value())
-    {
-      transaction.setAutoRenewAccountId(AccountId::fromString(createTokenParams.mAutoRenewAccountId.value()));
-    }
-
-    if (createTokenParams.mAutoRenewPeriod.has_value())
-    {
-      transaction.setAutoRenewPeriod(
-        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createTokenParams.mAutoRenewPeriod.value())));
-    }
-
-    if (createTokenParams.mMemo.has_value())
-    {
-      transaction.setTokenMemo(createTokenParams.mMemo.value());
-    }
-
-    return WrappedTransaction(transaction);
+    return translateCreateToken(params);
   }
 
   if (method == "deleteToken")
   {
-    const auto deleteTokenParams = params.get<TokenService::DeleteTokenParams>();
-    TokenDeleteTransaction transaction;
-
-    if (deleteTokenParams.mTokenId.has_value())
-    {
-      transaction.setTokenId(TokenId::fromString(deleteTokenParams.mTokenId.value()));
-    }
-
-    return WrappedTransaction(transaction);
+    return translateDeleteToken(params);
   }
 
   if (method == "updateToken")
   {
-    const auto updateTokenParams = params.get<TokenService::UpdateTokenParams>();
-    TokenUpdateTransaction transaction;
-
-    if (updateTokenParams.mTokenId.has_value())
-    {
-      transaction.setTokenId(TokenId::fromString(updateTokenParams.mTokenId.value()));
-    }
-
-    if (updateTokenParams.mSymbol.has_value())
-    {
-      transaction.setTokenSymbol(updateTokenParams.mSymbol.value());
-    }
-
-    if (updateTokenParams.mName.has_value())
-    {
-      transaction.setTokenName(updateTokenParams.mName.value());
-    }
-
-    if (updateTokenParams.mTreasuryAccountId.has_value())
-    {
-      transaction.setTreasuryAccountId(AccountId::fromString(updateTokenParams.mTreasuryAccountId.value()));
-    }
-
-    if (updateTokenParams.mAdminKey.has_value())
-    {
-      transaction.setAdminKey(KeyService::getHieroKey(updateTokenParams.mAdminKey.value()));
-    }
-
-    if (updateTokenParams.mKycKey.has_value())
-    {
-      transaction.setKycKey(KeyService::getHieroKey(updateTokenParams.mKycKey.value()));
-    }
-
-    if (updateTokenParams.mFreezeKey.has_value())
-    {
-      transaction.setFreezeKey(KeyService::getHieroKey(updateTokenParams.mFreezeKey.value()));
-    }
-
-    if (updateTokenParams.mWipeKey.has_value())
-    {
-      transaction.setWipeKey(KeyService::getHieroKey(updateTokenParams.mWipeKey.value()));
-    }
-
-    if (updateTokenParams.mSupplyKey.has_value())
-    {
-      transaction.setSupplyKey(KeyService::getHieroKey(updateTokenParams.mSupplyKey.value()));
-    }
-
-    if (updateTokenParams.mAutoRenewAccountId.has_value())
-    {
-      transaction.setAutoRenewAccountId(AccountId::fromString(updateTokenParams.mAutoRenewAccountId.value()));
-    }
-
-    if (updateTokenParams.mAutoRenewPeriod.has_value())
-    {
-      transaction.setAutoRenewPeriod(
-        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateTokenParams.mAutoRenewPeriod.value())));
-    }
-
-    if (updateTokenParams.mExpirationTime.has_value())
-    {
-      transaction.setExpirationTime(
-        std::chrono::system_clock::from_time_t(0) +
-        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateTokenParams.mExpirationTime.value())));
-    }
-
-    if (updateTokenParams.mMemo.has_value())
-    {
-      transaction.setTokenMemo(updateTokenParams.mMemo.value());
-    }
-
-    return WrappedTransaction(transaction);
+    return translateUpdateToken(params);
   }
 
   if (method == "createTopic")
   {
-    const auto createTopicParams = params.get<TopicService::CreateTopicParams>();
-    TopicCreateTransaction transaction;
-
-    if (createTopicParams.mMemo.has_value())
-    {
-      transaction.setMemo(createTopicParams.mMemo.value());
-    }
-
-    if (createTopicParams.mAdminKey.has_value())
-    {
-      transaction.setAdminKey(KeyService::getHieroKey(createTopicParams.mAdminKey.value()));
-    }
-
-    if (createTopicParams.mSubmitKey.has_value())
-    {
-      transaction.setSubmitKey(KeyService::getHieroKey(createTopicParams.mSubmitKey.value()));
-    }
-
-    if (createTopicParams.mAutoRenewPeriod.has_value())
-    {
-      transaction.setAutoRenewPeriod(
-        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createTopicParams.mAutoRenewPeriod.value())));
-    }
-
-    if (createTopicParams.mAutoRenewAccount.has_value())
-    {
-      transaction.setAutoRenewAccountId(AccountId::fromString(createTopicParams.mAutoRenewAccount.value()));
-    }
-
-    return WrappedTransaction(transaction);
+    return translateCreateTopic(params);
   }
 
   if (method == "deleteTopic")
   {
-    const auto deleteTopicParams = params.get<TopicService::DeleteTopicParams>();
-    TopicDeleteTransaction transaction;
-
-    if (deleteTopicParams.mTopicId.has_value())
-    {
-      transaction.setTopicId(TopicId::fromString(deleteTopicParams.mTopicId.value()));
-    }
-
-    return WrappedTransaction(transaction);
+    return translateDeleteTopic(params);
   }
 
   if (method == "submitTopicMessage")
   {
-    const auto submitParams = params.get<TopicService::TopicMessageSubmitParams>();
-    TopicMessageSubmitTransaction transaction;
-
-    if (submitParams.mTopicId.has_value())
-    {
-      transaction.setTopicId(TopicId::fromString(submitParams.mTopicId.value()));
-    }
-
-    if (submitParams.mMessage.has_value())
-    {
-      transaction.setMessage(submitParams.mMessage.value());
-    }
-
-    if (submitParams.mMaxChunks.has_value())
-    {
-      transaction.setMaxChunks(static_cast<int>(submitParams.mMaxChunks.value()));
-    }
-
-    return WrappedTransaction(transaction);
+    return translateSubmitTopicMessage(params);
   }
 
   throw std::invalid_argument("Unsupported scheduled transaction method: " + method);

--- a/src/tck/src/schedule/ScheduleService.cc
+++ b/src/tck/src/schedule/ScheduleService.cc
@@ -126,22 +126,24 @@ WrappedTransaction translateTransferCrypto(const nlohmann::json& params)
   {
     for (const TransferParams& txParams : transferParams.mTransfers.value())
     {
-      if (txParams.mHbar.has_value())
-      {
-        addHbarTransfer(transaction, txParams);
-      }
-      else if (txParams.mToken.has_value())
-      {
-        addTokenTransfer(transaction, txParams);
-      }
-      else
-      {
-        addNftTransfer(transaction, txParams);
-      }
+      if (txParams.mHbar.has_value()) addHbarTransfer(transaction, txParams);
+      else if (txParams.mToken.has_value()) addTokenTransfer(transaction, txParams);
+      else addNftTransfer(transaction, txParams);
     }
   }
 
   return WrappedTransaction(transaction);
+}
+
+/**
+ * Set account staking parameters.
+ */
+template<typename T, typename P>
+void setAccountStaking(T& tx, const P& p)
+{
+  if (p.mStakedAccountId.has_value()) tx.setStakedAccountId(AccountId::fromString(p.mStakedAccountId.value()));
+  if (p.mStakedNodeId.has_value()) tx.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(p.mStakedNodeId.value()));
+  if (p.mDeclineStakingReward.has_value()) tx.setDeclineStakingReward(p.mDeclineStakingReward.value());
 }
 
 /**
@@ -159,11 +161,9 @@ WrappedTransaction translateCreateAccount(const nlohmann::json& params)
   if (p.mAutoRenewPeriod.has_value()) tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
   if (p.mMemo.has_value()) tx.setAccountMemo(p.mMemo.value());
   if (p.mMaxAutoTokenAssociations.has_value()) tx.setMaxAutomaticTokenAssociations(p.mMaxAutoTokenAssociations.value());
-  if (p.mStakedAccountId.has_value()) tx.setStakedAccountId(AccountId::fromString(p.mStakedAccountId.value()));
-  if (p.mStakedNodeId.has_value()) tx.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(p.mStakedNodeId.value()));
-  if (p.mDeclineStakingReward.has_value()) tx.setDeclineStakingReward(p.mDeclineStakingReward.value());
   if (p.mAlias.has_value()) tx.setAlias(EvmAddress::fromString(p.mAlias.value()));
 
+  setAccountStaking(tx, p);
   return WrappedTransaction(tx);
 }
 
@@ -196,11 +196,33 @@ WrappedTransaction translateUpdateAccount(const nlohmann::json& params)
   if (p.mReceiverSignatureRequired.has_value()) tx.setReceiverSignatureRequired(p.mReceiverSignatureRequired.value());
   if (p.mMemo.has_value()) tx.setAccountMemo(p.mMemo.value());
   if (p.mMaxAutoTokenAssociations.has_value()) tx.setMaxAutomaticTokenAssociations(p.mMaxAutoTokenAssociations.value());
-  if (p.mStakedAccountId.has_value()) tx.setStakedAccountId(AccountId::fromString(p.mStakedAccountId.value()));
-  if (p.mStakedNodeId.has_value()) tx.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(p.mStakedNodeId.value()));
-  if (p.mDeclineStakingReward.has_value()) tx.setDeclineStakingReward(p.mDeclineStakingReward.value());
 
+  setAccountStaking(tx, p);
   return WrappedTransaction(tx);
+}
+
+/**
+ * Set common token parameters.
+ */
+template<typename T, typename P>
+void setTokenKeys(T& tx, const P& p)
+{
+  if (p.mAdminKey.has_value()) tx.setAdminKey(KeyService::getHieroKey(p.mAdminKey.value()));
+  if (p.mKycKey.has_value()) tx.setKycKey(KeyService::getHieroKey(p.mKycKey.value()));
+  if (p.mFreezeKey.has_value()) tx.setFreezeKey(KeyService::getHieroKey(p.mFreezeKey.value()));
+  if (p.mWipeKey.has_value()) tx.setWipeKey(KeyService::getHieroKey(p.mWipeKey.value()));
+  if (p.mSupplyKey.has_value()) tx.setSupplyKey(KeyService::getHieroKey(p.mSupplyKey.value()));
+}
+
+/**
+ * Set common token renewal and memo parameters.
+ */
+template<typename T, typename P>
+void setTokenRenewAndMemo(T& tx, const P& p)
+{
+  if (p.mAutoRenewAccountId.has_value()) tx.setAutoRenewAccountId(AccountId::fromString(p.mAutoRenewAccountId.value()));
+  if (p.mAutoRenewPeriod.has_value()) tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
+  if (p.mMemo.has_value()) tx.setTokenMemo(p.mMemo.value());
 }
 
 /**
@@ -216,17 +238,11 @@ WrappedTransaction translateCreateToken(const nlohmann::json& params)
   if (p.mDecimals.has_value()) tx.setDecimals(p.mDecimals.value());
   if (p.mInitialSupply.has_value()) tx.setInitialSupply(internal::EntityIdHelper::getNum<int64_t>(p.mInitialSupply.value()));
   if (p.mTreasuryAccountId.has_value()) tx.setTreasuryAccountId(AccountId::fromString(p.mTreasuryAccountId.value()));
-  if (p.mAdminKey.has_value()) tx.setAdminKey(KeyService::getHieroKey(p.mAdminKey.value()));
-  if (p.mKycKey.has_value()) tx.setKycKey(KeyService::getHieroKey(p.mKycKey.value()));
-  if (p.mFreezeKey.has_value()) tx.setFreezeKey(KeyService::getHieroKey(p.mFreezeKey.value()));
-  if (p.mWipeKey.has_value()) tx.setWipeKey(KeyService::getHieroKey(p.mWipeKey.value()));
-  if (p.mSupplyKey.has_value()) tx.setSupplyKey(KeyService::getHieroKey(p.mSupplyKey.value()));
   if (p.mFreezeDefault.has_value()) tx.setFreezeDefault(p.mFreezeDefault.value());
   if (p.mExpirationTime.has_value()) tx.setExpirationTime(parseTime(p.mExpirationTime));
-  if (p.mAutoRenewAccountId.has_value()) tx.setAutoRenewAccountId(AccountId::fromString(p.mAutoRenewAccountId.value()));
-  if (p.mAutoRenewPeriod.has_value()) tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
-  if (p.mMemo.has_value()) tx.setTokenMemo(p.mMemo.value());
 
+  setTokenKeys(tx, p);
+  setTokenRenewAndMemo(tx, p);
   return WrappedTransaction(tx);
 }
 
@@ -255,16 +271,10 @@ WrappedTransaction translateUpdateToken(const nlohmann::json& params)
   if (p.mSymbol.has_value()) tx.setTokenSymbol(p.mSymbol.value());
   if (p.mName.has_value()) tx.setTokenName(p.mName.value());
   if (p.mTreasuryAccountId.has_value()) tx.setTreasuryAccountId(AccountId::fromString(p.mTreasuryAccountId.value()));
-  if (p.mAdminKey.has_value()) tx.setAdminKey(KeyService::getHieroKey(p.mAdminKey.value()));
-  if (p.mKycKey.has_value()) tx.setKycKey(KeyService::getHieroKey(p.mKycKey.value()));
-  if (p.mFreezeKey.has_value()) tx.setFreezeKey(KeyService::getHieroKey(p.mFreezeKey.value()));
-  if (p.mWipeKey.has_value()) tx.setWipeKey(KeyService::getHieroKey(p.mWipeKey.value()));
-  if (p.mSupplyKey.has_value()) tx.setSupplyKey(KeyService::getHieroKey(p.mSupplyKey.value()));
-  if (p.mAutoRenewAccountId.has_value()) tx.setAutoRenewAccountId(AccountId::fromString(p.mAutoRenewAccountId.value()));
-  if (p.mAutoRenewPeriod.has_value()) tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
   if (p.mExpirationTime.has_value()) tx.setExpirationTime(parseTime(p.mExpirationTime));
-  if (p.mMemo.has_value()) tx.setTokenMemo(p.mMemo.value());
 
+  setTokenKeys(tx, p);
+  setTokenRenewAndMemo(tx, p);
   return WrappedTransaction(tx);
 }
 
@@ -293,7 +303,7 @@ WrappedTransaction translateDeleteTopic(const nlohmann::json& params)
   const auto p = params.get<TopicService::DeleteTopicParams>();
   TopicDeleteTransaction tx;
 
-  if (p.mTopicId.has_value()) tx.setId(TopicId::fromString(p.mTopicId.value()));
+  if (p.mTopicId.has_value()) tx.setTopicId(TopicId::fromString(p.mTopicId.value()));
 
   return WrappedTransaction(tx);
 }

--- a/src/tck/src/schedule/ScheduleService.cc
+++ b/src/tck/src/schedule/ScheduleService.cc
@@ -72,13 +72,26 @@ void addHbarTransfer(TransferTransaction& transaction, const TransferParams& txP
   if (txParams.mHbar->mAccountId.has_value())
   {
     const AccountId accountId = AccountId::fromString(txParams.mHbar->mAccountId.value());
-    approved ? transaction.addApprovedHbarTransfer(accountId, amount) : transaction.addHbarTransfer(accountId, amount);
+    if (approved)
+    {
+      transaction.addApprovedHbarTransfer(accountId, amount);
+    }
+    else
+    {
+      transaction.addHbarTransfer(accountId, amount);
+    }
   }
   else
   {
     const EvmAddress evmAddress = EvmAddress::fromString(txParams.mHbar->mEvmAddress.value());
-    approved ? transaction.addApprovedHbarTransfer(AccountId::fromEvmAddress(evmAddress), amount)
-             : transaction.addHbarTransfer(evmAddress, amount);
+    if (approved)
+    {
+      transaction.addApprovedHbarTransfer(AccountId::fromEvmAddress(evmAddress), amount);
+    }
+    else
+    {
+      transaction.addHbarTransfer(evmAddress, amount);
+    }
   }
 }
 
@@ -95,13 +108,25 @@ void addTokenTransfer(TransferTransaction& transaction, const TransferParams& tx
   if (txParams.mToken->mDecimals.has_value())
   {
     const uint32_t decimals = txParams.mToken->mDecimals.value();
-    approved ? transaction.addApprovedTokenTransferWithDecimals(tokenId, accountId, amount, decimals)
-             : transaction.addTokenTransferWithDecimals(tokenId, accountId, amount, decimals);
+    if (approved)
+    {
+      transaction.addApprovedTokenTransferWithDecimals(tokenId, accountId, amount, decimals);
+    }
+    else
+    {
+      transaction.addTokenTransferWithDecimals(tokenId, accountId, amount, decimals);
+    }
   }
   else
   {
-    approved ? transaction.addApprovedTokenTransfer(tokenId, accountId, amount)
-             : transaction.addTokenTransfer(tokenId, accountId, amount);
+    if (approved)
+    {
+      transaction.addApprovedTokenTransfer(tokenId, accountId, amount);
+    }
+    else
+    {
+      transaction.addTokenTransfer(tokenId, accountId, amount);
+    }
   }
 }
 
@@ -116,8 +141,14 @@ void addNftTransfer(TransferTransaction& transaction, const TransferParams& txPa
     NftId(TokenId::fromString(txParams.mNft->mTokenId), internal::EntityIdHelper::getNum(txParams.mNft->mSerialNumber));
   const bool approved = txParams.mApproved.has_value() && txParams.mApproved.value();
 
-  approved ? transaction.addApprovedNftTransfer(nftId, senderAccountId, receiverAccountId)
-           : transaction.addNftTransfer(nftId, senderAccountId, receiverAccountId);
+  if (approved)
+  {
+    transaction.addApprovedNftTransfer(nftId, senderAccountId, receiverAccountId);
+  }
+  else
+  {
+    transaction.addNftTransfer(nftId, senderAccountId, receiverAccountId);
+  }
 }
 
 /**
@@ -133,11 +164,17 @@ WrappedTransaction translateTransferCrypto(const nlohmann::json& params)
     for (const TransferParams& txParams : transferParams.mTransfers.value())
     {
       if (txParams.mHbar.has_value())
+      {
         addHbarTransfer(transaction, txParams);
+      }
       else if (txParams.mToken.has_value())
+      {
         addTokenTransfer(transaction, txParams);
+      }
       else
+      {
         addNftTransfer(transaction, txParams);
+      }
     }
   }
 
@@ -151,11 +188,17 @@ template<typename T, typename P>
 void setAccountStaking(T& tx, const P& p)
 {
   if (p.mStakedAccountId.has_value())
+  {
     tx.setStakedAccountId(AccountId::fromString(p.mStakedAccountId.value()));
+  }
   if (p.mStakedNodeId.has_value())
+  {
     tx.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(p.mStakedNodeId.value()));
+  }
   if (p.mDeclineStakingReward.has_value())
+  {
     tx.setDeclineStakingReward(p.mDeclineStakingReward.value());
+  }
 }
 
 /**
@@ -167,20 +210,34 @@ WrappedTransaction translateCreateAccount(const nlohmann::json& params)
   AccountCreateTransaction tx;
 
   if (p.mKey.has_value())
+  {
     tx.setKeyWithoutAlias(KeyService::getHieroKey(p.mKey.value()));
+  }
   if (p.mInitialBalance.has_value())
+  {
     tx.setInitialBalance(
       Hbar(internal::EntityIdHelper::getNum<int64_t>(p.mInitialBalance.value()), HbarUnit::TINYBAR()));
+  }
   if (p.mReceiverSignatureRequired.has_value())
+  {
     tx.setReceiverSignatureRequired(p.mReceiverSignatureRequired.value());
+  }
   if (p.mAutoRenewPeriod.has_value())
+  {
     tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
+  }
   if (p.mMemo.has_value())
+  {
     tx.setAccountMemo(p.mMemo.value());
+  }
   if (p.mMaxAutoTokenAssociations.has_value())
+  {
     tx.setMaxAutomaticTokenAssociations(p.mMaxAutoTokenAssociations.value());
+  }
   if (p.mAlias.has_value())
+  {
     tx.setAlias(EvmAddress::fromString(p.mAlias.value()));
+  }
 
   setAccountStaking(tx, p);
   return WrappedTransaction(tx);
@@ -195,9 +252,13 @@ WrappedTransaction translateDeleteAccount(const nlohmann::json& params)
   AccountDeleteTransaction tx;
 
   if (p.mDeleteAccountId.has_value())
+  {
     tx.setDeleteAccountId(AccountId::fromString(p.mDeleteAccountId.value()));
+  }
   if (p.mTransferAccountId.has_value())
+  {
     tx.setTransferAccountId(AccountId::fromString(p.mTransferAccountId.value()));
+  }
 
   return WrappedTransaction(tx);
 }
@@ -211,19 +272,33 @@ WrappedTransaction translateUpdateAccount(const nlohmann::json& params)
   AccountUpdateTransaction tx;
 
   if (p.mAccountId.has_value())
+  {
     tx.setAccountId(AccountId::fromString(p.mAccountId.value()));
+  }
   if (p.mKey.has_value())
+  {
     tx.setKey(KeyService::getHieroKey(p.mKey.value()));
+  }
   if (p.mAutoRenewPeriod.has_value())
+  {
     tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
+  }
   if (p.mExpirationTime.has_value())
+  {
     tx.setExpirationTime(parseTime(p.mExpirationTime));
+  }
   if (p.mReceiverSignatureRequired.has_value())
+  {
     tx.setReceiverSignatureRequired(p.mReceiverSignatureRequired.value());
+  }
   if (p.mMemo.has_value())
+  {
     tx.setAccountMemo(p.mMemo.value());
+  }
   if (p.mMaxAutoTokenAssociations.has_value())
+  {
     tx.setMaxAutomaticTokenAssociations(p.mMaxAutoTokenAssociations.value());
+  }
 
   setAccountStaking(tx, p);
   return WrappedTransaction(tx);
@@ -236,15 +311,25 @@ template<typename T, typename P>
 void setTokenKeys(T& tx, const P& p)
 {
   if (p.mAdminKey.has_value())
+  {
     tx.setAdminKey(KeyService::getHieroKey(p.mAdminKey.value()));
+  }
   if (p.mKycKey.has_value())
+  {
     tx.setKycKey(KeyService::getHieroKey(p.mKycKey.value()));
+  }
   if (p.mFreezeKey.has_value())
+  {
     tx.setFreezeKey(KeyService::getHieroKey(p.mFreezeKey.value()));
+  }
   if (p.mWipeKey.has_value())
+  {
     tx.setWipeKey(KeyService::getHieroKey(p.mWipeKey.value()));
+  }
   if (p.mSupplyKey.has_value())
+  {
     tx.setSupplyKey(KeyService::getHieroKey(p.mSupplyKey.value()));
+  }
 }
 
 /**
@@ -254,11 +339,17 @@ template<typename T, typename P>
 void setTokenRenewAndMemo(T& tx, const P& p)
 {
   if (p.mAutoRenewAccountId.has_value())
+  {
     tx.setAutoRenewAccountId(AccountId::fromString(p.mAutoRenewAccountId.value()));
+  }
   if (p.mAutoRenewPeriod.has_value())
+  {
     tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
+  }
   if (p.mMemo.has_value())
+  {
     tx.setTokenMemo(p.mMemo.value());
+  }
 }
 
 /**
@@ -270,19 +361,33 @@ WrappedTransaction translateCreateToken(const nlohmann::json& params)
   TokenCreateTransaction tx;
 
   if (p.mName.has_value())
+  {
     tx.setTokenName(p.mName.value());
+  }
   if (p.mSymbol.has_value())
+  {
     tx.setTokenSymbol(p.mSymbol.value());
+  }
   if (p.mDecimals.has_value())
+  {
     tx.setDecimals(p.mDecimals.value());
+  }
   if (p.mInitialSupply.has_value())
+  {
     tx.setInitialSupply(internal::EntityIdHelper::getNum<int64_t>(p.mInitialSupply.value()));
+  }
   if (p.mTreasuryAccountId.has_value())
+  {
     tx.setTreasuryAccountId(AccountId::fromString(p.mTreasuryAccountId.value()));
+  }
   if (p.mFreezeDefault.has_value())
+  {
     tx.setFreezeDefault(p.mFreezeDefault.value());
+  }
   if (p.mExpirationTime.has_value())
+  {
     tx.setExpirationTime(parseTime(p.mExpirationTime));
+  }
 
   setTokenKeys(tx, p);
   setTokenRenewAndMemo(tx, p);
@@ -298,7 +403,9 @@ WrappedTransaction translateDeleteToken(const nlohmann::json& params)
   TokenDeleteTransaction tx;
 
   if (p.mTokenId.has_value())
+  {
     tx.setTokenId(TokenId::fromString(p.mTokenId.value()));
+  }
 
   return WrappedTransaction(tx);
 }
@@ -312,20 +419,31 @@ WrappedTransaction translateUpdateToken(const nlohmann::json& params)
   TokenUpdateTransaction tx;
 
   if (p.mTokenId.has_value())
+  {
     tx.setTokenId(TokenId::fromString(p.mTokenId.value()));
+  }
   if (p.mSymbol.has_value())
+  {
     tx.setTokenSymbol(p.mSymbol.value());
+  }
   if (p.mName.has_value())
+  {
     tx.setTokenName(p.mName.value());
+  }
   if (p.mTreasuryAccountId.has_value())
+  {
     tx.setTreasuryAccountId(AccountId::fromString(p.mTreasuryAccountId.value()));
+  }
   if (p.mExpirationTime.has_value())
+  {
     tx.setExpirationTime(parseTime(p.mExpirationTime));
+  }
 
   setTokenKeys(tx, p);
   setTokenRenewAndMemo(tx, p);
   return WrappedTransaction(tx);
 }
+
 /**
  * Translate a burnToken TCK JSON-RPC params into a WrappedTransaction.
  */
@@ -456,15 +574,25 @@ WrappedTransaction translateCreateTopic(const nlohmann::json& params)
   TopicCreateTransaction tx;
 
   if (p.mMemo.has_value())
+  {
     tx.setMemo(p.mMemo.value());
+  }
   if (p.mAdminKey.has_value())
+  {
     tx.setAdminKey(KeyService::getHieroKey(p.mAdminKey.value()));
+  }
   if (p.mSubmitKey.has_value())
+  {
     tx.setSubmitKey(KeyService::getHieroKey(p.mSubmitKey.value()));
+  }
   if (p.mAutoRenewPeriod.has_value())
+  {
     tx.setAutoRenewPeriod(parseSeconds(p.mAutoRenewPeriod));
+  }
   if (p.mAutoRenewAccount.has_value())
+  {
     tx.setAutoRenewAccountId(AccountId::fromString(p.mAutoRenewAccount.value()));
+  }
 
   return WrappedTransaction(tx);
 }
@@ -478,7 +606,9 @@ WrappedTransaction translateDeleteTopic(const nlohmann::json& params)
   TopicDeleteTransaction tx;
 
   if (p.mTopicId.has_value())
+  {
     tx.setTopicId(TopicId::fromString(p.mTopicId.value()));
+  }
 
   return WrappedTransaction(tx);
 }
@@ -492,11 +622,17 @@ WrappedTransaction translateSubmitTopicMessage(const nlohmann::json& params)
   TopicMessageSubmitTransaction tx;
 
   if (p.mTopicId.has_value())
+  {
     tx.setTopicId(TopicId::fromString(p.mTopicId.value()));
+  }
   if (p.mMessage.has_value())
+  {
     tx.setMessage(p.mMessage.value());
+  }
   if (p.mMaxChunks.has_value())
+  {
     tx.setMaxChunks(static_cast<int>(p.mMaxChunks.value()));
+  }
 
   return WrappedTransaction(tx);
 }
@@ -541,15 +677,25 @@ nlohmann::json createSchedule(const CreateScheduleParams& params)
   scheduleCreateTransaction.setGrpcDeadline(SdkClient::DEFAULT_TCK_REQUEST_TIMEOUT);
 
   if (params.mMemo.has_value())
+  {
     scheduleCreateTransaction.setScheduleMemo(params.mMemo.value());
+  }
   if (params.mAdminKey.has_value())
+  {
     scheduleCreateTransaction.setAdminKey(KeyService::getHieroKey(params.mAdminKey.value()));
+  }
   if (params.mPayerAccountId.has_value())
+  {
     scheduleCreateTransaction.setPayerAccountId(AccountId::fromString(params.mPayerAccountId.value()));
+  }
   if (params.mExpirationTime.has_value())
+  {
     scheduleCreateTransaction.setExpirationTime(parseTime(params.mExpirationTime));
+  }
   if (params.mWaitForExpiry.has_value())
+  {
     scheduleCreateTransaction.setWaitForExpiry(params.mWaitForExpiry.value());
+  }
 
   scheduleCreateTransaction.setScheduledTransaction(translateScheduledTransaction(params.mScheduledTransaction));
 

--- a/src/tck/src/schedule/ScheduleService.cc
+++ b/src/tck/src/schedule/ScheduleService.cc
@@ -1,0 +1,585 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "schedule/ScheduleService.h"
+
+#include "account/params/CreateAccountParams.h"
+#include "account/params/DeleteAccountParams.h"
+#include "account/params/UpdateAccountParams.h"
+#include "account/params/TransferCryptoParams.h"
+#include "common/transfer/TransferParams.h"
+#include "key/KeyService.h"
+#include "schedule/params/CreateScheduleParams.h"
+#include "sdk/SdkClient.h"
+#include "token/params/CreateTokenParams.h"
+#include "token/params/DeleteTokenParams.h"
+#include "token/params/UpdateTokenParams.h"
+#include "topic/params/CreateTopicParams.h"
+#include "topic/params/DeleteTopicParams.h"
+#include "topic/params/TopicMessageSubmitParams.h"
+
+#include <AccountCreateTransaction.h>
+#include <AccountDeleteTransaction.h>
+#include <AccountUpdateTransaction.h>
+#include <HbarUnit.h>
+#include <ScheduleCreateTransaction.h>
+#include <TokenCreateTransaction.h>
+#include <TokenDeleteTransaction.h>
+#include <TokenUpdateTransaction.h>
+#include <TopicCreateTransaction.h>
+#include <TopicDeleteTransaction.h>
+#include <TopicMessageSubmitTransaction.h>
+#include <TransactionReceipt.h>
+#include <TransactionResponse.h>
+#include <TransferTransaction.h>
+#include <WrappedTransaction.h>
+#include <impl/EntityIdHelper.h>
+
+#include <chrono>
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace Hiero::TCK::ScheduleService
+{
+namespace
+{
+/**
+ * Translate a TCK JSON-RPC scheduled transaction into a WrappedTransaction.
+ *
+ * @param json The JSON object containing the method and params for the scheduled transaction.
+ * @return The translated WrappedTransaction.
+ */
+WrappedTransaction translateScheduledTransaction(const nlohmann::json& json)
+{
+  const std::string method = json.at("method").get<std::string>();
+  const nlohmann::json params = json.at("params");
+
+  if (method == "transferCrypto")
+  {
+    const auto transferParams = params.get<AccountService::TransferCryptoParams>();
+    TransferTransaction transaction;
+
+    if (transferParams.mTransfers.has_value())
+    {
+      for (const TransferParams& txParams : transferParams.mTransfers.value())
+      {
+        const bool approved = txParams.mApproved.has_value() && txParams.mApproved.value();
+
+        if (txParams.mHbar.has_value())
+        {
+          const Hbar amount = Hbar::fromTinybars(internal::EntityIdHelper::getNum<int64_t>(txParams.mHbar->mAmount));
+
+          if (txParams.mHbar->mAccountId.has_value())
+          {
+            const AccountId accountId = AccountId::fromString(txParams.mHbar->mAccountId.value());
+
+            if (approved)
+            {
+              transaction.addApprovedHbarTransfer(accountId, amount);
+            }
+            else
+            {
+              transaction.addHbarTransfer(accountId, amount);
+            }
+          }
+          else
+          {
+            const EvmAddress evmAddress = EvmAddress::fromString(txParams.mHbar->mEvmAddress.value());
+
+            if (approved)
+            {
+              transaction.addApprovedHbarTransfer(AccountId::fromEvmAddress(evmAddress), amount);
+            }
+            else
+            {
+              transaction.addHbarTransfer(evmAddress, amount);
+            }
+          }
+        }
+        else if (txParams.mToken.has_value())
+        {
+          const AccountId accountId = AccountId::fromString(txParams.mToken->mAccountId);
+          const TokenId tokenId = TokenId::fromString(txParams.mToken->mTokenId);
+          const auto amount = internal::EntityIdHelper::getNum<int64_t>(txParams.mToken->mAmount);
+
+          if (txParams.mToken->mDecimals.has_value())
+          {
+            const uint32_t decimals = txParams.mToken->mDecimals.value();
+            if (approved)
+            {
+              transaction.addApprovedTokenTransferWithDecimals(tokenId, accountId, amount, decimals);
+            }
+            else
+            {
+              transaction.addTokenTransferWithDecimals(tokenId, accountId, amount, decimals);
+            }
+          }
+          else
+          {
+            if (approved)
+            {
+              transaction.addApprovedTokenTransfer(tokenId, accountId, amount);
+            }
+            else
+            {
+              transaction.addTokenTransfer(tokenId, accountId, amount);
+            }
+          }
+        }
+        else
+        {
+          const AccountId senderAccountId = AccountId::fromString(txParams.mNft->mSenderAccountId);
+          const AccountId receiverAccountId = AccountId::fromString(txParams.mNft->mReceiverAccountId);
+          const NftId nftId = NftId(TokenId::fromString(txParams.mNft->mTokenId),
+                                    internal::EntityIdHelper::getNum(txParams.mNft->mSerialNumber));
+
+          if (approved)
+          {
+            transaction.addApprovedNftTransfer(nftId, senderAccountId, receiverAccountId);
+          }
+          else
+          {
+            transaction.addNftTransfer(nftId, senderAccountId, receiverAccountId);
+          }
+        }
+      }
+    }
+
+    return WrappedTransaction(transaction);
+  }
+
+  if (method == "createAccount")
+  {
+    const auto createAccountParams = params.get<AccountService::CreateAccountParams>();
+    AccountCreateTransaction transaction;
+
+    if (createAccountParams.mKey.has_value())
+    {
+      transaction.setKeyWithoutAlias(KeyService::getHieroKey(createAccountParams.mKey.value()));
+    }
+
+    if (createAccountParams.mInitialBalance.has_value())
+    {
+      transaction.setInitialBalance(Hbar(internal::EntityIdHelper::getNum<int64_t>(createAccountParams.mInitialBalance.value()), HbarUnit::TINYBAR()));
+    }
+
+    if (createAccountParams.mReceiverSignatureRequired.has_value())
+    {
+      transaction.setReceiverSignatureRequired(createAccountParams.mReceiverSignatureRequired.value());
+    }
+
+    if (createAccountParams.mAutoRenewPeriod.has_value())
+    {
+      transaction.setAutoRenewPeriod(
+        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createAccountParams.mAutoRenewPeriod.value())));
+    }
+
+    if (createAccountParams.mMemo.has_value())
+    {
+      transaction.setAccountMemo(createAccountParams.mMemo.value());
+    }
+
+    if (createAccountParams.mMaxAutoTokenAssociations.has_value())
+    {
+      transaction.setMaxAutomaticTokenAssociations(createAccountParams.mMaxAutoTokenAssociations.value());
+    }
+
+    if (createAccountParams.mStakedAccountId.has_value())
+    {
+      transaction.setStakedAccountId(AccountId::fromString(createAccountParams.mStakedAccountId.value()));
+    }
+
+    if (createAccountParams.mStakedNodeId.has_value())
+    {
+      transaction.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(createAccountParams.mStakedNodeId.value()));
+    }
+
+    if (createAccountParams.mDeclineStakingReward.has_value())
+    {
+      transaction.setDeclineStakingReward(createAccountParams.mDeclineStakingReward.value());
+    }
+
+    if (createAccountParams.mAlias.has_value())
+    {
+      transaction.setAlias(EvmAddress::fromString(createAccountParams.mAlias.value()));
+    }
+
+    return WrappedTransaction(transaction);
+  }
+
+  if (method == "deleteAccount")
+  {
+    const auto deleteAccountParams = params.get<AccountService::DeleteAccountParams>();
+    AccountDeleteTransaction transaction;
+
+    if (deleteAccountParams.mDeleteAccountId.has_value())
+    {
+      transaction.setDeleteAccountId(AccountId::fromString(deleteAccountParams.mDeleteAccountId.value()));
+    }
+
+    if (deleteAccountParams.mTransferAccountId.has_value())
+    {
+      transaction.setTransferAccountId(AccountId::fromString(deleteAccountParams.mTransferAccountId.value()));
+    }
+
+    return WrappedTransaction(transaction);
+  }
+
+  if (method == "updateAccount")
+  {
+    const auto updateAccountParams = params.get<AccountService::UpdateAccountParams>();
+    AccountUpdateTransaction transaction;
+
+    if (updateAccountParams.mAccountId.has_value())
+    {
+      transaction.setAccountId(AccountId::fromString(updateAccountParams.mAccountId.value()));
+    }
+
+    if (updateAccountParams.mKey.has_value())
+    {
+      transaction.setKey(KeyService::getHieroKey(updateAccountParams.mKey.value()));
+    }
+
+    if (updateAccountParams.mAutoRenewPeriod.has_value())
+    {
+      transaction.setAutoRenewPeriod(
+        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateAccountParams.mAutoRenewPeriod.value())));
+    }
+
+    if (updateAccountParams.mExpirationTime.has_value())
+    {
+      transaction.setExpirationTime(
+        std::chrono::system_clock::from_time_t(0) +
+        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateAccountParams.mExpirationTime.value())));
+    }
+
+    if (updateAccountParams.mReceiverSignatureRequired.has_value())
+    {
+      transaction.setReceiverSignatureRequired(updateAccountParams.mReceiverSignatureRequired.value());
+    }
+
+    if (updateAccountParams.mMemo.has_value())
+    {
+      transaction.setAccountMemo(updateAccountParams.mMemo.value());
+    }
+
+    if (updateAccountParams.mMaxAutoTokenAssociations.has_value())
+    {
+      transaction.setMaxAutomaticTokenAssociations(updateAccountParams.mMaxAutoTokenAssociations.value());
+    }
+
+    if (updateAccountParams.mStakedAccountId.has_value())
+    {
+      transaction.setStakedAccountId(AccountId::fromString(updateAccountParams.mStakedAccountId.value()));
+    }
+
+    if (updateAccountParams.mStakedNodeId.has_value())
+    {
+      transaction.setStakedNodeId(internal::EntityIdHelper::getNum<int64_t>(updateAccountParams.mStakedNodeId.value()));
+    }
+
+    if (updateAccountParams.mDeclineStakingReward.has_value())
+    {
+      transaction.setDeclineStakingReward(updateAccountParams.mDeclineStakingReward.value());
+    }
+
+    return WrappedTransaction(transaction);
+  }
+
+  if (method == "createToken")
+  {
+    const auto createTokenParams = params.get<TokenService::CreateTokenParams>();
+    TokenCreateTransaction transaction;
+
+    if (createTokenParams.mName.has_value())
+    {
+      transaction.setTokenName(createTokenParams.mName.value());
+    }
+
+    if (createTokenParams.mSymbol.has_value())
+    {
+      transaction.setTokenSymbol(createTokenParams.mSymbol.value());
+    }
+
+    if (createTokenParams.mDecimals.has_value())
+    {
+      transaction.setDecimals(createTokenParams.mDecimals.value());
+    }
+
+    if (createTokenParams.mInitialSupply.has_value())
+    {
+      transaction.setInitialSupply(internal::EntityIdHelper::getNum<int64_t>(createTokenParams.mInitialSupply.value()));
+    }
+
+    if (createTokenParams.mTreasuryAccountId.has_value())
+    {
+      transaction.setTreasuryAccountId(AccountId::fromString(createTokenParams.mTreasuryAccountId.value()));
+    }
+
+    if (createTokenParams.mAdminKey.has_value())
+    {
+      transaction.setAdminKey(KeyService::getHieroKey(createTokenParams.mAdminKey.value()));
+    }
+
+    if (createTokenParams.mKycKey.has_value())
+    {
+      transaction.setKycKey(KeyService::getHieroKey(createTokenParams.mKycKey.value()));
+    }
+
+    if (createTokenParams.mFreezeKey.has_value())
+    {
+      transaction.setFreezeKey(KeyService::getHieroKey(createTokenParams.mFreezeKey.value()));
+    }
+
+    if (createTokenParams.mWipeKey.has_value())
+    {
+      transaction.setWipeKey(KeyService::getHieroKey(createTokenParams.mWipeKey.value()));
+    }
+
+    if (createTokenParams.mSupplyKey.has_value())
+    {
+      transaction.setSupplyKey(KeyService::getHieroKey(createTokenParams.mSupplyKey.value()));
+    }
+
+    if (createTokenParams.mFreezeDefault.has_value())
+    {
+      transaction.setFreezeDefault(createTokenParams.mFreezeDefault.value());
+    }
+
+    if (createTokenParams.mExpirationTime.has_value())
+    {
+      transaction.setExpirationTime(
+        std::chrono::system_clock::from_time_t(0) +
+        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createTokenParams.mExpirationTime.value())));
+    }
+
+    if (createTokenParams.mAutoRenewAccountId.has_value())
+    {
+      transaction.setAutoRenewAccountId(AccountId::fromString(createTokenParams.mAutoRenewAccountId.value()));
+    }
+
+    if (createTokenParams.mAutoRenewPeriod.has_value())
+    {
+      transaction.setAutoRenewPeriod(
+        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createTokenParams.mAutoRenewPeriod.value())));
+    }
+
+    if (createTokenParams.mMemo.has_value())
+    {
+      transaction.setTokenMemo(createTokenParams.mMemo.value());
+    }
+
+    return WrappedTransaction(transaction);
+  }
+
+  if (method == "deleteToken")
+  {
+    const auto deleteTokenParams = params.get<TokenService::DeleteTokenParams>();
+    TokenDeleteTransaction transaction;
+
+    if (deleteTokenParams.mTokenId.has_value())
+    {
+      transaction.setTokenId(TokenId::fromString(deleteTokenParams.mTokenId.value()));
+    }
+
+    return WrappedTransaction(transaction);
+  }
+
+  if (method == "updateToken")
+  {
+    const auto updateTokenParams = params.get<TokenService::UpdateTokenParams>();
+    TokenUpdateTransaction transaction;
+
+    if (updateTokenParams.mTokenId.has_value())
+    {
+      transaction.setTokenId(TokenId::fromString(updateTokenParams.mTokenId.value()));
+    }
+
+    if (updateTokenParams.mSymbol.has_value())
+    {
+      transaction.setTokenSymbol(updateTokenParams.mSymbol.value());
+    }
+
+    if (updateTokenParams.mName.has_value())
+    {
+      transaction.setTokenName(updateTokenParams.mName.value());
+    }
+
+    if (updateTokenParams.mTreasuryAccountId.has_value())
+    {
+      transaction.setTreasuryAccountId(AccountId::fromString(updateTokenParams.mTreasuryAccountId.value()));
+    }
+
+    if (updateTokenParams.mAdminKey.has_value())
+    {
+      transaction.setAdminKey(KeyService::getHieroKey(updateTokenParams.mAdminKey.value()));
+    }
+
+    if (updateTokenParams.mKycKey.has_value())
+    {
+      transaction.setKycKey(KeyService::getHieroKey(updateTokenParams.mKycKey.value()));
+    }
+
+    if (updateTokenParams.mFreezeKey.has_value())
+    {
+      transaction.setFreezeKey(KeyService::getHieroKey(updateTokenParams.mFreezeKey.value()));
+    }
+
+    if (updateTokenParams.mWipeKey.has_value())
+    {
+      transaction.setWipeKey(KeyService::getHieroKey(updateTokenParams.mWipeKey.value()));
+    }
+
+    if (updateTokenParams.mSupplyKey.has_value())
+    {
+      transaction.setSupplyKey(KeyService::getHieroKey(updateTokenParams.mSupplyKey.value()));
+    }
+
+    if (updateTokenParams.mAutoRenewAccountId.has_value())
+    {
+      transaction.setAutoRenewAccountId(AccountId::fromString(updateTokenParams.mAutoRenewAccountId.value()));
+    }
+
+    if (updateTokenParams.mAutoRenewPeriod.has_value())
+    {
+      transaction.setAutoRenewPeriod(
+        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateTokenParams.mAutoRenewPeriod.value())));
+    }
+
+    if (updateTokenParams.mExpirationTime.has_value())
+    {
+      transaction.setExpirationTime(
+        std::chrono::system_clock::from_time_t(0) +
+        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(updateTokenParams.mExpirationTime.value())));
+    }
+
+    if (updateTokenParams.mMemo.has_value())
+    {
+      transaction.setTokenMemo(updateTokenParams.mMemo.value());
+    }
+
+    return WrappedTransaction(transaction);
+  }
+
+  if (method == "createTopic")
+  {
+    const auto createTopicParams = params.get<TopicService::CreateTopicParams>();
+    TopicCreateTransaction transaction;
+
+    if (createTopicParams.mMemo.has_value())
+    {
+      transaction.setMemo(createTopicParams.mMemo.value());
+    }
+
+    if (createTopicParams.mAdminKey.has_value())
+    {
+      transaction.setAdminKey(KeyService::getHieroKey(createTopicParams.mAdminKey.value()));
+    }
+
+    if (createTopicParams.mSubmitKey.has_value())
+    {
+      transaction.setSubmitKey(KeyService::getHieroKey(createTopicParams.mSubmitKey.value()));
+    }
+
+    if (createTopicParams.mAutoRenewPeriod.has_value())
+    {
+      transaction.setAutoRenewPeriod(
+        std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(createTopicParams.mAutoRenewPeriod.value())));
+    }
+
+    if (createTopicParams.mAutoRenewAccount.has_value())
+    {
+      transaction.setAutoRenewAccountId(AccountId::fromString(createTopicParams.mAutoRenewAccount.value()));
+    }
+
+    return WrappedTransaction(transaction);
+  }
+
+  if (method == "deleteTopic")
+  {
+    const auto deleteTopicParams = params.get<TopicService::DeleteTopicParams>();
+    TopicDeleteTransaction transaction;
+
+    if (deleteTopicParams.mTopicId.has_value())
+    {
+      transaction.setTopicId(TopicId::fromString(deleteTopicParams.mTopicId.value()));
+    }
+
+    return WrappedTransaction(transaction);
+  }
+
+  if (method == "submitTopicMessage")
+  {
+    const auto submitParams = params.get<TopicService::TopicMessageSubmitParams>();
+    TopicMessageSubmitTransaction transaction;
+
+    if (submitParams.mTopicId.has_value())
+    {
+      transaction.setTopicId(TopicId::fromString(submitParams.mTopicId.value()));
+    }
+
+    if (submitParams.mMessage.has_value())
+    {
+      transaction.setMessage(submitParams.mMessage.value());
+    }
+
+    if (submitParams.mMaxChunks.has_value())
+    {
+      transaction.setMaxChunks(static_cast<int>(submitParams.mMaxChunks.value()));
+    }
+
+    return WrappedTransaction(transaction);
+  }
+
+  throw std::invalid_argument("Unsupported scheduled transaction method: " + method);
+}
+} // namespace
+
+//-----
+nlohmann::json createSchedule(const CreateScheduleParams& params)
+{
+  ScheduleCreateTransaction scheduleCreateTransaction;
+  scheduleCreateTransaction.setGrpcDeadline(SdkClient::DEFAULT_TCK_REQUEST_TIMEOUT);
+
+  if (params.mMemo.has_value())
+  {
+    scheduleCreateTransaction.setScheduleMemo(params.mMemo.value());
+  }
+
+  if (params.mAdminKey.has_value())
+  {
+    scheduleCreateTransaction.setAdminKey(KeyService::getHieroKey(params.mAdminKey.value()));
+  }
+
+  if (params.mPayerAccountId.has_value())
+  {
+    scheduleCreateTransaction.setPayerAccountId(AccountId::fromString(params.mPayerAccountId.value()));
+  }
+
+  if (params.mExpirationTime.has_value())
+  {
+    scheduleCreateTransaction.setExpirationTime(
+      std::chrono::system_clock::from_time_t(0) +
+      std::chrono::seconds(internal::EntityIdHelper::getNum<int64_t>(params.mExpirationTime.value())));
+  }
+
+  if (params.mWaitForExpiry.has_value())
+  {
+    scheduleCreateTransaction.setWaitForExpiry(params.mWaitForExpiry.value());
+  }
+
+  scheduleCreateTransaction.setScheduledTransaction(translateScheduledTransaction(params.mScheduledTransaction));
+
+  if (params.mCommonTxParams.has_value())
+  {
+    params.mCommonTxParams->fillOutTransaction(scheduleCreateTransaction, SdkClient::getClient());
+  }
+
+  const TransactionReceipt txReceipt =
+    scheduleCreateTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient());
+
+  return {
+    {"status",     gStatusToString.at(txReceipt.mStatus)   },
+    {"scheduleId", txReceipt.mScheduleId.value().toString()}
+  };
+}
+
+} // namespace Hiero::TCK::ScheduleService


### PR DESCRIPTION
**Description**:
Implement the `createSchedule` JSON-RPC endpoint for the TCK (Test Compatibility Kit). This allows the TCK test suite to verify the Schedule Service by creating and executing scheduled transactions.

* Add `CreateScheduleParams` struct and `nlohmann::json` deserializer for TCK parameters.
* Implement `ScheduleService` to handle `createSchedule` logic and transaction execution.
* Implement a translation dispatcher to map TCK JSON-RPC method calls to SDK `WrappedTransaction` objects.
* Register the `createSchedule` method in `TckServer`.
* Update `src/tck/CMakeLists.txt` to include the new service files.

Fixes #1502

**Notes for reviewer**:

The implementation includes a comprehensive dispatcher that supports scheduling the following transaction types:

- **Account**: `createAccount`, `updateAccount`, `deleteAccount`, `transferCrypto`
- **Token**: `createToken`, `updateToken`, `deleteToken`
- **Topic**: `createTopic`, `deleteTopic`, `submitTopicMessage`

The service correctly handles optional schedule parameters including `memo`, `adminKey`, `payerAccountId`, `expirationTime`, and `waitForExpiry`. The implementation follows the established patterns used in other TCK services (like `AccountService` and `TopicService`).

**Checklist**
- [x] Documented (Code comments)
- [ ] Tested (unit, integration, etc.)
