### PR TITLE
Feat/tck delete schedule 1503

### DIFF
--- a/src/tck/CMakeLists.txt
+++ b/src/tck/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(${TCK_SERVER_NAME}
         src/sdk/SdkClient.cc
         src/token/TokenService.cc
         src/topic/TopicService.cc
+        src/schedule/ScheduleService.cc
         src/main.cc
         src/TckServer.cc)
 

--- a/src/tck/include/schedule/ScheduleService.h
+++ b/src/tck/include/schedule/ScheduleService.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef HIERO_TCK_CPP_SCHEDULE_SERVICE_H_
+#define HIERO_TCK_CPP_SCHEDULE_SERVICE_H_
+
+#include <nlohmann/json_fwd.hpp>
+
+namespace Hiero::TCK::ScheduleService
+{
+/**
+ * Forward declarations.
+ */
+struct DeleteScheduleParams;
+
+/**
+ * Delete a schedule.
+ *
+ * @param params The parameters to use to delete a schedule.
+ * @return A JSON response containing the status of the deletion of the schedule.
+ */
+nlohmann::json deleteSchedule(const DeleteScheduleParams& params);
+
+} // namespace Hiero::TCK::ScheduleService
+
+#endif // HIERO_TCK_CPP_SCHEDULE_SERVICE_H_

--- a/src/tck/include/schedule/ScheduleService.h
+++ b/src/tck/include/schedule/ScheduleService.h
@@ -9,16 +9,8 @@ namespace Hiero::TCK::ScheduleService
 /**
  * Forward declarations.
  */
-struct DeleteScheduleParams;
 struct CreateScheduleParams;
-
-/**
- * Delete a schedule.
- *
- * @param params The parameters to use to delete a schedule.
- * @return A JSON response containing the status of the deletion of the schedule.
- */
-nlohmann::json deleteSchedule(const DeleteScheduleParams& params);
+struct DeleteScheduleParams;
 
 /**
  * Create a schedule.
@@ -27,6 +19,14 @@ nlohmann::json deleteSchedule(const DeleteScheduleParams& params);
  * @return A JSON response containing the status of the schedule creation and the new schedule's ID.
  */
 nlohmann::json createSchedule(const CreateScheduleParams& params);
+
+/**
+ * Delete a schedule.
+ *
+ * @param params The parameters to use to delete a schedule.
+ * @return A JSON response containing the status of the deletion of the schedule.
+ */
+nlohmann::json deleteSchedule(const DeleteScheduleParams& params);
 
 } // namespace Hiero::TCK::ScheduleService
 

--- a/src/tck/include/schedule/params/DeleteScheduleParams.h
+++ b/src/tck/include/schedule/params/DeleteScheduleParams.h
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef HIERO_TCK_CPP_DELETE_SCHEDULE_PARAMS_H_
+#define HIERO_TCK_CPP_DELETE_SCHEDULE_PARAMS_H_
+
+#include "common/CommonTransactionParams.h"
+#include "nlohmann/json.hpp"
+
+#include "json/JsonUtils.h"
+#include <optional>
+#include <string>
+
+namespace Hiero::TCK::ScheduleService
+{
+/**
+ * Struct to hold the arguments for a `deleteSchedule` Json-RPC method call.
+ */
+struct DeleteScheduleParams
+{
+  /**
+   * The ID of the schedule to delete.
+   */
+  std::optional<std::string> mScheduleId;
+
+  /**
+   * Any parameters common to all transaction types.
+   */
+  std::optional<CommonTransactionParams> mCommonTxParams;
+};
+
+} // namespace Hiero::TCK::ScheduleService
+
+namespace nlohmann
+{
+/**
+ * JSON serializer template specialisation required to convert DeleteScheduleParams argument properly.
+ */
+template<>
+struct [[maybe_unused]] adl_serializer<Hiero::TCK::ScheduleService::DeleteScheduleParams>
+{
+  /**
+   * Convert a JSON object to a DeleteScheduleParams.
+   *
+   * @param jsonFrom The JSON object with which to fill the DeleteScheduleParams.
+   * @param params   The DeleteScheduleParams to fill with the JSON object.
+   */
+  static void from_json(const json& jsonFrom, Hiero::TCK::ScheduleService::DeleteScheduleParams& params)
+  {
+    params.mScheduleId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "scheduleId");
+
+    params.mCommonTxParams =
+      Hiero::TCK::getOptionalJsonParameter<Hiero::TCK::CommonTransactionParams>(jsonFrom, "commonTransactionParams");
+  }
+};
+
+} // namespace nlohmann
+
+#endif // HIERO_TCK_CPP_DELETE_SCHEDULE_PARAMS_H_

--- a/src/tck/src/TckServer.cc
+++ b/src/tck/src/TckServer.cc
@@ -29,6 +29,8 @@
 #include "file/params/UpdateFileParams.h"
 #include "key/KeyService.h"
 #include "key/params/GenerateKeyParams.h"
+#include "schedule/ScheduleService.h"
+#include "schedule/params/DeleteScheduleParams.h"
 #include "sdk/SdkClient.h"
 #include "sdk/params/ResetParams.h"
 #include "sdk/params/SetupParams.h"
@@ -57,8 +59,6 @@
 #include "topic/params/DeleteTopicParams.h"
 #include "topic/params/GetTopicInfoQueryParams.h"
 #include "topic/params/TopicMessageSubmitParams.h"
-#include "schedule/ScheduleService.h"
-#include "schedule/params/DeleteScheduleParams.h"
 #include "json/JsonUtils.h"
 
 namespace Hiero::TCK

--- a/src/tck/src/TckServer.cc
+++ b/src/tck/src/TckServer.cc
@@ -57,6 +57,8 @@
 #include "topic/params/DeleteTopicParams.h"
 #include "topic/params/GetTopicInfoQueryParams.h"
 #include "topic/params/TopicMessageSubmitParams.h"
+#include "schedule/ScheduleService.h"
+#include "schedule/params/DeleteScheduleParams.h"
 #include "json/JsonUtils.h"
 
 namespace Hiero::TCK
@@ -115,6 +117,9 @@ TckServer::TckServer(int port)
   mJsonRpcParser.addMethod("deleteTopic", getHandle(TopicService::deleteTopic));
   mJsonRpcParser.addMethod("getTopicInfo", getHandle(TopicService::getTopicInfo));
   mJsonRpcParser.addMethod("submitTopicMessage", getHandle(TopicService::submitTopicMessage));
+
+  // Schedule Service
+  mJsonRpcParser.addMethod("deleteSchedule", getHandle(ScheduleService::deleteSchedule));
 
   // Contract Service
   mJsonRpcParser.addMethod("createContract", getHandle(ContractService::createContract));
@@ -275,5 +280,7 @@ template TckServer::MethodHandle TckServer::getHandle<TopicService::GetTopicInfo
   nlohmann::json (*method)(const TopicService::GetTopicInfoQueryParams&));
 template TckServer::MethodHandle TckServer::getHandle<TopicService::TopicMessageSubmitParams>(
   nlohmann::json (*method)(const TopicService::TopicMessageSubmitParams&));
+template TckServer::MethodHandle TckServer::getHandle<ScheduleService::DeleteScheduleParams>(
+  nlohmann::json (*method)(const ScheduleService::DeleteScheduleParams&));
 
 } // namespace Hiero::TCK

--- a/src/tck/src/TckServer.cc
+++ b/src/tck/src/TckServer.cc
@@ -119,9 +119,6 @@ TckServer::TckServer(int port)
   mJsonRpcParser.addMethod("getTopicInfo", getHandle(TopicService::getTopicInfo));
   mJsonRpcParser.addMethod("submitTopicMessage", getHandle(TopicService::submitTopicMessage));
 
-  // Schedule Service
-  mJsonRpcParser.addMethod("deleteSchedule", getHandle(ScheduleService::deleteSchedule));
-
   // Contract Service
   mJsonRpcParser.addMethod("createContract", getHandle(ContractService::createContract));
   mJsonRpcParser.addMethod("contractByteCodeQuery", getHandle(ContractService::contractByteCodeQuery));
@@ -141,6 +138,7 @@ TckServer::TckServer(int port)
 
   // Schedule Service
   mJsonRpcParser.addMethod("createSchedule", getHandle(ScheduleService::createSchedule));
+  mJsonRpcParser.addMethod("deleteSchedule", getHandle(ScheduleService::deleteSchedule));
 
   setupHttpHandler();
   mServer.listen("localhost", port);

--- a/src/tck/src/schedule/ScheduleService.cc
+++ b/src/tck/src/schedule/ScheduleService.cc
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "schedule/ScheduleService.h"
+#include "common/CommonTransactionParams.h"
+#include "schedule/params/DeleteScheduleParams.h"
+#include "sdk/SdkClient.h"
+
+#include <ScheduleDeleteTransaction.h>
+#include <ScheduleId.h>
+#include <TransactionReceipt.h>
+#include <TransactionResponse.h>
+
+#include <nlohmann/json.hpp>
+
+namespace Hiero::TCK::ScheduleService
+{
+//-----
+nlohmann::json deleteSchedule(const DeleteScheduleParams& params)
+{
+  ScheduleDeleteTransaction scheduleDeleteTransaction;
+  scheduleDeleteTransaction.setGrpcDeadline(SdkClient::DEFAULT_TCK_REQUEST_TIMEOUT);
+
+  if (params.mScheduleId.has_value())
+  {
+    scheduleDeleteTransaction.setScheduleId(ScheduleId::fromString(params.mScheduleId.value()));
+  }
+
+  if (params.mCommonTxParams.has_value())
+  {
+    params.mCommonTxParams->fillOutTransaction(scheduleDeleteTransaction, SdkClient::getClient());
+  }
+
+  return {
+    {"status",
+     gStatusToString.at(
+        scheduleDeleteTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient()).mStatus)},
+  };
+}
+
+} // namespace Hiero::TCK::ScheduleService

--- a/src/tck/src/schedule/ScheduleService.cc
+++ b/src/tck/src/schedule/ScheduleService.cc
@@ -693,7 +693,7 @@ nlohmann::json deleteSchedule(const DeleteScheduleParams& params)
   return {
     {"status",
      gStatusToString.at(
-       scheduleDeleteTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient()).mStatus)}
+        scheduleDeleteTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient()).mStatus)}
   };
 }
 

--- a/src/tck/src/schedule/ScheduleService.cc
+++ b/src/tck/src/schedule/ScheduleService.cc
@@ -693,7 +693,7 @@ nlohmann::json deleteSchedule(const DeleteScheduleParams& params)
   return {
     {"status",
      gStatusToString.at(
-        scheduleDeleteTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient()).mStatus)}
+        scheduleDeleteTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient()).mStatus)},
   };
 }
 


### PR DESCRIPTION
**Description**:
Implement the `deleteSchedule` JSON-RPC endpoint on the TCK server by wrapping `ScheduleDeleteTransaction`.
* Add `DeleteScheduleParams` struct with `scheduleId` and `commonTransactionParams` fields
* Add `ScheduleService` header with `deleteSchedule` declaration
* Implement `deleteSchedule` in `ScheduleService` following the established delete endpoint pattern
* Register `deleteSchedule` method in `TckServer`
* Add `ScheduleService.cc` to the TCK build


**Related issue(s)**:
Fixes #1503


**Notes for reviewer**:
New `ScheduleService` files follow the same structure as `TopicService`. The endpoint accepts `scheduleId` (required) and `commonTransactionParams` (optional), returns `{ "status": "SUCCESS" }`.