### PR TITLE
Fix: Near-miss command detection ignores non-whitespace separators

### DIFF
--- a/.github/scripts/bot-on-comment.js
+++ b/.github/scripts/bot-on-comment.js
@@ -46,7 +46,7 @@ function parseComment(body) {
     }
 
     // near miss
-    if (new RegExp(`^/${command}\\s+`, 'i').test(trimmed)) {
+    if (new RegExp(`^/${command}\\b`, 'i').test(trimmed)) {
       logger.log(`parseComment: near miss /${command}`);
       return { nearMiss: command };
     }

--- a/.github/scripts/tests/test-on-comment-bot.js
+++ b/.github/scripts/tests/test-on-comment-bot.js
@@ -38,6 +38,10 @@ const unitTests = [
     test: () => deepEqual(parseComment('/finalize now'), { nearMiss: 'finalize' }),
   },
   {
+    name: 'near miss assign non-whitespace separator',
+    test: () => deepEqual(parseComment('/assign!'), { nearMiss: 'assign' }),
+  },
+  {
     name: 'unrelated comment',
     test: () => deepEqual(parseComment('hello'), { commands: [] }),
   },


### PR DESCRIPTION
Fix: Near-miss regex fails to detect non-whitespace separators
Fixes #1537 

Description
The near-miss command detection in bot-on-comment.js used \s+ in its regex, which only matched commands followed by whitespace. Malformed inputs like /assign!, /assign,oops, or /assign.work — where the command is followed by a non-space character — silently passed through without triggering the correction message.

This PR replaces \s+ with the \b (word boundary) assertion, which matches at any position where a word character is adjacent to a non-word character. This catches all malformed command variants, not just whitespace-separated ones.
<img width="770" height="170" alt="Screenshot 2026-05-04 at 7 26 58 PM" src="https://github.com/user-attachments/assets/4de7971e-e2df-4680-ad23-e604c6b3fbc9" />
