### PR TITLE
chore: version bump for release v0.55.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15...4.3)
-project(hiero-sdk-cpp VERSION 0.54.0 DESCRIPTION "Hiero SDK C++" LANGUAGES CXX)
+project(hiero-sdk-cpp VERSION 0.55.0 DESCRIPTION "Hiero SDK C++" LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
## Summary

Bumps the project version in [CMakeLists.txt](CMakeLists.txt) from `0.54.0` to `0.55.0` in preparation for the v0.55.0 release. This is the pre-release version-bump PR described in [RELEASE.md §1](RELEASE.md) - once merged, the `v0.55.0` tag is cut from the merge commit on `main`.

## Changes

### Version bump

```diff
- project(hiero-sdk-cpp VERSION 0.54.0 DESCRIPTION "Hiero SDK C++" LANGUAGES CXX)
+ project(hiero-sdk-cpp VERSION 0.55.0 DESCRIPTION "Hiero SDK C++" LANGUAGES CXX)
```

**Files Changed:**
- [CMakeLists.txt:2](CMakeLists.txt#L2)

## Testing

No code paths are touched by this PR — only the CMake `project(... VERSION ...)` value changes. CI (`ZXC: Build Library` on Linux) builds the library from this commit; the SHA produced here is the one used for the release artifacts per [RELEASE.md §3](RELEASE.md).

**Test Plan:**
- [x] Repo builds with the new version (delegated to CI)
- [ ] After merge: tag `v0.55.0` from the merge commit on `main`
- [ ] After merge: trigger Windows and macOS builds via [ZXC: Build Library](https://github.com/hiero-ledger/hiero-sdk-cpp/actions/workflows/zxc-build-library.yaml) at the version-bump commit
- [ ] After merge: download `hapi-library-{Linux,Windows,macOS}-{shortSHA}` and produce `hiero-sdk-cpp-v0.55.0-{shortSHA}.tar.gz` per [RELEASE.md §3](RELEASE.md)

## Files Changed Summary

| Category | Files |
|----------|-------|
| Build | [CMakeLists.txt](CMakeLists.txt) |

1 file changed, 1 insertion(+), 1 deletion(-).

## Breaking Changes

**None.** This is a version-string bump only; no public API, ABI, or behavior changes.
