### PR TITLE
fix: broken actions/download-artifact SHA for On PR Review (Labels)

### DIFF
--- a/.github/workflows/on-pr-review-labels.yaml
+++ b/.github/workflows/on-pr-review-labels.yaml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Download artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: review-event-${{ github.event.workflow_run.id }}
 

--- a/.github/workflows/on-pr-review-labels.yaml
+++ b/.github/workflows/on-pr-review-labels.yaml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Download artifact
-        uses: actions/download-artifact@3f3d89d98d4b1c8b2cdd5e17739fb8bcbac2b0c7 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: review-event-${{ github.event.workflow_run.id }}
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
Fix the Bot - On PR Review (Labels) workflow failing during job setup because actions/download-artifact is pinned to a SHA that no longer resolves.

Update actions/download-artifact to the current resolvable v4 commit SHA
Preserve the existing SHA-pinning style used by the workflow
Keep the workflow behavior unchanged
**Related issue(s)**:

Fixes #1538

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Verified the old SHA does not resolve from `actions/download-artifact`:
`git ls-remote https://github.com/actions/download-artifact.git 3f3d89d98d4b1c8b2cdd5e17739fb8bcbac2b0c7`

Verified the replacement SHA resolves to `v4 / v4.3.0`:
`git ls-remote https://github.com/actions/download-artifact.git refs/tags/v4`

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
