### PR TITLE
feat(StakingInfo): Added operator== to StakingInfo

### DIFF
--- a/src/sdk/main/include/StakingInfo.h
+++ b/src/sdk/main/include/StakingInfo.h
@@ -32,10 +32,6 @@ public:
    * @param proto The StakingInfo protobuf object from which to construct a StakingInfo object.
    * @return The constructed StakingInfo object.
    */
-
-  [[nodiscard]] bool operator==(const StakingInfo& rhs) const;
-  [[nodiscard]] bool operator!=(const StakingInfo& rhs) const { return !operator==(rhs); }
-  
   [[nodiscard]] static StakingInfo fromProtobuf(const proto::StakingInfo& proto);
 
   /**
@@ -66,6 +62,14 @@ public:
    * @return The string representation of this StakingInfo object.
    */
   [[nodiscard]] std::string toString() const;
+
+  /**
+   * Compare this StakingInfo to another StakingInfo and determine if they represent the same staking metadata.
+   *
+   * @param rhs The other StakingInfo with which to compare this StakingInfo.
+   * @return \c TRUE if this StakingInfo is the same as the input StakingInfo, otherwise \c FALSE.
+   */
+  [[nodiscard]] bool operator==(const StakingInfo& rhs) const;
 
   /**
    * Write this StakingInfo to an output stream.

--- a/src/sdk/main/include/StakingInfo.h
+++ b/src/sdk/main/include/StakingInfo.h
@@ -32,6 +32,10 @@ public:
    * @param proto The StakingInfo protobuf object from which to construct a StakingInfo object.
    * @return The constructed StakingInfo object.
    */
+
+  [[nodiscard]] bool operator==(const StakingInfo& rhs) const;
+  [[nodiscard]] bool operator!=(const StakingInfo& rhs) const { return !operator==(rhs); }
+  
   [[nodiscard]] static StakingInfo fromProtobuf(const proto::StakingInfo& proto);
 
   /**

--- a/src/sdk/main/src/StakingInfo.cc
+++ b/src/sdk/main/src/StakingInfo.cc
@@ -109,16 +109,12 @@ std::ostream& operator<<(std::ostream& os, const StakingInfo& info)
   return os;
 }
 
-
+//-----
 bool StakingInfo::operator==(const StakingInfo& rhs) const
 {
-  return mDeclineRewards == rhs.mDeclineRewards &&
-         mStakePeriodStart == rhs.mStakePeriodStart &&
-         mPendingReward == rhs.mPendingReward &&
-         mStakedToMe == rhs.mStakedToMe &&
-         mStakedAccountId == rhs.mStakedAccountId &&
-         mStakedNodeId == rhs.mStakedNodeId;
+  return mDeclineRewards == rhs.mDeclineRewards && mStakePeriodStart == rhs.mStakePeriodStart &&
+         mPendingReward == rhs.mPendingReward && mStakedToMe == rhs.mStakedToMe &&
+         mStakedAccountId == rhs.mStakedAccountId && mStakedNodeId == rhs.mStakedNodeId;
 }
 
 } // namespace Hiero
-

--- a/src/sdk/main/src/StakingInfo.cc
+++ b/src/sdk/main/src/StakingInfo.cc
@@ -109,4 +109,16 @@ std::ostream& operator<<(std::ostream& os, const StakingInfo& info)
   return os;
 }
 
+
+bool StakingInfo::operator==(const StakingInfo& rhs) const
+{
+  return mDeclineRewards == rhs.mDeclineRewards &&
+         mStakePeriodStart == rhs.mStakePeriodStart &&
+         mPendingReward == rhs.mPendingReward &&
+         mStakedToMe == rhs.mStakedToMe &&
+         mStakedAccountId == rhs.mStakedAccountId &&
+         mStakedNodeId == rhs.mStakedNodeId;
+}
+
 } // namespace Hiero
+

--- a/src/sdk/tests/unit/StakingInfoUnitTests.cc
+++ b/src/sdk/tests/unit/StakingInfoUnitTests.cc
@@ -75,3 +75,73 @@ TEST_F(StakingInfoUnitTests, ToString)
   EXPECT_NE(result.find("mStakedToMe"), std::string::npos);
   EXPECT_NE(result.find(std::to_string(getTestStakedNodeId())), std::string::npos);
 }
+
+TEST_F(StakingInfoUnitTests, ToProtobuf)
+{
+  // Given
+  StakingInfo stakingInfo;
+  stakingInfo.mDeclineRewards = getTestDeclineReward();
+  stakingInfo.mStakePeriodStart = getTestStakePeriodStart();
+  stakingInfo.mPendingReward = Hbar(getTestPendingReward(), HbarUnit::TINYBAR());
+  stakingInfo.mStakedToMe = Hbar(getTestStakedToMe(), HbarUnit::TINYBAR());
+  stakingInfo.mStakedNodeId = getTestStakedNodeId();
+
+  // When
+  const std::unique_ptr<proto::StakingInfo> protoStakingInfo = stakingInfo.toProtobuf();
+
+  // Then
+  EXPECT_EQ(protoStakingInfo->decline_reward(), getTestDeclineReward());
+  ASSERT_TRUE(protoStakingInfo->has_stake_period_start());
+  EXPECT_EQ(internal::TimestampConverter::fromProtobuf(protoStakingInfo->stake_period_start()),
+            getTestStakePeriodStart());
+  EXPECT_EQ(protoStakingInfo->pending_reward(), getTestPendingReward());
+  EXPECT_EQ(protoStakingInfo->staked_to_me(), getTestStakedToMe());
+  EXPECT_FALSE(protoStakingInfo->has_staked_account_id());
+  ASSERT_TRUE(protoStakingInfo->has_staked_node_id());
+  EXPECT_EQ(protoStakingInfo->staked_node_id(), getTestStakedNodeId());
+}
+
+//-----
+TEST_F(StakingInfoUnitTests, OperatorEqual)
+{
+  // Given
+  StakingInfo stakingInfo1;
+  StakingInfo stakingInfo2;
+
+  // Two default-constructed instances are equal
+  EXPECT_EQ(stakingInfo1, stakingInfo2);
+
+  // Two identically-constructed instances are equal
+  stakingInfo1.mDeclineRewards = getTestDeclineReward();
+  stakingInfo1.mStakePeriodStart = getTestStakePeriodStart();
+  stakingInfo1.mPendingReward = Hbar(getTestPendingReward(), HbarUnit::TINYBAR());
+  stakingInfo1.mStakedToMe = Hbar(getTestStakedToMe(), HbarUnit::TINYBAR());
+  stakingInfo1.mStakedNodeId = getTestStakedNodeId();
+
+  stakingInfo2 = stakingInfo1;
+  EXPECT_EQ(stakingInfo1, stakingInfo2);
+
+  // Instances differing in each field are not equal
+  stakingInfo2.mDeclineRewards = !getTestDeclineReward();
+  EXPECT_NE(stakingInfo1, stakingInfo2);
+  stakingInfo2 = stakingInfo1;
+
+  stakingInfo2.mStakePeriodStart = getTestStakePeriodStart() + std::chrono::seconds(1);
+  EXPECT_NE(stakingInfo1, stakingInfo2);
+  stakingInfo2 = stakingInfo1;
+
+  stakingInfo2.mPendingReward = Hbar(getTestPendingReward() + 1LL, HbarUnit::TINYBAR());
+  EXPECT_NE(stakingInfo1, stakingInfo2);
+  stakingInfo2 = stakingInfo1;
+
+  stakingInfo2.mStakedToMe = Hbar(getTestStakedToMe() + 1LL, HbarUnit::TINYBAR());
+  EXPECT_NE(stakingInfo1, stakingInfo2);
+  stakingInfo2 = stakingInfo1;
+
+  stakingInfo2.mStakedAccountId = AccountId(1ULL);
+  EXPECT_NE(stakingInfo1, stakingInfo2);
+  stakingInfo2 = stakingInfo1;
+
+  stakingInfo2.mStakedNodeId = getTestStakedNodeId() + 1LL;
+  EXPECT_NE(stakingInfo1, stakingInfo2);
+}

--- a/src/sdk/tests/unit/StakingInfoUnitTests.cc
+++ b/src/sdk/tests/unit/StakingInfoUnitTests.cc
@@ -120,6 +120,3 @@ TEST_F(StakingInfoUnitTests, OperatorEqual)
   stakingInfo2.mStakedNodeId = getTestStakedNodeId() + 1LL;
   EXPECT_FALSE(stakingInfo1 == stakingInfo2);
 }
-
-
-

--- a/src/sdk/tests/unit/StakingInfoUnitTests.cc
+++ b/src/sdk/tests/unit/StakingInfoUnitTests.cc
@@ -76,31 +76,6 @@ TEST_F(StakingInfoUnitTests, ToString)
   EXPECT_NE(result.find(std::to_string(getTestStakedNodeId())), std::string::npos);
 }
 
-TEST_F(StakingInfoUnitTests, ToProtobuf)
-{
-  // Given
-  StakingInfo stakingInfo;
-  stakingInfo.mDeclineRewards = getTestDeclineReward();
-  stakingInfo.mStakePeriodStart = getTestStakePeriodStart();
-  stakingInfo.mPendingReward = Hbar(getTestPendingReward(), HbarUnit::TINYBAR());
-  stakingInfo.mStakedToMe = Hbar(getTestStakedToMe(), HbarUnit::TINYBAR());
-  stakingInfo.mStakedNodeId = getTestStakedNodeId();
-
-  // When
-  const std::unique_ptr<proto::StakingInfo> protoStakingInfo = stakingInfo.toProtobuf();
-
-  // Then
-  EXPECT_EQ(protoStakingInfo->decline_reward(), getTestDeclineReward());
-  ASSERT_TRUE(protoStakingInfo->has_stake_period_start());
-  EXPECT_EQ(internal::TimestampConverter::fromProtobuf(protoStakingInfo->stake_period_start()),
-            getTestStakePeriodStart());
-  EXPECT_EQ(protoStakingInfo->pending_reward(), getTestPendingReward());
-  EXPECT_EQ(protoStakingInfo->staked_to_me(), getTestStakedToMe());
-  EXPECT_FALSE(protoStakingInfo->has_staked_account_id());
-  ASSERT_TRUE(protoStakingInfo->has_staked_node_id());
-  EXPECT_EQ(protoStakingInfo->staked_node_id(), getTestStakedNodeId());
-}
-
 //-----
 TEST_F(StakingInfoUnitTests, OperatorEqual)
 {
@@ -123,25 +98,28 @@ TEST_F(StakingInfoUnitTests, OperatorEqual)
 
   // Instances differing in each field are not equal
   stakingInfo2.mDeclineRewards = !getTestDeclineReward();
-  EXPECT_NE(stakingInfo1, stakingInfo2);
+  EXPECT_FALSE(stakingInfo1 == stakingInfo2);
   stakingInfo2 = stakingInfo1;
 
   stakingInfo2.mStakePeriodStart = getTestStakePeriodStart() + std::chrono::seconds(1);
-  EXPECT_NE(stakingInfo1, stakingInfo2);
+  EXPECT_FALSE(stakingInfo1 == stakingInfo2);
   stakingInfo2 = stakingInfo1;
 
   stakingInfo2.mPendingReward = Hbar(getTestPendingReward() + 1LL, HbarUnit::TINYBAR());
-  EXPECT_NE(stakingInfo1, stakingInfo2);
+  EXPECT_FALSE(stakingInfo1 == stakingInfo2);
   stakingInfo2 = stakingInfo1;
 
   stakingInfo2.mStakedToMe = Hbar(getTestStakedToMe() + 1LL, HbarUnit::TINYBAR());
-  EXPECT_NE(stakingInfo1, stakingInfo2);
+  EXPECT_FALSE(stakingInfo1 == stakingInfo2);
   stakingInfo2 = stakingInfo1;
 
   stakingInfo2.mStakedAccountId = AccountId(1ULL);
-  EXPECT_NE(stakingInfo1, stakingInfo2);
+  EXPECT_FALSE(stakingInfo1 == stakingInfo2);
   stakingInfo2 = stakingInfo1;
 
   stakingInfo2.mStakedNodeId = getTestStakedNodeId() + 1LL;
-  EXPECT_NE(stakingInfo1, stakingInfo2);
+  EXPECT_FALSE(stakingInfo1 == stakingInfo2);
 }
+
+
+


### PR DESCRIPTION
Implement equality operators for StakingInfo and add corresponding unit tests.

**Description**:
Adds equality operator support to the `StakingInfo` class to allow for direct instance comparisons.

* Add `operator==` implementation to compare all member fields
* Add inline `operator!=` implementation 
* Add unit tests to cover default construction, identical instances, and field-by-field inequality

**Related issue(s)**:

Fixes #1574 

**Notes for reviewer**:
Unit tests have been added in `StakingInfoUnitTests.cc` to verify equivalence and un-equivalence across all properties. All tests pass locally.
