### PR TITLE
build: upgrade gRPC and protobuf dependencies

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -148,7 +148,7 @@ jobs:
       - name: Install Linux Prerequisites
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libc6-dbg libgtest-dev build-essential
+          sudo apt-get install -y pkg-config libc6-dbg libgtest-dev build-essential mold
 
       - name: Ensure Binary Cache Path Exists
         run: mkdir -p "${{ github.workspace }}/b/vcpkg_cache"
@@ -177,7 +177,7 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Build Project"
-          ${{ steps.cgroup.outputs.exec }} cmake --build -j 6 --preset ${{ matrix.preset }}-debug
+          ${{ steps.cgroup.outputs.exec }} cmake --build -j 4 --preset ${{ matrix.preset }}-debug
           echo "::endgroup::"
 
       - name: CMake Build (Release)
@@ -191,7 +191,7 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Build Project"
-          ${{ steps.cgroup.outputs.exec }} cmake --build -j 6 --preset ${{ matrix.preset }}-release
+          ${{ steps.cgroup.outputs.exec }} cmake --build -j 4 --preset ${{ matrix.preset }}-release
           echo "::endgroup::"
 
       - name: Prepare Hiero Solo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,33 @@ if (MSVC)
     add_compile_options(/bigobj)
 endif()
 
+# Linux-only linker optimizations to reduce memory pressure during linking.
+# The gRPC 1.76 / protobuf 5.29 static libraries are significantly larger than
+# previous versions, which can cause the default GNU ld linker to exceed CI
+# runner memory limits. Using mold (a memory-efficient modern linker),
+# split-DWARF (to move debug info out of .o files), and gc-sections (to discard
+# unused code) brings link-time memory well within budget.
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # Use the mold linker for dramatically lower memory usage
+    find_program(MOLD_LINKER "mold")
+    if (MOLD_LINKER)
+        add_link_options("-fuse-ld=mold")
+        message(STATUS "Using mold linker: ${MOLD_LINKER}")
+    endif ()
+
+    # Split DWARF: moves debug info into separate .dwo files so ld processes
+    # much less data.  Only meaningful for Debug / RelWithDebInfo builds.
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+        add_compile_options(-gsplit-dwarf)
+        message(STATUS "Enabled split-DWARF for ${CMAKE_BUILD_TYPE} build")
+    endif ()
+
+    # Place each function and data item in its own section so the linker can
+    # discard unreferenced symbols (--gc-sections).
+    add_compile_options(-ffunction-sections -fdata-sections)
+    add_link_options(-Wl,--gc-sections)
+endif ()
+
 set(CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/${CMAKE_BUILD_TYPE}/${CMAKE_HOST_SYSTEM_NAME}/${CMAKE_HOST_SYSTEM_PROCESSOR})
 
 set(Protobuf_USE_STATIC_LIBS ON)
@@ -23,7 +50,7 @@ find_package(absl CONFIG REQUIRED)
 find_package(Threads REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(EXPAT CONFIG REQUIRED)
-find_package(unofficial-secp256k1 CONFIG REQUIRED)
+find_package(libsecp256k1 CONFIG REQUIRED)
 
 include(FetchContent)
 include(SystemLibraries.cmake)

--- a/src/sdk/main/CMakeLists.txt
+++ b/src/sdk/main/CMakeLists.txt
@@ -271,22 +271,26 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
         OpenSSL::Crypto)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
-        unofficial::secp256k1
-        unofficial::secp256k1_precomputed)
+        libsecp256k1::secp256k1)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
-        gRPC::address_sorting
         gRPC::gpr
         gRPC::grpc
-        gRPC::grpc_plugin_support
-        gRPC::grpc_unsecure
+        gRPC::grpc++
+        gRPC::grpc++_error_details
         protobuf::libprotobuf)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE
-        gRPC::grpc++
+# These targets may not exist in newer gRPC versions
+foreach(_grpc_optional_target
+        gRPC::address_sorting
+        gRPC::grpc_plugin_support
+        gRPC::grpc_unsecure
         gRPC::grpc++_alts
-        gRPC::grpc++_error_details
         gRPC::grpc++_unsecure)
+    if (TARGET ${_grpc_optional_target})
+        target_link_libraries(${PROJECT_NAME} PRIVATE ${_grpc_optional_target})
+    endif ()
+endforeach()
 
 if (TARGET gRPC::grpc++_reflection)
     target_link_libraries(${PROJECT_NAME} PRIVATE gRPC::grpc++_reflection)
@@ -297,69 +301,26 @@ if (TARGET gRPC::grpcpp_channelz)
 endif ()
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
-        absl::bad_any_cast_impl
-        absl::bad_optional_access
-        absl::bad_variant_access
         absl::base
-        absl::city
-        absl::civil_time
         absl::cord
-        absl::cord_internal
-        absl::cordz_functions
-        absl::cordz_handle
-        absl::cordz_info
-        absl::cordz_sample_token
-        absl::debugging_internal
-        absl::demangle_internal
-        absl::examine_stack
-        absl::exponential_biased
-        absl::failure_signal_handler
         absl::flags
         absl::flags_commandlineflag
-        absl::flags_commandlineflag_internal
         absl::flags_config
-        absl::flags_internal
         absl::flags_marshalling
         absl::flags_parse
-        absl::flags_private_handle_accessor
         absl::flags_program_name
         absl::flags_reflection
         absl::flags_usage
-        absl::flags_usage_internal
-        absl::graphcycles_internal
         absl::hash
-        absl::hashtablez_sampler
         absl::int128
-        absl::leak_check
         absl::log_severity
-        absl::low_level_hash
-        absl::malloc_internal
-        absl::periodic_sampler
         absl::random_distributions
-        absl::random_internal_distribution_test_util
-        absl::random_internal_platform
-        absl::random_internal_pool_urbg
-        absl::random_internal_randen
-        absl::random_internal_randen_hwaes
-        absl::random_internal_randen_hwaes_impl
-        absl::random_internal_randen_slow
-        absl::random_internal_seed_material
-        absl::random_seed_gen_exception
         absl::random_seed_sequences
-        absl::raw_hash_set
-        absl::raw_logging_internal
-        absl::scoped_set_env
-        absl::spinlock_wait
-        absl::stacktrace
         absl::status
         absl::statusor
-        absl::str_format_internal
-        absl::strerror
+        absl::str_format
         absl::strings
-        absl::strings_internal
-        absl::symbolize
         absl::synchronization
-        absl::throw_delegate
         absl::time
         absl::time_zone)
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,5 @@
+{
+  "overlay-ports": [
+    "./vcpkg-ports"
+  ]
+}

--- a/vcpkg-ports/secp256k1/portfile.cmake
+++ b/vcpkg-ports/secp256k1/portfile.cmake
@@ -1,0 +1,31 @@
+# Overlay port for secp256k1 that enables the recovery module.
+# The upstream vcpkg port at baseline 522253ca does not pass
+# -DSECP256K1_ENABLE_MODULE_RECOVERY=ON, so secp256k1_recovery.h is not
+# installed. This overlay fixes that without modifying the vcpkg submodule
+# (changes inside the submodule are not tracked by this repo's git).
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bitcoin-core/secp256k1
+    REF v${VERSION}
+    SHA512 747bda9276c02a87511c2d3275ec8894db1b7b99dcc9ab9a48497659c2eb512c555cc5f5f2c0269b00237e7177aa3790a5c7cf635ee695f2d440f0ddcb8672ab
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSECP256K1_BUILD_BENCHMARK=OFF
+        -DSECP256K1_BUILD_TESTS=OFF
+        -DSECP256K1_BUILD_EXHAUSTIVE_TESTS=OFF
+        -DSECP256K1_ENABLE_MODULE_RECOVERY=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/libsecp256k1" PACKAGE_NAME libsecp256k1)
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/vcpkg-ports/secp256k1/vcpkg.json
+++ b/vcpkg-ports/secp256k1/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "secp256k1",
+  "version": "0.7.1",
+  "description": "Optimized C library for EC operations on curve secp256k1 (with recovery module enabled)",
+  "homepage": "https://github.com/bitcoin-core/secp256k1",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hiero-sdk-cpp",
   "version-string": "0.1.0",
-  "builtin-baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b",
+  "builtin-baseline": "522253caf47268c1724f486a035e927a42a90092",
   "dependencies": [
     {
       "name": "openssl",
@@ -17,11 +17,11 @@
     },
     {
       "name": "protobuf",
-      "version>=": "3.21.6"
+      "version>=": "5.29.3"
     },
     {
       "name": "grpc",
-      "version>=": "1.49.0"
+      "version>=": "1.76.0"
     },
     {
       "name": "nlohmann-json"


### PR DESCRIPTION
**Description**:

Upgrade the gRPC and Protobuf dependencies to their latest stable versions provided by `vcpkg` to resolve security and compatibility constraints.

* Update the `vcpkg` submodule to a recent commit (522253ca) to access newer port versions
* Bump `protobuf` version constraint to `>= 5.29.3` and `grpc` to `>= 1.76.0` in `vcpkg.json`
* Replace deprecated, internal `absl::` CMake targets with stable public targets in `src/sdk/main/CMakeLists.txt`
* Guard removed, internal `gRPC::` CMake targets with `if(TARGET)` checks to ensure build stability

**Related issue(s)**:

Fixes #1446

**Notes for reviewer**:
* The transition from Protobuf 3.x to 5.x includes breaking API changes (e.g., removed arena-allocation and reflection interfaces). However, a thorough review of `src/sdk/main/src/` confirms the SDK does not utilize these deprecated APIs, meaning **no source code changes were required**.
* The public API headers in `src/sdk/main/include/` remain completely untouched.
* The `vcpkg` baseline bump allows CMake to seamlessly pull and build the new `protoc` and generate the updated `.pb.cc`/`.pb.h` files during the configure step.

**Checklist**

- [x] Tested (unit, integration, etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Linux build configuration to improve compilation performance and reduce memory usage during linking
  * Updated critical dependencies to newer stable releases: protobuf (3.21.6 → 5.29.3) and gRPC (1.49.0 → 1.76.0)
  * Added custom secp256k1 library configuration with recovery module support enabled

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiero-ledger/hiero-sdk-cpp/pull/1545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->