### PR TITLE
added operator eq token allowance

### DIFF
--- a/src/sdk/main/include/TokenAllowance.h
+++ b/src/sdk/main/include/TokenAllowance.h
@@ -43,7 +43,7 @@ public:
   /**
    * Construct a TokenAllowance object from a TokenAllowance protobuf object.
    *
-   * @param proto The TokenAllowance protobuf object from which to construct an TokenAllowance object.
+   * @param proto The TokenAllowance protobuf object from which to construct a TokenAllowance object.
    * @return The constructed TokenAllowance object.
    */
   [[nodiscard]] static TokenAllowance fromProtobuf(const proto::TokenAllowance& proto);
@@ -51,7 +51,7 @@ public:
   /**
    * Construct a TokenAllowance object from a byte array.
    *
-   * @param bytes The byte array from which to construct an TokenAllowance object.
+   * @param bytes The byte array from which to construct a TokenAllowance object.
    * @return The constructed TokenAllowance object.
    */
   [[nodiscard]] static TokenAllowance fromBytes(const std::vector<std::byte>& bytes);
@@ -77,6 +77,14 @@ public:
    * @return A byte array representing this TokenAllowance object.
    */
   [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Compare this TokenAllowance to another TokenAllowance.
+   *
+   * @param rhs The TokenAllowance to compare against.
+   * @return \c TRUE if this TokenAllowance is the same as the input TokenAllowance, otherwise \c FALSE.
+   */
+  [[nodiscard]] bool operator==(const TokenAllowance& rhs) const;
 
   /**
    * The ID of the token that is being approved to be spent.

--- a/src/sdk/main/src/TokenAllowance.cc
+++ b/src/sdk/main/src/TokenAllowance.cc
@@ -70,4 +70,11 @@ std::vector<std::byte> TokenAllowance::toBytes() const
   return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
 }
 
+//-----
+bool TokenAllowance::operator==(const TokenAllowance& rhs) const
+{
+  return mTokenId == rhs.mTokenId && mOwnerAccountId == rhs.mOwnerAccountId &&
+         mSpenderAccountId == rhs.mSpenderAccountId && mAmount == rhs.mAmount;
+}
+
 } // namespace Hiero

--- a/src/sdk/tests/unit/TokenAllowanceUnitTests.cc
+++ b/src/sdk/tests/unit/TokenAllowanceUnitTests.cc
@@ -75,3 +75,79 @@ TEST_F(TokenAllowanceUnitTests, ToProtobuf)
   EXPECT_EQ(AccountId::fromProtobuf(protoTokenAllowance->spender()), getTestSpenderAccountId());
   EXPECT_EQ(protoTokenAllowance->amount(), getTestAmount());
 }
+
+//-----
+TEST_F(TokenAllowanceUnitTests, DefaultConstructedInstancesAreEqual)
+{
+  // Given / When
+  const TokenAllowance lhs;
+  const TokenAllowance rhs;
+
+  // Then
+  EXPECT_TRUE(lhs == rhs);
+}
+
+//-----
+TEST_F(TokenAllowanceUnitTests, IdenticalInstancesAreEqual)
+{
+  // Given / When
+  const TokenAllowance lhs(
+    getTestTokenId(), getTestOwnerAccountId(), getTestSpenderAccountId(), getTestAmount());
+  const TokenAllowance rhs(
+    getTestTokenId(), getTestOwnerAccountId(), getTestSpenderAccountId(), getTestAmount());
+
+  // Then
+  EXPECT_TRUE(lhs == rhs);
+}
+
+//-----
+TEST_F(TokenAllowanceUnitTests, InequalityDifferentTokenId)
+{
+  // Given / When
+  const TokenAllowance lhs(
+    getTestTokenId(), getTestOwnerAccountId(), getTestSpenderAccountId(), getTestAmount());
+  const TokenAllowance rhs(
+    TokenId(999ULL), getTestOwnerAccountId(), getTestSpenderAccountId(), getTestAmount());
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(TokenAllowanceUnitTests, InequalityDifferentOwnerAccountId)
+{
+  // Given / When
+  const TokenAllowance lhs(
+    getTestTokenId(), getTestOwnerAccountId(), getTestSpenderAccountId(), getTestAmount());
+  const TokenAllowance rhs(
+    getTestTokenId(), AccountId(999ULL), getTestSpenderAccountId(), getTestAmount());
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(TokenAllowanceUnitTests, InequalityDifferentSpenderAccountId)
+{
+  // Given / When
+  const TokenAllowance lhs(
+    getTestTokenId(), getTestOwnerAccountId(), getTestSpenderAccountId(), getTestAmount());
+  const TokenAllowance rhs(
+    getTestTokenId(), getTestOwnerAccountId(), AccountId(999ULL), getTestAmount());
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(TokenAllowanceUnitTests, InequalityDifferentAmount)
+{
+  // Given / When
+  const TokenAllowance lhs(
+    getTestTokenId(), getTestOwnerAccountId(), getTestSpenderAccountId(), getTestAmount());
+  const TokenAllowance rhs(
+    getTestTokenId(), getTestOwnerAccountId(), getTestSpenderAccountId(), 999LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}


### PR DESCRIPTION
**Description**:
Add `operator==` to `TokenAllowance` so callers can compare allowance objects directly without field-by-field comparison, following the same member-function pattern used by other SDK value types.

* Added 6 equality unit tests to `TokenAllowanceUnitTests.cc` covering default-constructed, identically-constructed, and per-field inequality cases

**Related issue(s)**:

Fixes #1575 
