### PR TITLE
feat: implement signSchedule method and parameters

### DIFF
--- a/src/tck/include/schedule/ScheduleService.h
+++ b/src/tck/include/schedule/ScheduleService.h
@@ -11,6 +11,7 @@ namespace Hiero::TCK::ScheduleService
  */
 struct CreateScheduleParams;
 struct DeleteScheduleParams;
+struct SignScheduleParams;
 
 /**
  * Create a schedule.
@@ -27,6 +28,14 @@ nlohmann::json createSchedule(const CreateScheduleParams& params);
  * @return A JSON response containing the status of the deletion of the schedule.
  */
 nlohmann::json deleteSchedule(const DeleteScheduleParams& params);
+
+/**
+ * Sign a schedule.
+ *
+ * @param params The parameters to use to sign a schedule.
+ * @return A JSON response containing the status of the schedule signing.
+ */
+nlohmann::json signSchedule(const SignScheduleParams& params);
 
 } // namespace Hiero::TCK::ScheduleService
 

--- a/src/tck/include/schedule/params/SignScheduleParams.h
+++ b/src/tck/include/schedule/params/SignScheduleParams.h
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef HIERO_TCK_CPP_SIGN_SCHEDULE_PARAMS_H_
+#define HIERO_TCK_CPP_SIGN_SCHEDULE_PARAMS_H_
+
+#include "common/CommonTransactionParams.h"
+#include "json/JsonUtils.h"
+
+#include <nlohmann/json.hpp>
+
+#include <optional>
+#include <string>
+
+namespace Hiero::TCK::ScheduleService
+{
+/**
+ * Struct to hold the arguments for a `signSchedule` JSON-RPC method call.
+ */
+struct SignScheduleParams
+{
+  /**
+   * The ID of the schedule to sign.
+   */
+  std::optional<std::string> mScheduleId;
+
+  /**
+   * Any parameters common to all transaction types.
+   */
+  std::optional<CommonTransactionParams> mCommonTxParams;
+};
+
+} // namespace Hiero::TCK::ScheduleService
+
+namespace nlohmann
+{
+/**
+ * JSON serializer template specialization required to convert SignScheduleParams arguments properly.
+ */
+template<>
+struct [[maybe_unused]] adl_serializer<Hiero::TCK::ScheduleService::SignScheduleParams>
+{
+  /**
+   * Convert a JSON object to a SignScheduleParams.
+   *
+   * @param jsonFrom The JSON object with which to fill the SignScheduleParams.
+   * @param params   The SignScheduleParams to fill with the JSON object.
+   */
+  static void from_json(const json& jsonFrom, Hiero::TCK::ScheduleService::SignScheduleParams& params)
+  {
+    params.mScheduleId = Hiero::TCK::getOptionalJsonParameter<std::string>(jsonFrom, "scheduleId");
+    params.mCommonTxParams =
+      Hiero::TCK::getOptionalJsonParameter<Hiero::TCK::CommonTransactionParams>(jsonFrom, "commonTransactionParams");
+  }
+};
+
+} // namespace nlohmann
+
+#endif // HIERO_TCK_CPP_SIGN_SCHEDULE_PARAMS_H_

--- a/src/tck/src/TckServer.cc
+++ b/src/tck/src/TckServer.cc
@@ -32,6 +32,7 @@
 #include "schedule/ScheduleService.h"
 #include "schedule/params/CreateScheduleParams.h"
 #include "schedule/params/DeleteScheduleParams.h"
+#include "schedule/params/SignScheduleParams.h"
 #include "sdk/SdkClient.h"
 #include "sdk/params/ResetParams.h"
 #include "sdk/params/SetupParams.h"
@@ -139,6 +140,7 @@ TckServer::TckServer(int port)
   // Schedule Service
   mJsonRpcParser.addMethod("createSchedule", getHandle(ScheduleService::createSchedule));
   mJsonRpcParser.addMethod("deleteSchedule", getHandle(ScheduleService::deleteSchedule));
+  mJsonRpcParser.addMethod("signSchedule", getHandle(ScheduleService::signSchedule));
 
   setupHttpHandler();
   mServer.listen("localhost", port);
@@ -286,5 +288,7 @@ template TckServer::MethodHandle TckServer::getHandle<ScheduleService::CreateSch
   nlohmann::json (*method)(const ScheduleService::CreateScheduleParams&));
 template TckServer::MethodHandle TckServer::getHandle<ScheduleService::DeleteScheduleParams>(
   nlohmann::json (*method)(const ScheduleService::DeleteScheduleParams&));
+template TckServer::MethodHandle TckServer::getHandle<ScheduleService::SignScheduleParams>(
+  nlohmann::json (*method)(const ScheduleService::SignScheduleParams&));
 
 } // namespace Hiero::TCK

--- a/src/tck/src/schedule/ScheduleService.cc
+++ b/src/tck/src/schedule/ScheduleService.cc
@@ -10,6 +10,7 @@
 #include "key/KeyService.h"
 #include "schedule/params/CreateScheduleParams.h"
 #include "schedule/params/DeleteScheduleParams.h"
+#include "schedule/params/SignScheduleParams.h"
 #include "sdk/SdkClient.h"
 #include "token/params/BurnTokenParams.h"
 #include "token/params/CreateTokenParams.h"
@@ -28,6 +29,7 @@
 #include <ScheduleCreateTransaction.h>
 #include <ScheduleDeleteTransaction.h>
 #include <ScheduleId.h>
+#include <ScheduleSignTransaction.h>
 #include <TokenBurnTransaction.h>
 #include <TokenCreateTransaction.h>
 #include <TokenDeleteTransaction.h>
@@ -694,6 +696,29 @@ nlohmann::json deleteSchedule(const DeleteScheduleParams& params)
     {"status",
      gStatusToString.at(
         scheduleDeleteTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient()).mStatus)},
+  };
+}
+
+//-----
+nlohmann::json signSchedule(const SignScheduleParams& params)
+{
+  ScheduleSignTransaction scheduleSignTransaction;
+  scheduleSignTransaction.setGrpcDeadline(SdkClient::DEFAULT_TCK_REQUEST_TIMEOUT);
+
+  if (params.mScheduleId.has_value())
+  {
+    scheduleSignTransaction.setScheduleId(ScheduleId::fromString(params.mScheduleId.value()));
+  }
+
+  if (params.mCommonTxParams.has_value())
+  {
+    params.mCommonTxParams->fillOutTransaction(scheduleSignTransaction, SdkClient::getClient());
+  }
+
+  return {
+    {"status",
+     gStatusToString.at(
+        scheduleSignTransaction.execute(SdkClient::getClient()).getReceipt(SdkClient::getClient()).mStatus)},
   };
 }
 


### PR DESCRIPTION
**Description**:
adds support for signing schedules via `signSchedule` method in the Schedule Service. 

**Related issue(s)**:

Fixes #1504

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
