### PR TITLE
feat: add recovery ID calculation for Ethereum transaction signing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(absl CONFIG REQUIRED)
 find_package(Threads REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(EXPAT CONFIG REQUIRED)
+find_package(unofficial-secp256k1 CONFIG REQUIRED)
 
 include(FetchContent)
 include(SystemLibraries.cmake)

--- a/src/sdk/main/CMakeLists.txt
+++ b/src/sdk/main/CMakeLists.txt
@@ -258,6 +258,10 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
         OpenSSL::Crypto)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
+        unofficial::secp256k1
+        unofficial::secp256k1_precomputed)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE
         gRPC::address_sorting
         gRPC::gpr
         gRPC::grpc

--- a/src/sdk/main/include/ECDSAsecp256k1PrivateKey.h
+++ b/src/sdk/main/include/ECDSAsecp256k1PrivateKey.h
@@ -140,6 +140,21 @@ public:
   [[nodiscard]] std::vector<std::byte> sign(const std::vector<std::byte>& bytesToSign) const override;
 
   /**
+   * Computes the recovery ID for an ECDSA signature.
+   *
+   * The recovery ID is an index (0-3) that identifies which of the possible public keys can be recovered from the
+   * signature. This is required for proper Ethereum transaction construction and EVM compatibility.
+   *
+   * @param r       The r component of the ECDSA signature (32 bytes).
+   * @param s       The s component of the ECDSA signature (32 bytes).
+   * @param message The original message that was signed (will be hashed with Keccak-256).
+   * @return The recovery ID (0-3), or -1 if recovery fails.
+   */
+  [[nodiscard]] int getRecoveryId(const std::vector<std::byte>& r,
+                                  const std::vector<std::byte>& s,
+                                  const std::vector<std::byte>& message) const;
+
+  /**
    * Derived from PrivateKey. Get the hex-encoded string of the DER-encoded bytes of this ECDSAsecp256k1PrivateKey.
    *
    * @return The hex-encoded string of the DER-encoded bytes of this ECDSAsecp256k1PrivateKey.

--- a/src/sdk/main/include/impl/openssl_utils/Secp256k1Context.h
+++ b/src/sdk/main/include/impl/openssl_utils/Secp256k1Context.h
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef HIERO_SDK_CPP_IMPL_OPENSSL_UTILS_SECP256K1_CONTEXT_H_
+#define HIERO_SDK_CPP_IMPL_OPENSSL_UTILS_SECP256K1_CONTEXT_H_
+
+#include "impl/openssl_utils/OpenSSLObjectWrapper.h"
+
+#include <secp256k1.h>
+
+namespace Hiero::internal::OpenSSLUtils
+{
+/**
+ * Wrapper class for the secp256k1_context object.
+ */
+class Secp256k1Context : public OpenSSLObjectWrapper<::secp256k1_context>
+{
+public:
+  /**
+   * No custom copier provided for secp256k1_context.
+   */
+  ~Secp256k1Context() override = default;
+  Secp256k1Context(const Secp256k1Context&) = delete;
+  Secp256k1Context& operator=(const Secp256k1Context&) = delete;
+  Secp256k1Context(Secp256k1Context&&) = default;
+  Secp256k1Context& operator=(Secp256k1Context&&) = default;
+
+  /**
+   * Construct with the input secp256k1_context and its secp256k1_context_destroy deleter function.
+   *
+   * @param ctx The secp256k1_context object to wrap.
+   */
+  explicit Secp256k1Context(::secp256k1_context* ctx)
+    : OpenSSLObjectWrapper(ctx, &secp256k1_context_destroy)
+  {
+  }
+};
+
+} // namespace Hiero::internal::OpenSSLUtils
+
+#endif // HIERO_SDK_CPP_IMPL_OPENSSL_UTILS_SECP256K1_CONTEXT_H_

--- a/src/sdk/main/src/ECDSAsecp256k1PrivateKey.cc
+++ b/src/sdk/main/src/ECDSAsecp256k1PrivateKey.cc
@@ -15,9 +15,15 @@
 #include "impl/openssl_utils/EVP_MD_CTX.h"
 #include "impl/openssl_utils/OSSL_LIB_CTX.h"
 #include "impl/openssl_utils/OpenSSLUtils.h"
+#include "impl/openssl_utils/Secp256k1Context.h"
 
 #include <openssl/ec.h>
 #include <openssl/x509.h>
+
+#include <secp256k1.h>
+#include <secp256k1_recovery.h>
+
+#include <cstring>
 
 #include <services/basic_types.pb.h>
 
@@ -69,6 +75,42 @@ const internal::OpenSSLUtils::BIGNUM CURVE_ORDER =
   }
 
   return key;
+}
+
+/**
+ * Attempt to recover a public key using the given recovery ID and compare it to the expected key.
+ *
+ * @param ctx              The secp256k1 context.
+ * @param compactSig       The compact signature (r || s) as 64 bytes.
+ * @param recId            The recovery ID to try (0-3).
+ * @param messageHash      The 32-byte Keccak-256 hash of the original message.
+ * @param expectedPubKey   The expected uncompressed public key bytes (65 bytes).
+ * @return True if the recovered public key matches the expected key.
+ */
+[[nodiscard]] bool tryRecoverWithId(const secp256k1_context* ctx,
+                                    const unsigned char* compactSig,
+                                    int recId,
+                                    const unsigned char* messageHash,
+                                    const std::vector<std::byte>& expectedPubKey)
+{
+  secp256k1_ecdsa_recoverable_signature recoverableSig;
+  if (secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &recoverableSig, compactSig, recId) != 1)
+  {
+    return false;
+  }
+
+  secp256k1_pubkey recoveredPubKey;
+  if (secp256k1_ecdsa_recover(ctx, &recoveredPubKey, &recoverableSig, messageHash) != 1)
+  {
+    return false;
+  }
+
+  // Serialize the recovered public key in uncompressed form.
+  unsigned char serializedPubKey[ECDSAsecp256k1PublicKey::UNCOMPRESSED_KEY_SIZE];
+  size_t outputLen = sizeof(serializedPubKey);
+  secp256k1_ec_pubkey_serialize(ctx, serializedPubKey, &outputLen, &recoveredPubKey, SECP256K1_EC_UNCOMPRESSED);
+
+  return outputLen == expectedPubKey.size() && std::memcmp(serializedPubKey, expectedPubKey.data(), outputLen) == 0;
 }
 
 } // namespace
@@ -261,6 +303,52 @@ std::vector<std::byte> ECDSAsecp256k1PrivateKey::sign(const std::vector<std::byt
   }
 
   return outputArray;
+}
+
+//-----
+int ECDSAsecp256k1PrivateKey::getRecoveryId(const std::vector<std::byte>& r,
+                                            const std::vector<std::byte>& s,
+                                            const std::vector<std::byte>& message) const
+{
+  // Validate input sizes.
+  if (r.size() != R_SIZE || s.size() != S_SIZE)
+  {
+    return -1;
+  }
+
+  // Compute the Keccak-256 hash of the message.
+  const std::vector<std::byte> messageHash = internal::OpenSSLUtils::computeKECCAK256(message);
+
+  // Build compact signature (r || s) as 64-byte array.
+  std::vector<unsigned char> compactSig(RAW_SIGNATURE_SIZE);
+  std::memcpy(compactSig.data(), r.data(), R_SIZE);
+  std::memcpy(compactSig.data() + R_SIZE, s.data(), S_SIZE);
+
+  // Get the expected uncompressed public key bytes (65 bytes: 0x04 || x || y).
+  const std::vector<std::byte> expectedPubKeyBytes =
+    ECDSAsecp256k1PublicKey::uncompressBytes(getPublicKey()->toBytesRaw());
+
+  // Create a secp256k1 context for verification/recovery using RAII.
+  internal::OpenSSLUtils::Secp256k1Context ctx(secp256k1_context_create(SECP256K1_CONTEXT_NONE));
+  if (!ctx)
+  {
+    return -1;
+  }
+
+  // Try each recovery ID (0-3) and check which one recovers our public key.
+  for (int recId = 0; recId < 4; ++recId)
+  {
+    if (tryRecoverWithId(ctx.get(),
+                         compactSig.data(),
+                         recId,
+                         reinterpret_cast<const unsigned char*>(messageHash.data()),
+                         expectedPubKeyBytes))
+    {
+      return recId;
+    }
+  }
+
+  return -1;
 }
 
 //-----

--- a/src/sdk/tests/unit/ECDSAsecp256k1PrivateKeyUnitTests.cc
+++ b/src/sdk/tests/unit/ECDSAsecp256k1PrivateKeyUnitTests.cc
@@ -4,6 +4,7 @@
 #include "ED25519PrivateKey.h"
 #include "exceptions/BadKeyException.h"
 #include "exceptions/UninitializedException.h"
+#include "impl/HexConverter.h"
 #include "impl/Utilities.h"
 
 #include <algorithm>
@@ -302,4 +303,139 @@ TEST_F(ECDSAsecp256k1PrivateKeyUnitTests, ECDSACompatibility)
     ASSERT_EQ(actualResultKeyPair->toStringRaw(), expectedPrivateKey);
     ASSERT_EQ(actualResultKeyPair->getPublicKey()->toStringRaw(), expectedPublicKey);
   }
+}
+
+//-----
+TEST_F(ECDSAsecp256k1PrivateKeyUnitTests, GetRecoveryIdReturnsValidId)
+{
+  // Given
+  const std::unique_ptr<ECDSAsecp256k1PrivateKey> privateKey =
+    ECDSAsecp256k1PrivateKey::fromString(getTestPrivateKeyHexString());
+  const std::vector<std::byte> message = { std::byte(0x01), std::byte(0x02), std::byte(0x03) };
+
+  // When
+  const std::vector<std::byte> signature = privateKey->sign(message);
+  const std::vector<std::byte> r(signature.cbegin(), signature.cbegin() + ECDSAsecp256k1PrivateKey::R_SIZE);
+  const std::vector<std::byte> s(signature.cbegin() + ECDSAsecp256k1PrivateKey::R_SIZE, signature.cend());
+  const int recoveryId = privateKey->getRecoveryId(r, s, message);
+
+  // Then
+  EXPECT_GE(recoveryId, 0);
+  EXPECT_LE(recoveryId, 3);
+}
+
+//-----
+TEST_F(ECDSAsecp256k1PrivateKeyUnitTests, GetRecoveryIdConsistentAcrossMultipleSignings)
+{
+  // Given - ECDSA signatures are non-deterministic, so we verify recovery works across multiple signings.
+  const std::unique_ptr<ECDSAsecp256k1PrivateKey> privateKey =
+    ECDSAsecp256k1PrivateKey::fromString(getTestPrivateKeyHexString());
+  const std::vector<std::byte> message = { std::byte(0xDE), std::byte(0xAD), std::byte(0xBE), std::byte(0xEF) };
+
+  for (int i = 0; i < 10; ++i)
+  {
+    // When
+    const std::vector<std::byte> signature = privateKey->sign(message);
+    const std::vector<std::byte> r(signature.cbegin(), signature.cbegin() + ECDSAsecp256k1PrivateKey::R_SIZE);
+    const std::vector<std::byte> s(signature.cbegin() + ECDSAsecp256k1PrivateKey::R_SIZE, signature.cend());
+    const int recoveryId = privateKey->getRecoveryId(r, s, message);
+
+    // Then
+    EXPECT_GE(recoveryId, 0);
+    EXPECT_LE(recoveryId, 3);
+  }
+}
+
+//-----
+TEST_F(ECDSAsecp256k1PrivateKeyUnitTests, GetRecoveryIdWithEmptyMessage)
+{
+  // Given
+  const std::unique_ptr<ECDSAsecp256k1PrivateKey> privateKey =
+    ECDSAsecp256k1PrivateKey::fromString(getTestPrivateKeyHexString());
+  const std::vector<std::byte> message = {};
+
+  // When
+  const std::vector<std::byte> signature = privateKey->sign(message);
+  const std::vector<std::byte> r(signature.cbegin(), signature.cbegin() + ECDSAsecp256k1PrivateKey::R_SIZE);
+  const std::vector<std::byte> s(signature.cbegin() + ECDSAsecp256k1PrivateKey::R_SIZE, signature.cend());
+  const int recoveryId = privateKey->getRecoveryId(r, s, message);
+
+  // Then
+  EXPECT_GE(recoveryId, 0);
+  EXPECT_LE(recoveryId, 3);
+}
+
+//-----
+TEST_F(ECDSAsecp256k1PrivateKeyUnitTests, GetRecoveryIdInvalidRSize)
+{
+  // Given
+  const std::unique_ptr<ECDSAsecp256k1PrivateKey> privateKey =
+    ECDSAsecp256k1PrivateKey::fromString(getTestPrivateKeyHexString());
+  const std::vector<std::byte> invalidR = { std::byte(0x01) }; // Too small
+  const std::vector<std::byte> validS(ECDSAsecp256k1PrivateKey::S_SIZE, std::byte(0x01));
+  const std::vector<std::byte> message = { std::byte(0x01) };
+
+  // When
+  const int recoveryId = privateKey->getRecoveryId(invalidR, validS, message);
+
+  // Then
+  EXPECT_EQ(recoveryId, -1);
+}
+
+//-----
+TEST_F(ECDSAsecp256k1PrivateKeyUnitTests, GetRecoveryIdInvalidSSize)
+{
+  // Given
+  const std::unique_ptr<ECDSAsecp256k1PrivateKey> privateKey =
+    ECDSAsecp256k1PrivateKey::fromString(getTestPrivateKeyHexString());
+  const std::vector<std::byte> validR(ECDSAsecp256k1PrivateKey::R_SIZE, std::byte(0x01));
+  const std::vector<std::byte> invalidS = { std::byte(0x01) }; // Too small
+  const std::vector<std::byte> message = { std::byte(0x01) };
+
+  // When
+  const int recoveryId = privateKey->getRecoveryId(validR, invalidS, message);
+
+  // Then
+  EXPECT_EQ(recoveryId, -1);
+}
+
+//-----
+TEST_F(ECDSAsecp256k1PrivateKeyUnitTests, GetRecoveryIdMatchesKnownVector)
+{
+  // Given - a known-good (privateKey, message, r, s, recoveryId) tuple computed via eth_keys (RFC6979 deterministic
+  // signing). This verifies the exact recovery ID value, catching endianness or off-by-one bugs.
+  const std::unique_ptr<ECDSAsecp256k1PrivateKey> privateKey =
+    ECDSAsecp256k1PrivateKey::fromString(getTestPrivateKeyHexString());
+  const std::vector<std::byte> message = { std::byte(0x01), std::byte(0x02), std::byte(0x03) };
+  const std::vector<std::byte> r =
+    internal::HexConverter::hexToBytes("A931117D9902782D36D000B958C7941BCC427B0032AB214D903E2BD78FD3C00E");
+  const std::vector<std::byte> s =
+    internal::HexConverter::hexToBytes("7189064C335CDB98B97483549B175D63E2F76EAEDF06A3F69C46F54F6F36B31D");
+  const int expectedRecoveryId = 0;
+
+  // When
+  const int recoveryId = privateKey->getRecoveryId(r, s, message);
+
+  // Then
+  EXPECT_EQ(recoveryId, expectedRecoveryId);
+}
+
+//-----
+TEST_F(ECDSAsecp256k1PrivateKeyUnitTests, GetRecoveryIdReturnsNegativeOneForForeignSignature)
+{
+  // Given - sign with one key, try recovery with another. When a signature was produced by a different key, no recovery
+  // ID can recover this key's public key, so -1 is returned.
+  const std::unique_ptr<ECDSAsecp256k1PrivateKey> signingKey =
+    ECDSAsecp256k1PrivateKey::fromString(getTestPrivateKeyHexString());
+  const std::unique_ptr<ECDSAsecp256k1PrivateKey> differentKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
+  const std::vector<std::byte> message = { std::byte(0x01), std::byte(0x02), std::byte(0x03) };
+
+  // When
+  const std::vector<std::byte> signature = signingKey->sign(message);
+  const std::vector<std::byte> r(signature.cbegin(), signature.cbegin() + ECDSAsecp256k1PrivateKey::R_SIZE);
+  const std::vector<std::byte> s(signature.cbegin() + ECDSAsecp256k1PrivateKey::R_SIZE, signature.cend());
+  const int recoveryId = differentKey->getRecoveryId(r, s, message);
+
+  // Then
+  EXPECT_EQ(recoveryId, -1);
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -44,6 +44,9 @@
     {
       "name": "gtest",
       "version>=": "1.16.0"
+    },
+    {
+      "name": "secp256k1"
     }
   ]
 }


### PR DESCRIPTION
**Description**:

Add recovery ID calculation for Ethereum transaction signing using bitcoin-core/secp256k1.

OpenSSL does not support ECDSA recovery operations, which are required for computing the `v` value in Ethereum transaction signatures. This introduces `secp256k1` as a targeted dependency specifically for recovery operations, while keeping OpenSSL for all existing ECDSA signing and verification.

* Add `secp256k1` as a vcpkg dependency
* Add `find_package(unofficial-secp256k1)` and link `unofficial::secp256k1` in CMake build system
* Implement `getRecoveryId(r, s, message)` method on `ECDSAsecp256k1PrivateKey`
* Add 6 unit tests covering valid recovery, non-deterministic signing consistency, empty message, invalid input sizes, and mismatched key detection

Fixes #684

**Notes for reviewer**:

The implementation uses a try-recover approach: for each candidate recovery ID (0–3), it recovers a public key using `secp256k1_ecdsa_recover()` and compares it against the expected public key. The message is hashed with Keccak-256, consistent with the existing `sign()` method.

Key design decisions:
- **Dual crypto library**: secp256k1 is used only for recovery; OpenSSL remains for all existing operations. No existing APIs are changed.
- **The vcpkg port already exists** at `vcpkg/ports/secp256k1/` with `-DENABLE_MODULE_RECOVERY` enabled - we just needed to add it to `vcpkg.json` and wire up CMake.
- **Method returns -1** on invalid inputs or failed recovery rather than throwing, matching the issue spec and keeping it lightweight for callers.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)