### PR TITLE
ci: add GitHub Actions workflow linting

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - hiero-client-sdk-linux-large

--- a/.github/workflows/zxc-lint-workflows.yaml
+++ b/.github/workflows/zxc-lint-workflows.yaml
@@ -42,8 +42,9 @@ jobs:
           cache: false
 
       - name: Install actionlint
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.8
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run actionlint
-        run: |
-          "$(go env GOPATH)/bin/actionlint" -shellcheck= -config-file .github/actionlint.yaml
+        run: actionlint -shellcheck= -config-file .github/actionlint.yaml

--- a/.github/workflows/zxc-lint-workflows.yaml
+++ b/.github/workflows/zxc-lint-workflows.yaml
@@ -1,0 +1,49 @@
+name: "ZXC: Lint Workflows"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - ".github/actionlint.yaml"
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: lint-workflows-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: Lint GitHub Actions Workflows
+    runs-on: hiero-client-sdk-linux-large
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.25"
+          cache: false
+
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.8
+
+      - name: Run actionlint
+        run: |
+          "$(go env GOPATH)/bin/actionlint" -shellcheck= -config-file .github/actionlint.yaml


### PR DESCRIPTION
**Description**:

Add GitHub Actions workflow linting so workflow YAML changes receive direct CI validation.

* Add an `actionlint` configuration for the repo's custom runner label
* Add a dedicated workflow lint job for `.github/workflows/**`
* Run actionlint with shellcheck integration disabled to keep this PR scoped to workflow validation

**Related issue(s)**:

Fixes #1585

**Notes for reviewer**:

Validated locally:

```text
python YAML parse check
YAML OK: .github/actionlint.yaml
YAML OK: .github/workflows/zxc-lint-workflows.yaml

actionlint
actionlint -shellcheck= -config-file .github/actionlint.yaml
# passed with no output
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
