### PR TITLE
fix: replace hardcoded label names and day counts in bot-inactivity.j…

### DIFF
--- a/.github/scripts/bot-inactivity.js
+++ b/.github/scripts/bot-inactivity.js
@@ -317,11 +317,14 @@ function buildWarningComment(assigneeLogins, itemType) {
     ? 'To stay active, leave a comment on this PR or the linked **issue**, or push a new commit.'
     : "If you're still on it, leave a comment to let us know!";
 
+  const warnDays = WARN_AFTER_MS / (24 * 60 * 60 * 1000);
+  const remainingDays = (CLOSE_AFTER_MS - WARN_AFTER_MS) / (24 * 60 * 60 * 1000);
+
   return [
     WARN_MARKER,
-    `👋 Hey ${mentions}! This ${itemType} has been inactive for 5 days.`,
+    `👋 Hey ${mentions}! This ${itemType} has been inactive for ${warnDays} days.`,
     '',
-    'Are you still working on this? We will close this in 2 days if we see no further activity.',
+    `Are you still working on this? We will close this in ${remainingDays} days if we see no further activity.`,
     '',
     `${activityHint} If you'd like to step down, comment \`/unassign\`.`,
   ].join('\n');
@@ -333,17 +336,19 @@ function buildWarningComment(assigneeLogins, itemType) {
  * @returns {string}
  */
 function buildClosureComment(itemType) {
+  const closeDays = CLOSE_AFTER_MS / (24 * 60 * 60 * 1000);
+
   if (itemType === 'issue') {
     return [
-      '⏱️ This issue has been unassigned and reset to `status: ready for dev` due to 7 days of inactivity.',
+      `⏱️ This issue has been unassigned and reset to \`${LABELS.READY_FOR_DEV}\` due to ${closeDays} days of inactivity.`,
       '',
       "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
     ].join('\n');
   }
   return [
-    '⏱️ This PR has been closed due to 7 days of inactivity.',
+    `⏱️ This PR has been closed due to ${closeDays} days of inactivity.`,
     '',
-    'It has been unassigned and reset to `status: ready for dev` so another contributor can pick it up.',
+    `It has been unassigned and reset to \`${LABELS.READY_FOR_DEV}\` so another contributor can pick it up.`,
     '',
     "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
   ].join('\n');
@@ -357,7 +362,7 @@ function buildLinkedPRClosedComment() {
   return [
     '🔗 The pull request linked to this issue was closed due to inactivity.',
     '',
-    'This issue has been unassigned and reset to `status: ready for dev`.',
+    `This issue has been unassigned and reset to \`${LABELS.READY_FOR_DEV}\`.`,
     '',
     "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
   ].join('\n');
@@ -378,7 +383,7 @@ function buildBlockedCheckinComment(assigneeLogins, itemType) {
     BLOCKED_CHECKIN_MARKER,
     `👋 Hey ${mentions}, just checking in! Is this ${itemType} still blocked?`,
     '',
-    'If it has been unblocked, please remove the `status: blocked` label so we can track progress.',
+    `If it has been unblocked, please remove the \`${LABELS.BLOCKED}\` label so we can track progress.`,
   ].join('\n');
 }
 


### PR DESCRIPTION
Replace hardcoded label name strings (e.g. 'status: ready for dev', 'status: blocked') with references to the existing LABELS constants in the four comment-builder functions:
  - buildWarningComment
  - buildClosureComment
  - buildLinkedPRClosedComment
  - buildBlockedCheckinComment

Replace magic number day counts ('5 days', '7 days', '2 days') with values derived from the module-level timing constants (WARN_AFTER_MS, CLOSE_AFTER_MS) so that any future changes to those constants are automatically reflected in user-facing messages.

No bot logic was changed — only the message text in the builder functions.

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #1561 
