### PR TITLE
feat: add operator== for ContractLogInfo

### DIFF
--- a/src/sdk/main/include/ContractLogInfo.h
+++ b/src/sdk/main/include/ContractLogInfo.h
@@ -71,6 +71,14 @@ public:
   friend std::ostream& operator<<(std::ostream& os, const ContractLogInfo& logInfo);
 
   /**
+   * Compare this ContractLogInfo to another ContractLogInfo and determine if they represent the same log event.
+   *
+   * @param other The other ContractLogInfo with which to compare this ContractLogInfo.
+   * @return \c TRUE if this ContractLogInfo is the same as the input ContractLogInfo, otherwise \c FALSE.
+   */
+  [[nodiscard]] bool operator==(const ContractLogInfo& other) const;
+
+  /**
    * The ID of the contract that emitted this log event.
    */
   ContractId mContractId;

--- a/src/sdk/main/src/ContractLogInfo.cc
+++ b/src/sdk/main/src/ContractLogInfo.cc
@@ -69,6 +69,13 @@ std::string ContractLogInfo::toString() const
 }
 
 //-----
+bool ContractLogInfo::operator==(const ContractLogInfo& other) const
+{
+  return (mContractId == other.mContractId) && (mBloom == other.mBloom) && (mTopics == other.mTopics) &&
+         (mData == other.mData);
+}
+
+//-----
 std::ostream& operator<<(std::ostream& os, const ContractLogInfo& logInfo)
 {
   os << logInfo.toString();

--- a/src/sdk/tests/unit/ContractLogInfoUnitTests.cc
+++ b/src/sdk/tests/unit/ContractLogInfoUnitTests.cc
@@ -98,3 +98,90 @@ TEST_F(ContractLogInfoUnitTests, ToProtobuf)
 
   EXPECT_EQ(protoContractLogInfo->data(), internal::Utilities::byteVectorToString(getTestData()));
 }
+
+//-----
+TEST_F(ContractLogInfoUnitTests, EqualityDefaultConstructed)
+{
+  // Given
+  const ContractLogInfo lhs;
+  const ContractLogInfo rhs;
+
+  // Then
+  EXPECT_TRUE(lhs == rhs);
+}
+
+//-----
+TEST_F(ContractLogInfoUnitTests, EqualityIdenticallyConstructed)
+{
+  // Given
+  ContractLogInfo lhs;
+  lhs.mContractId = getTestContractId();
+  lhs.mBloom = getTestBloom();
+  lhs.mTopics = getTestTopics();
+  lhs.mData = getTestData();
+
+  ContractLogInfo rhs;
+  rhs.mContractId = getTestContractId();
+  rhs.mBloom = getTestBloom();
+  rhs.mTopics = getTestTopics();
+  rhs.mData = getTestData();
+
+  // Then
+  EXPECT_TRUE(lhs == rhs);
+}
+
+//-----
+TEST_F(ContractLogInfoUnitTests, InequalityDifferentContractId)
+{
+  // Given
+  ContractLogInfo lhs;
+  lhs.mContractId = getTestContractId();
+
+  ContractLogInfo rhs;
+  rhs.mContractId = ContractId(99ULL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(ContractLogInfoUnitTests, InequalityDifferentBloom)
+{
+  // Given
+  ContractLogInfo lhs;
+  lhs.mBloom = getTestBloom();
+
+  ContractLogInfo rhs;
+  rhs.mBloom = { std::byte(0xFF) };
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(ContractLogInfoUnitTests, InequalityDifferentTopics)
+{
+  // Given
+  ContractLogInfo lhs;
+  lhs.mTopics = getTestTopics();
+
+  ContractLogInfo rhs;
+  rhs.mTopics = { { std::byte(0xFF) } };
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(ContractLogInfoUnitTests, InequalityDifferentData)
+{
+  // Given
+  ContractLogInfo lhs;
+  lhs.mData = getTestData();
+
+  ContractLogInfo rhs;
+  rhs.mData = { std::byte(0xFF) };
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}


### PR DESCRIPTION
## Description

Closes #1428

Adds `operator==` to `ContractLogInfo`, comparing all four member fields: `mContractId`, `mBloom`, `mTopics`, `mData`.

## Changes

- **`ContractLogInfo.h`** — Added `[[nodiscard]] bool operator==(const ContractLogInfo& other) const` declaration
- **`ContractLogInfo.cc`** — Implemented `operator==` comparing all four member fields
- **`ContractLogInfoUnitTests.cc`** — Added 6 equality tests:
  - Two default-constructed instances are equal
  - Two identically-constructed instances are equal
  - Instances differing in `mContractId` are not equal
  - Instances differing in `mBloom` are not equal
  - Instances differing in `mTopics` are not equal
  - Instances differing in `mData` are not equal

## Note

The issue suggests declaring `operator==` as a `[[nodiscard]] friend` function, but I implemented it as a **member function** instead — matching the `PendingAirdropId` reference implementation exactly (`PendingAirdropId.h:81`, `PendingAirdropId.cc:62`).

This also avoids a known Clang compilation error where `[[nodiscard]]` on a `friend` free function declaration produces `error: an attribute list cannot appear here` (currently affecting `AccountInfo.h`, `ContractFunctionResult.h`, and `TokenNftTransfer.h` on `main`).

## References

- Reference implementation: [`PendingAirdropId.h:81`](https://github.com/hiero-ledger/hiero-sdk-cpp/blob/main/src/sdk/main/include/PendingAirdropId.h#L81), [`PendingAirdropId.cc:62`](https://github.com/hiero-ledger/hiero-sdk-cpp/blob/main/src/sdk/main/src/PendingAirdropId.cc#L62)
- Related PR with the `friend` + `[[nodiscard]]` build issue: [#1488](https://github.com/hiero-ledger/hiero-sdk-cpp/pull/1488)