### PR TITLE
chore: update Hiero Solo version to v0.71.0

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -198,7 +198,7 @@ jobs:
         id: solo
         uses: hiero-ledger/hiero-solo-action@328bc84c3b00a990a151418144fd682a4eb76ea6 # v0.19.0
         with:
-          soloVersion: v0.69.0
+          soloVersion: v0.70.0
           installMirrorNode: true
           mirrorNodeVersion: v0.151.0
           hieroVersion: v0.73.0

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -198,7 +198,7 @@ jobs:
         id: solo
         uses: hiero-ledger/hiero-solo-action@328bc84c3b00a990a151418144fd682a4eb76ea6 # v0.19.0
         with:
-          soloVersion: v0.70.0
+          soloVersion: v0.71.0
           installMirrorNode: true
           mirrorNodeVersion: v0.151.0
           hieroVersion: v0.73.0


### PR DESCRIPTION
**Description**:
Update Hiero Solo version to v0.70.0 in the reusable build workflow to ensure the integration test environment remains current with the latest release.

* Update `soloVersion` from `v0.69.0` to `v0.71.0` in `.github/workflows/zxc-build-library.yaml`

**Related issue(s)**:

Fixes #1520 

**Notes for reviewer**:
This is a straightforward string replacement in the CI configuration as outlined in the "Good First Issue" description. No changes were made to C++ source code or SDK architecture. All commits are GPG-signed and include the DCO sign-off.

**Checklist**

- [x] Documented (N/A - CI configuration update)
- [x] Tested (Verified via CI workflow execution)