### PR TITLE
feat: add operator== to TokenAllowance - Add operator== declaration t…

### DIFF
--- a/src/sdk/main/include/TokenAllowance.h
+++ b/src/sdk/main/include/TokenAllowance.h
@@ -79,6 +79,14 @@ public:
   [[nodiscard]] std::vector<std::byte> toBytes() const;
 
   /**
+   * Compare this TokenAllowance to another TokenAllowance and determine if they represent the same allowance.
+   *
+   * @param rhs The other TokenAllowance with which to compare this TokenAllowance.
+   * @return \c TRUE if this TokenAllowance is the same as the input TokenAllowance, otherwise \c FALSE.
+   */
+  [[nodiscard]] bool operator==(const TokenAllowance& rhs) const;
+
+  /**
    * The ID of the token that is being approved to be spent.
    */
   TokenId mTokenId;

--- a/src/sdk/main/src/TokenAllowance.cc
+++ b/src/sdk/main/src/TokenAllowance.cc
@@ -70,4 +70,11 @@ std::vector<std::byte> TokenAllowance::toBytes() const
   return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
 }
 
+//-----
+bool TokenAllowance::operator==(const TokenAllowance& rhs) const
+{
+  return (mTokenId == rhs.mTokenId) && (mOwnerAccountId == rhs.mOwnerAccountId) &&
+         (mSpenderAccountId == rhs.mSpenderAccountId) && (mAmount == rhs.mAmount);
+}
+
 } // namespace Hiero

--- a/src/sdk/tests/unit/TokenAllowanceUnitTests.cc
+++ b/src/sdk/tests/unit/TokenAllowanceUnitTests.cc
@@ -75,3 +75,69 @@ TEST_F(TokenAllowanceUnitTests, ToProtobuf)
   EXPECT_EQ(AccountId::fromProtobuf(protoTokenAllowance->spender()), getTestSpenderAccountId());
   EXPECT_EQ(protoTokenAllowance->amount(), getTestAmount());
 }
+
+//-----
+TEST_F(TokenAllowanceUnitTests, DefaultInstancesAreEqual)
+{
+  // Given / When
+  const TokenAllowance lhs;
+  const TokenAllowance rhs;
+
+  // Then
+  EXPECT_TRUE(lhs == rhs);
+}
+
+//-----
+TEST_F(TokenAllowanceUnitTests, IdenticalInstancesAreEqual)
+{
+  // Given / When
+  const TokenAllowance lhs(getTestTokenId(), getTestOwnerAccountId(), getTestSpenderAccountId(), getTestAmount());
+  const TokenAllowance rhs(getTestTokenId(), getTestOwnerAccountId(), getTestSpenderAccountId(), getTestAmount());
+
+  // Then
+  EXPECT_TRUE(lhs == rhs);
+}
+
+//-----
+TEST_F(TokenAllowanceUnitTests, InequalityDifferentTokenId)
+{
+  // Given / When
+  const TokenAllowance lhs(getTestTokenId(), getTestOwnerAccountId(), getTestSpenderAccountId(), getTestAmount());
+  const TokenAllowance rhs(TokenId(999ULL), getTestOwnerAccountId(), getTestSpenderAccountId(), getTestAmount());
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(TokenAllowanceUnitTests, InequalityDifferentOwner)
+{
+  // Given / When
+  const TokenAllowance lhs(getTestTokenId(), getTestOwnerAccountId(), getTestSpenderAccountId(), getTestAmount());
+  const TokenAllowance rhs(getTestTokenId(), AccountId(999ULL), getTestSpenderAccountId(), getTestAmount());
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(TokenAllowanceUnitTests, InequalityDifferentSpender)
+{
+  // Given / When
+  const TokenAllowance lhs(getTestTokenId(), getTestOwnerAccountId(), getTestSpenderAccountId(), getTestAmount());
+  const TokenAllowance rhs(getTestTokenId(), getTestOwnerAccountId(), AccountId(999ULL), getTestAmount());
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}
+
+//-----
+TEST_F(TokenAllowanceUnitTests, InequalityDifferentAmount)
+{
+  // Given / When
+  const TokenAllowance lhs(getTestTokenId(), getTestOwnerAccountId(), getTestSpenderAccountId(), getTestAmount());
+  const TokenAllowance rhs(getTestTokenId(), getTestOwnerAccountId(), getTestSpenderAccountId(), 999LL);
+
+  // Then
+  EXPECT_FALSE(lhs == rhs);
+}

--- a/src/tck/src/schedule/ScheduleService.cc
+++ b/src/tck/src/schedule/ScheduleService.cc
@@ -647,19 +647,19 @@ WrappedTransaction translateSubmitTopicMessage(const nlohmann::json& params)
 WrappedTransaction translateScheduledTransaction(const nlohmann::json& json)
 {
   static const std::unordered_map<std::string, std::function<WrappedTransaction(const nlohmann::json&)>> dispatcher = {
-    {"transferCrypto",    translateTransferCrypto    },
-    { "createAccount",    translateCreateAccount     },
-    { "deleteAccount",    translateDeleteAccount     },
-    { "updateAccount",    translateUpdateAccount     },
-    { "createToken",      translateCreateToken       },
-    { "deleteToken",      translateDeleteToken       },
-    { "updateToken",      translateUpdateToken       },
-    { "burnToken",        translateBurnToken         },
-    { "mintToken",        translateMintToken         },
-    { "approveAllowance", translateApproveAllowance  },
-    { "createTopic",      translateCreateTopic       },
-    { "deleteTopic",      translateDeleteTopic       },
-    { "submitMessage",    translateSubmitTopicMessage}
+    { "transferCrypto",   translateTransferCrypto     },
+    { "createAccount",    translateCreateAccount      },
+    { "deleteAccount",    translateDeleteAccount      },
+    { "updateAccount",    translateUpdateAccount      },
+    { "createToken",      translateCreateToken        },
+    { "deleteToken",      translateDeleteToken        },
+    { "updateToken",      translateUpdateToken        },
+    { "burnToken",        translateBurnToken          },
+    { "mintToken",        translateMintToken          },
+    { "approveAllowance", translateApproveAllowance   },
+    { "createTopic",      translateCreateTopic        },
+    { "deleteTopic",      translateDeleteTopic        },
+    { "submitMessage",    translateSubmitTopicMessage }
   };
 
   const std::string method = json.at("method").get<std::string>();
@@ -691,9 +691,9 @@ nlohmann::json deleteSchedule(const DeleteScheduleParams& params)
   }
 
   return {
-    {"status",
-     gStatusToString.at(
-        scheduleDeleteTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient()).mStatus)},
+    { "status",
+      gStatusToString.at(
+        scheduleDeleteTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient()).mStatus) },
   };
 }
 
@@ -735,8 +735,8 @@ nlohmann::json createSchedule(const CreateScheduleParams& params)
     scheduleCreateTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient());
 
   return {
-    {"status",      gStatusToString.at(txReceipt.mStatus)   },
-    { "scheduleId", txReceipt.mScheduleId.value().toString()}
+    { "status",     gStatusToString.at(txReceipt.mStatus)    },
+    { "scheduleId", txReceipt.mScheduleId.value().toString() }
   };
 }
 


### PR DESCRIPTION
Fixes https://github.com/hiero-ledger/hiero-sdk-cpp/issues/1575

Add `operator==` to `TokenAllowance`, consistent with existing SDK value types such as `AccountId`, `TokenId`, and `HbarAllowance`.

- Add `[[nodiscard]] bool operator==(const TokenAllowance&) const` declaration to `TokenAllowance.h`
- Implement `operator==` in `TokenAllowance.cc`, comparing all four member fields (`mTokenId`, `mOwnerAccountId`, `mSpenderAccountId`, `mAmount`)
- Add unit tests for default-constructed equality, identical-instance equality, and per-field inequality using the `Inequality*` test pattern

**Related issue(s):**
- Resolves #1575 
