### PR TITLE
chore: update mirror node version to v0.153.1

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -200,7 +200,7 @@ jobs:
         with:
           soloVersion: v0.69.0
           installMirrorNode: true
-          mirrorNodeVersion: v0.151.0
+          mirrorNodeVersion: v0.153.1
           hieroVersion: v0.73.0
           dualMode: true
 


### PR DESCRIPTION
Description:
This PR updates the Hiero mirror node version in the CI build workflow to ensure integration tests are running against the latest environment.

Update mirrorNodeVersion to `v0.153.1` in `zxc-build-library.yaml`

Related issue(s):

Fixes #1519 

Notes for reviewer:
This is a straightforward version bump in the reusable workflow file. No changes were made to the C++ SDK source code or architecture. Verified that v0.151.0 no longer appears in the workflow file.

Checklist

[x] Documented (N/A - CI configuration change)

[x] Tested (Verified via CI integration tests)