### PR TITLE
Fix: Update OpenSSL version constraint to 3.4.1 in vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,7 @@
   "dependencies": [
     {
       "name": "openssl",
-      "version>=": "3.2.0#2"
+      "version>=": "3.4.1"
     },
     {
       "name": "pthreads",


### PR DESCRIPTION
## Description
Updates the `openssl` version constraint in `vcpkg.json` to the current stable release (`3.4.1`), addressing security patches issued since 3.2.0. As the OpenSSL 3.x API is backwards-compatible across minor versions, this is a single version update in `vcpkg.json`.

## Related Issue
Fixes #1532

## Motivation and Context
OpenSSL 3.4.x is the current stable release. This update ensures the SDK uses the latest security patches.

## How Has This Been Tested?
- Updated `vcpkg.json`
- Ran CMake configuration to ensure dependencies are resolved
- (Tests validation required as per CI/CD)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All commits are signed (`-s -S`).
