### PR TITLE
added getScheduleInfo JSON-RPC Endpoint

### DIFF
--- a/src/tck/include/schedule/ScheduleService.h
+++ b/src/tck/include/schedule/ScheduleService.h
@@ -11,6 +11,7 @@ namespace Hiero::TCK::ScheduleService
  */
 struct CreateScheduleParams;
 struct DeleteScheduleParams;
+struct GetScheduleInfoParams;
 
 /**
  * Create a schedule.
@@ -27,6 +28,14 @@ nlohmann::json createSchedule(const CreateScheduleParams& params);
  * @return A JSON response containing the status of the deletion of the schedule.
  */
 nlohmann::json deleteSchedule(const DeleteScheduleParams& params);
+
+/**
+ * Get schedule info.
+ *
+ * @param params The parameters to use to get info of a schedule.
+ * @return A JSON response containing the schedule info.
+ */
+nlohmann::json getScheduleInfo(const GetScheduleInfoParams& params);
 
 } // namespace Hiero::TCK::ScheduleService
 

--- a/src/tck/include/schedule/params/GetScheduleInfoParams.h
+++ b/src/tck/include/schedule/params/GetScheduleInfoParams.h
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef HIERO_TCK_CPP_GET_SCHEDULE_INFO_PARAMS_H_
+#define HIERO_TCK_CPP_GET_SCHEDULE_INFO_PARAMS_H_
+
+#include "json/JsonUtils.h"
+#include "nlohmann/json.hpp"
+
+#include <optional>
+#include <string>
+
+namespace Hiero::TCK::ScheduleService
+{
+/**
+ * Struct to hold the arguments for a `getScheduleInfo` JSON-RPC method call.
+ */
+struct GetScheduleInfoParams
+{
+  /**
+   * The ID of the schedule to query.
+   */
+  std::optional<std::string> mScheduleId;
+
+  /**
+   * The query payment (in tinybars) to use for this query.
+   */
+  std::optional<std::string> mQueryPayment;
+
+  /**
+   * The maximum query payment (in tinybars) to use for this query.
+   */
+  std::optional<std::string> mMaxQueryPayment;
+};
+
+} // namespace Hiero::TCK::ScheduleService
+
+namespace nlohmann
+{
+/**
+ * JSON serializer template specialisation required to convert GetScheduleInfoParams arguments properly.
+ */
+template<>
+struct [[maybe_unused]] adl_serializer<Hiero::TCK::ScheduleService::GetScheduleInfoParams>
+{
+  /**
+   * Convert a JSON object to a GetScheduleInfoParams.
+   *
+   * @param jsonFrom The JSON object which will fill the GetScheduleInfoParams.
+   * @param params   The GetScheduleInfoParams to fill from the JSON object.
+   */
+  static void from_json(const json& jsonFrom, Hiero::TCK::ScheduleService::GetScheduleInfoParams& params)
+  {
+    params.mScheduleId      = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "scheduleId");
+    params.mQueryPayment    = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "queryPayment");
+    params.mMaxQueryPayment = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "maxQueryPayment");
+  }
+};
+
+} // namespace nlohmann
+
+#endif // HIERO_TCK_CPP_GET_SCHEDULE_INFO_PARAMS_H_

--- a/src/tck/src/TckServer.cc
+++ b/src/tck/src/TckServer.cc
@@ -32,6 +32,7 @@
 #include "schedule/ScheduleService.h"
 #include "schedule/params/CreateScheduleParams.h"
 #include "schedule/params/DeleteScheduleParams.h"
+#include "schedule/params/GetScheduleInfoParams.h"
 #include "sdk/SdkClient.h"
 #include "sdk/params/ResetParams.h"
 #include "sdk/params/SetupParams.h"
@@ -139,6 +140,7 @@ TckServer::TckServer(int port)
   // Schedule Service
   mJsonRpcParser.addMethod("createSchedule", getHandle(ScheduleService::createSchedule));
   mJsonRpcParser.addMethod("deleteSchedule", getHandle(ScheduleService::deleteSchedule));
+  mJsonRpcParser.addMethod("getScheduleInfo", getHandle(ScheduleService::getScheduleInfo));
 
   setupHttpHandler();
   mServer.listen("localhost", port);
@@ -286,5 +288,7 @@ template TckServer::MethodHandle TckServer::getHandle<ScheduleService::CreateSch
   nlohmann::json (*method)(const ScheduleService::CreateScheduleParams&));
 template TckServer::MethodHandle TckServer::getHandle<ScheduleService::DeleteScheduleParams>(
   nlohmann::json (*method)(const ScheduleService::DeleteScheduleParams&));
+template TckServer::MethodHandle TckServer::getHandle<ScheduleService::GetScheduleInfoParams>(
+  nlohmann::json (*method)(const ScheduleService::GetScheduleInfoParams&));
 
 } // namespace Hiero::TCK

--- a/src/tck/src/schedule/ScheduleService.cc
+++ b/src/tck/src/schedule/ScheduleService.cc
@@ -10,6 +10,7 @@
 #include "key/KeyService.h"
 #include "schedule/params/CreateScheduleParams.h"
 #include "schedule/params/DeleteScheduleParams.h"
+#include "schedule/params/GetScheduleInfoParams.h"
 #include "sdk/SdkClient.h"
 #include "token/params/BurnTokenParams.h"
 #include "token/params/CreateTokenParams.h"
@@ -28,6 +29,9 @@
 #include <ScheduleCreateTransaction.h>
 #include <ScheduleDeleteTransaction.h>
 #include <ScheduleId.h>
+#include <ScheduleInfo.h>
+#include <ScheduleInfoQuery.h>
+#include <Key.h>
 #include <TokenBurnTransaction.h>
 #include <TokenCreateTransaction.h>
 #include <TokenDeleteTransaction.h>
@@ -42,6 +46,8 @@
 #include <WrappedTransaction.h>
 #include <impl/EntityIdHelper.h>
 #include <impl/HexConverter.h>
+#include <impl/Utilities.h>
+#include <services/basic_types.pb.h>
 
 #include <chrono>
 #include <functional>
@@ -738,6 +744,79 @@ nlohmann::json createSchedule(const CreateScheduleParams& params)
     {"status",      gStatusToString.at(txReceipt.mStatus)   },
     { "scheduleId", txReceipt.mScheduleId.value().toString()}
   };
+}
+
+//-----
+/**
+ * Build and configure a ScheduleInfoQuery from the given params.
+ */
+ScheduleInfoQuery buildScheduleInfoQuery(const GetScheduleInfoParams& params)
+{
+  ScheduleInfoQuery query;
+  query.setGrpcDeadline(SdkClient::DEFAULT_TCK_REQUEST_TIMEOUT);
+
+  if (params.mScheduleId.has_value())
+  {
+    query.setScheduleId(ScheduleId::fromString(params.mScheduleId.value()));
+  }
+  if (params.mQueryPayment.has_value())
+  {
+    query.setQueryPayment(Hbar::fromTinybars(std::stoll(params.mQueryPayment.value())));
+  }
+  if (params.mMaxQueryPayment.has_value())
+  {
+    query.setMaxQueryPayment(Hbar::fromTinybars(std::stoll(params.mMaxQueryPayment.value())));
+  }
+
+  return query;
+}
+
+//-----
+nlohmann::json getScheduleInfo(const GetScheduleInfoParams& params)
+{
+  const ScheduleInfo info = buildScheduleInfoQuery(params).execute(SdkClient::getClient());
+
+  nlohmann::json response;
+
+  response["scheduleId"]             = info.mScheduleId.toString();
+  response["scheduledTransactionId"] = info.mScheduledTransactionId.toString();
+  response["creatorAccountId"]       = info.mCreatorAccountId.toString();
+  response["payerAccountId"]         = info.mPayerAccountId.toString();
+
+  if (info.mAdminKey)
+  {
+    response["adminKey"] = internal::HexConverter::bytesToHex(info.mAdminKey->toBytes());
+  }
+
+  response["signers"] = nlohmann::json::array();
+  const auto signatoryProto = info.mSignatories.toProtobuf();
+  for (int i = 0; i < signatoryProto->keys_size(); ++i)
+  {
+    response["signers"].push_back(
+      internal::HexConverter::bytesToHex(Key::fromProtobuf(signatoryProto->keys(i))->toBytes()));
+  }
+
+  response["scheduleMemo"]  = info.mMemo;
+  response["waitForExpiry"] = info.mWaitForExpiry;
+  response["expirationTime"] =
+    std::to_string(std::chrono::duration_cast<std::chrono::seconds>(
+      info.mExpirationTime.time_since_epoch()).count());
+
+  if (info.mExecutionTime.has_value())
+  {
+    response["executedAt"] =
+      std::to_string(std::chrono::duration_cast<std::chrono::seconds>(
+        info.mExecutionTime.value().time_since_epoch()).count());
+  }
+
+  if (info.mDeletionTime.has_value())
+  {
+    response["deleted"] =
+      std::to_string(std::chrono::duration_cast<std::chrono::seconds>(
+        info.mDeletionTime.value().time_since_epoch()).count());
+  }
+
+  return response;
 }
 
 } // namespace Hiero::TCK::ScheduleService


### PR DESCRIPTION
**Description**:
Added `getScheduleInfo` JSON-RPC endpoint to the TCK server, wrapping `ScheduleInfoQuery` and returning a JSON response with the schedule's metadata.

* Added `GetScheduleInfoParams` struct with `nlohmann::adl_serializer` in `src/tck/include/schedule/params/GetScheduleInfoParams.h`
* Add `getScheduleInfo` function declaration to `src/tck/include/schedule/ScheduleService.h`
* Implement `getScheduleInfo` in `src/tck/src/schedule/ScheduleService.cc` — executes `ScheduleInfoQuery` and maps all `ScheduleInfo` fields to the TCK JSON response keys, omitting optional fields (`adminKey`, `executedAt`, `deleted`) when unset
* Register `getScheduleInfo` as a JSON-RPC method in `src/tck/src/TckServer.cc` with explicit template instantiation

**Related issue(s)**:

Fixes #1505 

**Notes for reviewer**:
- Follows the exact same pattern as `TopicService::getTopicInfo` and `FileService::getFileInfo`
- Optional fields (`adminKey`, `executedAt`, `deleted`) are omitted from the response when not set on the schedule, consistent with the TCK spec
- `signers` (KeyList) are serialized per-key via the protobuf representation, consistent with how other TCK endpoints serialize key structures
- All 38 existing TCK unit tests pass with no regressions

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
