### PR TITLE
Fix: Update log4cxx GIT_TAG to rel/v1.7.0

### DIFF
--- a/src/sdk/main/CMakeLists.txt
+++ b/src/sdk/main/CMakeLists.txt
@@ -1,7 +1,7 @@
 FetchContent_Declare(
         log4cxx
         GIT_REPOSITORY https://github.com/apache/logging-log4cxx.git
-        GIT_TAG rel/v1.1.0
+        GIT_TAG rel/v1.7.0
 )
 
 set(BUILD_SHARED_LIBS OFF)


### PR DESCRIPTION
## Description
Updates the `log4cxx` GIT_TAG in `src/sdk/main/CMakeLists.txt` from `rel/v1.1.0` to the latest stable release tag `rel/v1.7.0`.

## Related Issue
Fixes #1530

## Motivation and Context
The current log4cxx release tag used in `FetchContent` is outdated. Newer stable releases have been published, and updating ensures the SDK uses the latest stable version of the library. Since the logging API used is stable across minor versions, no code changes were necessary.

## How Has This Been Tested?
- Updated `GIT_TAG` to `rel/v1.7.0` in `src/sdk/main/CMakeLists.txt`
- Assessed that `log4cxx` APIs like `LOG4CXX_INFO`, `LOG4CXX_ERROR` are compatible

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All commits are signed (`-s -S`).
