### PR TITLE
feat: add operator== to NetworkVersionInfo

### DIFF
--- a/src/sdk/main/include/NetworkVersionInfo.h
+++ b/src/sdk/main/include/NetworkVersionInfo.h
@@ -34,6 +34,14 @@ public:
   NetworkVersionInfo(const SemanticVersion& hapi, const SemanticVersion& hiero);
 
   /**
+   * Compare this NetworkVersionInfo to another and determine if they are equal.
+   *
+   * @param rhs The other NetworkVersionInfo with which to compare this NetworkVersionInfo.
+   * @return \c TRUE if this NetworkVersionInfo is the same as the input, otherwise \c FALSE.
+   */
+  [[nodiscard]] bool operator==(const NetworkVersionInfo& rhs) const;
+
+  /**
    * Construct a NetworkVersionInfo object from a NetworkGetVersionInfoResponse protobuf object.
    *
    * @param proto The NetworkGetVersionInfoResponse protobuf object from which to construct a NetworkVersionInfo object.

--- a/src/sdk/main/src/NetworkVersionInfo.cc
+++ b/src/sdk/main/src/NetworkVersionInfo.cc
@@ -40,6 +40,12 @@ std::unique_ptr<proto::NetworkGetVersionInfoResponse> NetworkVersionInfo::toProt
 }
 
 //-----
+bool NetworkVersionInfo::operator==(const NetworkVersionInfo& rhs) const
+{
+  return mProtobufVersion == rhs.mProtobufVersion && mServicesVersion == rhs.mServicesVersion;
+}
+
+//-----
 std::vector<std::byte> NetworkVersionInfo::toBytes() const
 {
   return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());

--- a/src/sdk/tests/unit/NetworkVersionInfoUnitTests.cc
+++ b/src/sdk/tests/unit/NetworkVersionInfoUnitTests.cc
@@ -113,3 +113,33 @@ TEST_F(NetworkVersionInfoUnitTests, ToString)
   EXPECT_NE(result.find(getTestHapiVersion().toString()), std::string::npos);
   EXPECT_NE(result.find(getTestServicesVersion().toString()), std::string::npos);
 }
+
+//-----
+TEST_F(NetworkVersionInfoUnitTests, EqualityDefaultConstructed)
+{
+  EXPECT_TRUE(NetworkVersionInfo() == NetworkVersionInfo());
+}
+
+//-----
+TEST_F(NetworkVersionInfoUnitTests, EqualityIdenticallyConstructed)
+{
+  const NetworkVersionInfo lhs(getTestHapiVersion(), getTestServicesVersion());
+  const NetworkVersionInfo rhs(getTestHapiVersion(), getTestServicesVersion());
+  EXPECT_TRUE(lhs == rhs);
+}
+
+//-----
+TEST_F(NetworkVersionInfoUnitTests, InequalityDifferentProtobufVersion)
+{
+  const NetworkVersionInfo lhs(getTestHapiVersion(), getTestServicesVersion());
+  const NetworkVersionInfo rhs(SemanticVersion(9, 9, 9), getTestServicesVersion());
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(NetworkVersionInfoUnitTests, InequalityDifferentServicesVersion)
+{
+  const NetworkVersionInfo lhs(getTestHapiVersion(), getTestServicesVersion());
+  const NetworkVersionInfo rhs(getTestHapiVersion(), SemanticVersion(9, 9, 9));
+  EXPECT_FALSE(lhs == rhs);
+}


### PR DESCRIPTION

Description:

Add operator== to NetworkVersionInfo as a const member function, following the established pattern used by other SDK value types.

Add [[nodiscard]] bool operator==(const NetworkVersionInfo& rhs) const declaration to NetworkVersionInfo.h
Implement operator== in NetworkVersionInfo.cc, comparing mProtobufVersion and mServicesVersion
Add equality unit tests to NetworkVersionInfoUnitTests.cc
Related issue(s):

Fixes #1555 

Notes for reviewer:

All 10 NetworkVersionInfoUnitTests pass:

## NetworkVersionInfo Unit Test Results

### ✅ Passed Tests
- **ConstructWithValues**
- **FromProtobuf**
- **FromBytes**
- **ToProtobuf**
- **ToBytes**
- **ToString**
- **EqualityDefaultConstructed**
- **EqualityIdenticallyConstructed**
- **InequalityDifferentProtobufVersion**
- **InequalityDifferentServicesVersion**

---

###  Summary
- **Total Tests:** 10  
- **Passed:** 10  
- **Failed:** 0  
- **Success Rate:** 100%

Changes are strictly limited to NetworkVersionInfo.h, NetworkVersionInfo.cc, and NetworkVersionInfoUnitTests.cc. No behavior or API changes.