### PR TITLE
fix: bump mirror node version to v0.154.0 in CI workflow

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -200,7 +200,7 @@ jobs:
         with:
           soloVersion: v0.71.0
           installMirrorNode: true
-          mirrorNodeVersion: v0.153.1
+          mirrorNodeVersion: v0.154.0
           hieroVersion: v0.73.0
           dualMode: true
 


### PR DESCRIPTION
Update mirrorNodeVersion in zxc-build-library.yaml from v0.151.0 to v0.154.0 to keep the integration test environment current.

No other files were modified.

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #1560 
