### PR TITLE
fix: pr review labels download triggering artifact

### DIFF
--- a/.github/workflows/on-pr-review-labels.yaml
+++ b/.github/workflows/on-pr-review-labels.yaml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  actions: read
 
 jobs:
   run-bot:
@@ -31,11 +32,12 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: review-event-${{ github.event.workflow_run.id }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
 
       - name: Run bot
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const script = require('./.github/scripts/bot-on-pr-review-labels.js');
-            await script({ github, context }); 
-  
+            await script({ github, context });


### PR DESCRIPTION
**Description**:

Fix the PR review label workflow artifact download so it retrieves the `review-event-*` artifact from the triggering `Bot - On PR Review` workflow run.

* Add `actions: read` permission for cross-run artifact access
* Pass `run-id` to `actions/download-artifact`
* Pass `github-token` to `actions/download-artifact`

**Related issue(s)**:

Fixes #1582

**Notes for reviewer**:

The artifact name is unchanged because `github.event.workflow_run.id` in `Bot - On PR Review (Labels)` matches `github.run_id` from `Bot - On PR Review`.

Tested locally:

```text
node .github\scripts\tests\test-on-pr-review-bot.js
# 5 total, 5 passed

node .github\scripts\tests\test-on-pr-update-bot.js
# 27 total, 27 passed

git diff --check
# passed

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
