### PR TITLE
fix: resolve network update thread deadlock by releasing mutex before…

### DIFF
--- a/src/sdk/main/src/Client.cc
+++ b/src/sdk/main/src/Client.cc
@@ -588,8 +588,12 @@ std::optional<std::function<std::vector<std::byte>(const std::vector<std::byte>&
 
 void Client::close()
 {
-  std::unique_lock lock(mImpl->mMutex);
+  // Cancel the network update thread first WITHOUT holding the mutex.
+  // cancelScheduledNetworkUpdate() calls join() on the background thread,
+  // and that thread needs mMutex — holding the mutex here would deadlock.
   cancelScheduledNetworkUpdate();
+
+  std::unique_lock lock(mImpl->mMutex);
 
   std::for_each(mImpl->mSubscriptions.begin(),
                 mImpl->mSubscriptions.end(),
@@ -771,10 +775,12 @@ Logger Client::getLogger() const
 //-----
 Client& Client::setNetworkUpdatePeriod(const std::chrono::system_clock::duration& update)
 {
-  std::unique_lock lock(mImpl->mMutex);
-
-  // Cancel any previous network updates and wait for the thread to complete.
+  // Cancel any previous network updates WITHOUT holding the mutex.
+  // cancelScheduledNetworkUpdate() calls join() on the background thread,
+  // and that thread needs mMutex — holding the mutex here would deadlock.
   cancelScheduledNetworkUpdate();
+
+  std::unique_lock lock(mImpl->mMutex);
 
   // Update the network update period.
   mImpl->mNetworkUpdatePeriod = update;
@@ -1144,8 +1150,7 @@ void Client::startNetworkUpdateThread(const std::chrono::system_clock::duration&
 {
   mImpl->mStartNetworkUpdateWaitTime = std::chrono::system_clock::now();
   mImpl->mNetworkUpdatePeriod = period;
-  // mImpl->mNetworkUpdateThread =
-  // std::make_unique<std::thread>(&Client::scheduleNetworkUpdate, this);
+  mImpl->mNetworkUpdateThread = std::make_unique<std::thread>(&Client::scheduleNetworkUpdate, this);
 }
 
 //-----
@@ -1154,33 +1159,67 @@ void Client::scheduleNetworkUpdate()
   // Network updates should keep occurring until they're cancelled.
   while (true)
   {
-    if (std::unique_lock lock(mImpl->mMutex); !mImpl->mConditionVariable.wait_for(
-          lock, mImpl->mNetworkUpdatePeriod, [this]() { return mImpl->mCancelUpdate; }))
+    // Wait for the update period while holding the lock (condition_variable
+    // requires the lock). If the wait was NOT cancelled (returns false), we
+    // need to perform a network update.
+    bool shouldUpdate = false;
     {
-      try
-      {
-        // Get the address book and set the network based on the address book.
-        setNetworkFromAddressBookInternal(AddressBookQuery().setFileId(FileId::ADDRESS_BOOK).execute(*this));
+      std::unique_lock lock(mImpl->mMutex);
+      shouldUpdate = !mImpl->mConditionVariable.wait_for(
+        lock, mImpl->mNetworkUpdatePeriod, [this]() { return mImpl->mCancelUpdate; });
+    }
+    // Lock is released here.
 
-        // Adjust the network update period if this is the initial update.
-        if (!mImpl->mMadeInitialNetworkUpdate)
-        {
-          mImpl->mNetworkUpdatePeriod = DEFAULT_NETWORK_UPDATE_PERIOD;
-          mImpl->mMadeInitialNetworkUpdate = true;
-        }
+    if (!shouldUpdate)
+    {
+      // The network update was cancelled, stop looping.
+      break;
+    }
 
-        // Schedule the next network update.
-        mImpl->mStartNetworkUpdateWaitTime = std::chrono::system_clock::now();
-      }
-      catch (const std::exception& exception)
+    // Skip the update if no mirror network or consensus network is configured.
+    // AddressBookQuery requires a mirror network endpoint, and
+    // setNetworkFromAddressBookInternal requires a consensus network.
+    // Calling execute() without a mirror network would dereference a nullptr.
+    if (!getClientMirrorNetwork() || !getClientNetwork())
+    {
+      continue;
+    }
+
+    try
+    {
+      // Execute the address book query WITHOUT holding mMutex.
+      // AddressBookQuery::execute() calls back into Client getters
+      // (getRequestTimeout, getClientMirrorNetwork, etc.) which all
+      // acquire mMutex. Holding mMutex here would cause a self-deadlock
+      // on the same thread since std::mutex is non-recursive.
+      const NodeAddressBook addressBook = AddressBookQuery().setFileId(FileId::ADDRESS_BOOK).execute(*this);
+
+      // Re-acquire the lock to update internal state.
+      std::unique_lock lock(mImpl->mMutex);
+
+      // Check if we were cancelled while the query was executing.
+      if (mImpl->mCancelUpdate)
       {
-        mImpl->mLogger.warn(std::string("Failed to update address book via mirror node query ") + exception.what());
         break;
       }
+
+      // Update the network from the fetched address book.
+      setNetworkFromAddressBookInternal(addressBook);
+
+      // Adjust the network update period if this is the initial update.
+      if (!mImpl->mMadeInitialNetworkUpdate)
+      {
+        mImpl->mNetworkUpdatePeriod = DEFAULT_NETWORK_UPDATE_PERIOD;
+        mImpl->mMadeInitialNetworkUpdate = true;
+      }
+
+      // Schedule the next network update.
+      mImpl->mStartNetworkUpdateWaitTime = std::chrono::system_clock::now();
     }
-    // The network update was cancelled, stop looping.
-    else
+    catch (const std::exception& exception)
     {
+      std::unique_lock lock(mImpl->mMutex);
+      mImpl->mLogger.warn(std::string("Failed to update address book via mirror node query ") + exception.what());
       break;
     }
   }
@@ -1195,9 +1234,17 @@ void Client::cancelScheduledNetworkUpdate()
     return;
   }
 
-  // Signal the thread to stop and wait for it to stop (if it was running).
-  mImpl->mCancelUpdate = true;
-  mImpl->mConditionVariable.notify_all();
+  // Signal the thread to stop. Must hold the mutex when modifying
+  // mCancelUpdate and notifying, since the background thread checks
+  // the flag under the same mutex in its condition_variable predicate.
+  {
+    std::unique_lock lock(mImpl->mMutex);
+    mImpl->mCancelUpdate = true;
+    mImpl->mConditionVariable.notify_all();
+  }
+  // Lock released before join() — the background thread needs mMutex
+  // to complete its current wait_for or to re-acquire after query execution.
+
   if (mImpl->mNetworkUpdateThread->joinable())
   {
     mImpl->mNetworkUpdateThread->join();
@@ -1215,6 +1262,8 @@ void Client::cancelScheduledNetworkUpdate()
 void Client::moveClient(Client&& other)
 {
   // Cancel this Client's network update if one exists.
+  // This is called without holding mMutex, which is correct since
+  // cancelScheduledNetworkUpdate() calls join() on the background thread.
   cancelScheduledNetworkUpdate();
 
   // If there's a network update thread running in the moved-from Client, it

--- a/src/sdk/main/src/Client.cc
+++ b/src/sdk/main/src/Client.cc
@@ -1159,9 +1159,9 @@ void Client::scheduleNetworkUpdate()
   // Network updates should keep occurring until they're cancelled.
   while (true)
   {
-    // Wait for the update period while holding the lock (condition_variable
-    // requires the lock). If the wait was NOT cancelled (returns false), we
-    // need to perform a network update.
+    // wait_for returns true  if the predicate fired (cancelled) --> should NOT update
+    // wait_for returns false if the timeout expired             --> should update
+    // Negate so that shouldUpdate == true means "run the update".
     bool shouldUpdate = false;
     {
       std::unique_lock lock(mImpl->mMutex);

--- a/src/sdk/tests/unit/ClientUnitTests.cc
+++ b/src/sdk/tests/unit/ClientUnitTests.cc
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include <thread>
+
 using namespace Hiero;
 
 class ClientUnitTests : public ::testing::Test
@@ -254,4 +256,106 @@ TEST_F(ClientUnitTests, SetAllowReceiptNodeFailover)
 
   client.setAllowReceiptNodeFailover(false);
   EXPECT_FALSE(client.getAllowReceiptNodeFailover());
+}
+
+//-----
+// Regression tests for Issue #931: Network update thread deadlock.
+// The network update thread calls back into Client getters (getRequestTimeout,
+// getClientMirrorNetwork, etc.) which all acquire mMutex. If the thread held
+// mMutex during the query, it would self-deadlock. These tests verify that
+// Client lifecycle operations complete without hanging.
+
+TEST_F(ClientUnitTests, NetworkUpdateThreadDoesNotDeadlockOnDestruction)
+{
+  // Given / When
+  // Creating and immediately destroying a Client exercises the full lifecycle:
+  // constructor starts the bg thread, destructor cancels and joins it.
+  // This test will hang/timeout if the deadlock is present.
+  {
+    Client client;
+    // Give the thread a moment to start and enter its wait state.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  // If we get here, no deadlock occurred.
+
+  // Then
+  SUCCEED();
+}
+
+//-----
+TEST_F(ClientUnitTests, NetworkUpdateThreadDoesNotDeadlockWithConcurrentGetters)
+{
+  // Given
+  Client client;
+  client.setOperator(getTestAccountId(), getTestPrivateKey());
+
+  // When — call multiple getters concurrently while the bg thread is alive.
+  // These getters all acquire mMutex. If the bg thread holds mMutex during its
+  // query, this would deadlock or contend indefinitely.
+  for (int i = 0; i < 10; ++i)
+  {
+    EXPECT_NO_THROW(client.getRequestTimeout());
+    EXPECT_NO_THROW(client.getOperatorAccountId());
+    EXPECT_NO_THROW(client.getNetworkUpdatePeriod());
+    EXPECT_NO_THROW(client.getMaxTransactionFee());
+    EXPECT_NO_THROW(client.getMaxQueryPayment());
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // Then — destruction also must not deadlock.
+  SUCCEED();
+}
+
+//-----
+TEST_F(ClientUnitTests, NetworkUpdateThreadDoesNotDeadlockOnSetNetworkUpdatePeriod)
+{
+  // Given
+  Client client;
+
+  // When — setNetworkUpdatePeriod cancels the old thread and starts a new one.
+  // This exercises cancel + join + restart while the bg thread may be waiting.
+  EXPECT_NO_THROW(client.setNetworkUpdatePeriod(std::chrono::seconds(30)));
+  EXPECT_EQ(client.getNetworkUpdatePeriod(), std::chrono::seconds(30));
+
+  // When — do it again to exercise the cycle a second time.
+  EXPECT_NO_THROW(client.setNetworkUpdatePeriod(std::chrono::seconds(60)));
+  EXPECT_EQ(client.getNetworkUpdatePeriod(), std::chrono::seconds(60));
+
+  // Then
+  SUCCEED();
+}
+
+//-----
+TEST_F(ClientUnitTests, NetworkUpdateThreadDoesNotDeadlockOnMove)
+{
+  // Given
+  Client client;
+  client.setOperator(getTestAccountId(), getTestPrivateKey());
+
+  // Give the thread a moment to start.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  // When — moving a Client cancels the bg thread on the source and restarts
+  // it on the destination.
+  Client client2 = std::move(client);
+
+  // Then — the moved-to client should be functional and destroyable.
+  EXPECT_EQ(*client2.getOperatorAccountId(), getTestAccountId());
+  SUCCEED();
+}
+
+//-----
+TEST_F(ClientUnitTests, NetworkUpdateThreadDoesNotDeadlockOnClose)
+{
+  // Given
+  Client client;
+
+  // Give the thread a moment to start.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  // When — close() cancels the bg thread and joins it.
+  EXPECT_NO_THROW(client.close());
+
+  // Then — if we reach here without hanging, no deadlock occurred.
+  SUCCEED();
 }

--- a/src/sdk/tests/unit/ClientUnitTests.cc
+++ b/src/sdk/tests/unit/ClientUnitTests.cc
@@ -359,3 +359,21 @@ TEST_F(ClientUnitTests, NetworkUpdateThreadDoesNotDeadlockOnClose)
   // Then — if we reach here without hanging, no deadlock occurred.
   SUCCEED();
 }
+
+//-----
+TEST_F(ClientUnitTests, NetworkUpdateThreadSkipsUpdateWhenNoNetworkConfigured)
+{
+  // Given — a Client with no mirror/consensus network and a very short update
+  // period. This forces the bg thread past wait_for and into the body of
+  // scheduleNetworkUpdate(), exercising the null-network continue guard.
+  Client client;
+  client.setNetworkUpdatePeriod(std::chrono::milliseconds(50));
+
+  // When — let several update cycles fire.
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+  // Then — the update period is preserved and the mutex is not stuck.
+  // getNetworkUpdatePeriod() acquires mMutex, so it would hang if the bg
+  // thread were holding the lock.
+  EXPECT_EQ(client.getNetworkUpdatePeriod(), std::chrono::milliseconds(50));
+}


### PR DESCRIPTION
**Description**:

Fix network update thread deadlock by releasing mutex before query execution

* Release `mMutex` before calling `AddressBookQuery::execute()` in `scheduleNetworkUpdate()` to prevent self-deadlock on the same thread (non-recursive mutex)
* Fix secondary deadlock in `close()` and `setNetworkUpdatePeriod()` - call `cancelScheduledNetworkUpdate()` before acquiring `mMutex`, since `join()` waits for the bg thread which needs the same mutex
* Make `cancelScheduledNetworkUpdate()` hold `mMutex` briefly when setting `mCancelUpdate` and notifying, then release before `join()`
* Add null-safety guard for mirror/consensus network in the update loop to prevent nullptr dereference
* Re-enable the network update thread in `startNetworkUpdateThread()`
* Add 5 regression tests covering destruction, concurrent getters, period change, move, and close

Fixes #931

**Notes for reviewer**:

The root cause was a self-deadlock: `scheduleNetworkUpdate()` held `mImpl->mMutex` and called `AddressBookQuery::execute(*this)`, which calls `client.getRequestTimeout()` (and many other getters) - all of which try to re-lock the same non-recursive `std::mutex` on the same thread.

The fix follows the same pattern already used in `updateAddressBook()` (line 703): execute the query without the lock, then re-acquire to update state. A cancellation check after re-acquiring handles the race where someone calls `close()` during the query window.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)