### PR TITLE
ci: fix PR review bot failing to update labels on fork PRs

### DIFF
--- a/.github/scripts/bot-on-pr-review-labels.js
+++ b/.github/scripts/bot-on-pr-review-labels.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+
+module.exports = async ({ github, context }) => {
+  const data = JSON.parse(
+    fs.readFileSync('review-event.json', 'utf8')
+  );
+
+  const prNumber = data.pr_number;
+  const reviewState = data.review_state;
+
+  const { data: pr } = await github.rest.pulls.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: prNumber,
+  });
+
+  context.payload = {
+    pull_request: pr,
+    review: {
+      state: reviewState,
+    },
+  };
+
+  const bot = require('./bot-on-pr-review.js');
+  await bot({ github, context });
+};

--- a/.github/scripts/bot-on-pr-review-labels.js
+++ b/.github/scripts/bot-on-pr-review-labels.js
@@ -1,9 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// bot-on-pr-review-labels.js
+//
+// Triggered by workflow_run after "Bot - On PR Review" completes.
+// Downloads the recorder artifact, reconstructs context, and delegates to
+// bot-on-pr-review.js to apply the correct status label.
+ 
 const fs = require('fs');
 
 module.exports = async ({ github, context }) => {
   const data = JSON.parse(
     fs.readFileSync('review-event.json', 'utf8')
   );
+ 
+  if (data.draft) {
+    return;
+  } 
 
   const prNumber = data.pr_number;
   const reviewState = data.review_state;
@@ -13,6 +25,8 @@ module.exports = async ({ github, context }) => {
     repo: context.repo.repo,
     pull_number: prNumber,
   });
+ 
+  context.eventName = 'pull_request_review';
 
   context.payload = {
     pull_request: pr,
@@ -23,4 +37,4 @@ module.exports = async ({ github, context }) => {
 
   const bot = require('./bot-on-pr-review.js');
   await bot({ github, context });
-};
+}; 

--- a/.github/workflows/on-pr-review-labels.yaml
+++ b/.github/workflows/on-pr-review-labels.yaml
@@ -1,0 +1,38 @@
+name: Bot - On PR Review (Labels)
+
+on:
+  workflow_run:
+    workflows: ["Bot - On PR Review"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  run-bot:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: hiero-client-sdk-linux-large
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40
+
+      - name: Checkout default branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Download artifact
+        uses: actions/download-artifact@3f3d89d98d4b1c8b2cdd5e17739fb8bcbac2b0c7
+        with:
+          name: review-event-${{ github.event.workflow_run.id }}
+
+      - name: Run bot
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const script = require('./.github/scripts/bot-on-pr-review-labels.js');
+            await script({ github, context });

--- a/.github/workflows/on-pr-review-labels.yaml
+++ b/.github/workflows/on-pr-review-labels.yaml
@@ -18,21 +18,24 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
 
       - name: Checkout default branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Download artifact
-        uses: actions/download-artifact@3f3d89d98d4b1c8b2cdd5e17739fb8bcbac2b0c7
+        uses: actions/download-artifact@3f3d89d98d4b1c8b2cdd5e17739fb8bcbac2b0c7 # v4
         with:
           name: review-event-${{ github.event.workflow_run.id }}
 
       - name: Run bot
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const script = require('./.github/scripts/bot-on-pr-review-labels.js');
-            await script({ github, context });
+            await script({ github, context }); 
+  

--- a/.github/workflows/on-pr-review.yaml
+++ b/.github/workflows/on-pr-review.yaml
@@ -19,11 +19,13 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
 
       - name: Save review event
         run: |
-          echo '{"pr_number":${{ github.event.pull_request.number }}, "review_state":"${{ github.event.review.state }}"}' > review-event.json
+          echo '{"pr_number":${{ github.event.pull_request.number }}, "review_state":"${{ github.event.review.state }}", "draft":${{ github.event.pull_request.draft }}}' > review-event.json
 
       - name: Upload review event
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -31,3 +33,4 @@ jobs:
           name: review-event-${{ github.run_id }}
           path: review-event.json
           retention-days: 1
+           

--- a/.github/workflows/on-pr-review.yaml
+++ b/.github/workflows/on-pr-review.yaml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  checks: write
 
 jobs:
   on-pr-review:
@@ -21,16 +19,15 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: audit
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40
 
-      - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Save review event
+        run: |
+          echo '{"pr_number":${{ github.event.pull_request.number }}, "review_state":"${{ github.event.review.state }}"}' > review-event.json
 
-      - name: Run Bot
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - name: Upload review event
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          script: |
-            const script = require('./.github/scripts/bot-on-pr-review.js');
-            await script({ github, context });
+          name: review-event-${{ github.run_id }}
+          path: review-event.json
+          retention-days: 1


### PR DESCRIPTION
**Description**:
Fix PR review bot failing to update labels on fork PRs by splitting workflow into a recorder and a labels workflow.

* Convert `on-pr-review.yaml` into a recorder workflow that saves review data as an artifact
* Add `on-pr-review-labels.yaml` triggered via `workflow_run` to update labels with proper permissions
* Add `bot-on-pr-review-labels.js` to reconstruct context and reuse existing bot logic

**Related issue(s)**:

Fixes #1442

**Notes for reviewer**:
- Uses artifact-based communication between workflows
- Ensures execution in base repository context for correct permissions
- Behavior for same-repo PRs remains unchanged

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (logic validated for fork PR scenario)