### PR TITLE
feat: notify maintainers when recommended issue queue is empty

### DIFF
--- a/.github/scripts/bot/bot-recommend-issues.js
+++ b/.github/scripts/bot/bot-recommend-issues.js
@@ -156,6 +156,25 @@ function buildRecommendationErrorComment(username) {
 }
 
 /**
+ * Builds a maintainer nudge comment when no issues are available.
+ *
+ * @param {string} username
+ * @param {string} targetLevel
+ * @returns {string}
+ */
+function buildMaintainerNudgeComment(username, targetLevel) {
+    return [
+        `👋 Hi @${username}!`,
+        '',
+        `It looks like there are currently no open issues available at the **${targetLevel}** level.`,
+        '',
+        `${MAINTAINER_TEAM} — could you please create or finalize some issues at the **${targetLevel}** level so they have a clear next step?`,
+        '',
+        `Thanks for your contributions!`,
+    ].join('\n');
+}
+
+/**
  * Checks whether a contributor qualifies for a level via bypass.
  *
  * A contributor passes the bypass check if they have at least one closed
@@ -475,6 +494,9 @@ async function handleRecommendIssues(botContext) {
 
     if (issues.length === 0) {
         logger.log('recommendation.empty', { user: username });
+        const targetLevel = unlockedLevel || skillLevel;
+        const comment = buildMaintainerNudgeComment(username, targetLevel);
+        await postComment(botContext, comment);
         return;
     }
 
@@ -502,4 +524,5 @@ module.exports = {
     getRecommendedIssues,
     resolveEligibleLevel,
     detectUnlockedLevel,
+    buildMaintainerNudgeComment,
 };

--- a/.github/scripts/tests/test-recommend-issues-bot.js
+++ b/.github/scripts/tests/test-recommend-issues-bot.js
@@ -12,6 +12,7 @@ const {
   getRecommendedIssues,
   resolveEligibleLevel,
   detectUnlockedLevel,
+  buildMaintainerNudgeComment,
 } = require('../bot/bot-recommend-issues');
 
 // =============================================================================
@@ -505,6 +506,19 @@ const unitTests = [
   },
 
   // ---------------------------------------------------------------------------
+  // Comment Builders
+  // ---------------------------------------------------------------------------
+  {
+    name: 'buildMaintainerNudgeComment: returns properly formatted message with team tag and nextLevel',
+    test: async () => {
+      const result = buildMaintainerNudgeComment('alice', LABELS.SKILL_BEGINNER);
+      return result.includes('@alice') &&
+             result.includes(MAINTAINER_TEAM) &&
+             result.includes(`**${LABELS.SKILL_BEGINNER}**`);
+    },
+  },
+
+  // ---------------------------------------------------------------------------
   // handleRecommendIssues — short-circuit cases
   // ---------------------------------------------------------------------------
   {
@@ -534,15 +548,17 @@ const unitTests = [
     },
   },
   {
-    name: 'handleRecommendIssues: no matching issues at eligible level → no comment',
+    name: 'handleRecommendIssues: no matching issues at eligible level → maintainer nudge comment',
     test: async () => {
       const { botContext, calls } = createMockBotContext({
+        sender: { login: 'user' },
         issue: makeIssue([BEGINNER, LABELS.READY_FOR_DEV]),
         closedCounts: {},
         searchItems: [],
       });
       await handleRecommendIssues(botContext);
-      return calls.comments.length === 0;
+      const expected = buildMaintainerNudgeComment('user', BEGINNER);
+      return calls.comments.length === 1 && calls.comments[0] === expected;
     },
   },
   {


### PR DESCRIPTION
**Description**:
Notify maintainers when the recommended issues queue is empty for a contributor's skill level. Previously, the bot would silently exit if no issues were found, leaving the contributor without guidance. 

* Add `buildMaintainerNudgeComment` to generate a formatted message tagging the maintainer team
* Update `handleRecommendIssues` to post a maintainer nudge comment instead of returning silently when recommendations are empty
* Add unit tests to verify the empty queue fallback logic and the new comment builder

**Related issue(s)**:

Fixes #1413



**Checklist**

- [x] Documented (Code comments)
- [x] Tested (unit)