### PR TITLE
Refactor: bot-on-comment.js

### DIFF
--- a/.github/scripts/bot-on-comment.js
+++ b/.github/scripts/bot-on-comment.js
@@ -15,7 +15,13 @@ const { handleAssign } = require('./commands/assign');
 const { handleUnassign } = require('./commands/unassign');
 const { handleFinalize } = require('./commands/finalize');
 
-const KNOWN_COMMANDS = ['assign', 'unassign', 'finalize'];
+const COMMAND_HANDLERS = {
+  assign: handleAssign,
+  unassign: handleUnassign,
+  finalize: handleFinalize,
+};
+
+const KNOWN_COMMANDS = Object.keys(COMMAND_HANDLERS);
 
 let logger = createLogger('on-comment');
 
@@ -100,12 +106,10 @@ module.exports = async ({ github, context }) => {
       // (postComment, addLabels, etc.) log with the correct tag.
       logger = createLogger(`on-${command}`);
 
-      if (command === 'assign') {
-        await handleAssign(botContext);
-      } else if (command === 'unassign') {
-        await handleUnassign(botContext);
-      } else if (command === 'finalize') {
-        await handleFinalize(botContext);
+      const handler = COMMAND_HANDLERS[command];
+
+      if (handler) {
+        await handler(botContext);
       } else {
         logger.log('Unknown command:', command);
       }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
Refactors `.github/scripts/bot-on-comment.js` to dispatch slash commands through a `COMMAND_HANDLERS` map instead of a manual `if/else` chain.

The supported commands are now visible in one place:

1. `assign`
2. `unassign`
3. `finalize`

The per command logger reassignment remains inside the dispatch loop so helper functions continue logging with the correct command-specific prefix.

**Related issue(s)**:

Fixes #1577 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

1. Ran all existing bot tests: `test-*-bot.js`
2. Ran the full `.github/scripts/tests/test-*.js` suite

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
