### PR TITLE
Fix swapStatusLabel silently swallowing errors

### DIFF
--- a/.github/scripts/bot-on-pr-merged.js
+++ b/.github/scripts/bot-on-pr-merged.js
@@ -52,7 +52,10 @@ async function checkSiblingConflictsOnMerge(globalBotContext) {
     if (currentlyShowsConflict !== actuallyHasConflict) {
       logger.log(`PR #${pr.number} conflict status changed to ${actuallyHasConflict ? 'conflicted' : 'clean'}, updating...`);
       const { allPassed } = await runAllChecksAndComment(prContext, { merge: mergeResult });
-      await swapStatusLabel(prContext, allPassed);
+      const swapResult = await swapStatusLabel(prContext, allPassed);
+      if (!swapResult.success) {
+        logger.error(`Failed to swap status label for PR #${pr.number}: ${swapResult.errorDetails}`);
+      }
 
       // Post a standalone notification when a conflict is newly introduced
       if (!currentlyShowsConflict && actuallyHasConflict) {

--- a/.github/scripts/bot-on-pr-open.js
+++ b/.github/scripts/bot-on-pr-open.js
@@ -58,7 +58,10 @@ module.exports = async ({ github, context }) => {
     }
 
     const { allPassed } = await runAllChecksAndComment(botContext);
-    await swapStatusLabel(botContext, allPassed, { force: true });
+    const result = await swapStatusLabel(botContext, allPassed, { force: true });
+    if (!result.success) {
+      logger.error(`Failed to swap status label: ${result.errorDetails}`);
+    }
 
     logger.log('On-PR-open bot completed');
   } catch (error) {

--- a/.github/scripts/bot-on-pr-review.js
+++ b/.github/scripts/bot-on-pr-review.js
@@ -26,8 +26,12 @@ module.exports = async ({ github, context }) => {
     }
 
     // Force swap to needs-revision (allPassed = false)
-    await swapStatusLabel(botContext, false, { force: true });
-    logger.log(`Successfully swapped status to needs revision`);
+    const result = await swapStatusLabel(botContext, false, { force: true });
+    if (!result.success) {
+      logger.error(`Failed to swap status to needs revision: ${result.errorDetails}`);
+    } else {
+      logger.log(`Successfully swapped status to needs revision`);
+    }
   } catch (error) {
     logger.error('Error:', {
       message: error.message,

--- a/.github/scripts/bot-on-pr-update.js
+++ b/.github/scripts/bot-on-pr-update.js
@@ -32,7 +32,10 @@ module.exports = async ({ github, context }) => {
     }
 
     const { allPassed } = await runAllChecksAndComment(botContext);
-    await swapStatusLabel(botContext, allPassed);
+    const result = await swapStatusLabel(botContext, allPassed);
+    if (!result.success) {
+      logger.error(`Failed to swap status label: ${result.errorDetails}`);
+    }
 
     logger.log('On-PR-update bot completed');
   } catch (error) {

--- a/.github/scripts/helpers/api.js
+++ b/.github/scripts/helpers/api.js
@@ -485,24 +485,32 @@ async function fetchClosingIssueNumbers(botContext) {
  * @param {object} botContext
  * @param {boolean} allPassed
  * @param {{ force?: boolean }} [options]
- * @returns {Promise<void>}
+ * @returns {Promise<{ success: boolean, errorDetails: string }>}
  */
 async function swapStatusLabel(botContext, allPassed, { force = false } = {}) {
   const pr = botContext.pr;
   const labelToAdd = allPassed ? LABELS.NEEDS_REVIEW : LABELS.NEEDS_REVISION;
   const labelToRemove = allPassed ? LABELS.NEEDS_REVISION : LABELS.NEEDS_REVIEW;
+  const errors = [];
 
-  if (force) {
-    if (hasLabel(pr, labelToRemove)) {
-      await removeLabel(botContext, labelToRemove);
-    }
-    await addLabels(botContext, [labelToAdd]);
-  } else {
-    if (hasLabel(pr, labelToRemove)) {
-      await removeLabel(botContext, labelToRemove);
-      await addLabels(botContext, [labelToAdd]);
+  const shouldRemove = hasLabel(pr, labelToRemove);
+  const shouldAdd = force || shouldRemove;
+
+  if (shouldRemove) {
+    const removeResult = await removeLabel(botContext, labelToRemove);
+    if (!removeResult.success) {
+      errors.push(`Failed to remove '${labelToRemove}': ${removeResult.error}`);
     }
   }
+
+  if (shouldAdd) {
+    const addResult = await addLabels(botContext, [labelToAdd]);
+    if (!addResult.success) {
+      errors.push(`Failed to add '${labelToAdd}': ${addResult.error}`);
+    }
+  }
+
+  return { success: errors.length === 0, errorDetails: errors.join('; ') };
 }
 
 /**


### PR DESCRIPTION
Resolves #1441

**Description**:
Update `swapStatusLabel` to aggregate and return errors from underlying API calls instead of failing silently. Update its callers to check the return value and explicitly log any errors, preventing misleading success logs when a label swap fails due to permission issues.

* Update `swapStatusLabel` to return `{ success, errorDetails }`
* Log errors in `bot-on-pr-review.js` when label swap fails
* Log errors in `bot-on-pr-update.js` when label swap fails
* Log errors in `bot-on-pr-merged.js` when label swap fails
* Log errors in `bot-on-pr-open.js` when label swap fails

**Related issue(s)**:

Fixes #1441

**Notes for reviewer**:
All 41 existing integration tests in `.github/scripts/tests/` have been executed locally and continue to pass successfully. The updated code strictly follows the existing error-handling pattern already established in the `swapLabels` helper.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
