### PR TITLE
Fix duplicate assign limit check

### DIFF
--- a/.github/scripts/commands/assign.js
+++ b/.github/scripts/commands/assign.js
@@ -329,6 +329,59 @@ async function enforceAssignmentLimit(botContext, requesterUsername) {
       currentCount: openAssignmentCount,
     });
 
+    // Suppress limit failures caused by a duplicate /assign for this issue.
+    let freshIssue;
+    try {
+      const response = await botContext.github.rest.issues.get({
+        owner: botContext.owner,
+        repo: botContext.repo,
+        issue_number: botContext.number,
+      });
+      freshIssue = response.data;
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      logger.error("Failed to fetch fresh issue state:", errorMsg);
+      await postComment(botContext, buildApiErrorComment(requesterUsername));
+      return false;
+    }
+
+    const requesterAlreadyAssigned = freshIssue.assignees?.some(
+      (assignee) =>
+        (assignee.login || "").toLowerCase() ===
+        requesterUsername.toLowerCase(),
+    );
+
+    if (requesterAlreadyAssigned) {
+      logger.log("Exit: user is already assigned (caught during limit check)");
+      await postComment(
+        botContext,
+        buildAlreadyAssignedComment(
+          requesterUsername,
+          freshIssue,
+          botContext.owner,
+          botContext.repo,
+        ),
+      );
+      return false;
+    }
+
+    if (freshIssue.assignees?.length > 0) {
+      logger.log(
+        "Exit: issue already assigned to",
+        freshIssue.assignees.map((assignee) => assignee.login),
+      );
+      await postComment(
+        botContext,
+        buildAlreadyAssignedComment(
+          requesterUsername,
+          freshIssue,
+          botContext.owner,
+          botContext.repo,
+        ),
+      );
+      return false;
+    }
+
     // --- Needs-review bypass check ---
     // If every open (non-blocked) assigned issue has an open PR authored by
     // the contributor with "status: needs review", allow the bypass.

--- a/.github/scripts/commands/assign.js
+++ b/.github/scripts/commands/assign.js
@@ -365,23 +365,6 @@ async function enforceAssignmentLimit(botContext, requesterUsername) {
       return false;
     }
 
-    if (freshIssue.assignees?.length > 0) {
-      logger.log(
-        "Exit: issue already assigned to",
-        freshIssue.assignees.map((assignee) => assignee.login),
-      );
-      await postComment(
-        botContext,
-        buildAlreadyAssignedComment(
-          requesterUsername,
-          freshIssue,
-          botContext.owner,
-          botContext.repo,
-        ),
-      );
-      return false;
-    }
-
     // --- Needs-review bypass check ---
     // If every open (non-blocked) assigned issue has an open PR authored by
     // the contributor with "status: needs review", allow the bypass.

--- a/.github/scripts/tests/test-assign-bot.js
+++ b/.github/scripts/tests/test-assign-bot.js
@@ -347,6 +347,38 @@ const scenarios = [
     ],
   },
   {
+    name: "Race Condition - Duplicate Assignment Trigger At Limit",
+    description:
+      "A duplicate queued /assign sees the current issue in the live assignment count and must not post a limit-exceeded comment",
+    context: {
+      eventName: "issue_comment",
+      payload: {
+        issue: {
+          number: 127,
+          assignees: [], // stale payload: appears unassigned
+          labels: [
+            { name: "status: ready for dev" },
+            { name: "skill: good first issue" },
+          ],
+        },
+        comment: {
+          id: 1028,
+          body: "/assign",
+          user: { login: "duplicate-requester", type: "User" },
+        },
+      },
+      repo: { owner: "hiero-ledger", repo: "hiero-sdk-cpp" },
+    },
+    githubOptions: {
+      issueAlreadyAssignedTo: "duplicate-requester",
+      openAssignmentCount: 2,
+    },
+    expectedAssignee: null,
+    expectedComments: [
+      `👋 Hi @duplicate-requester! You're already assigned to this issue. You're all set to start working on it!\n\nIf you have any questions, feel free to ask here or reach out to the team.`,
+    ],
+  },
+  {
     name: "Race Condition - Fresh Issue Has Multiple Assignees",
     description:
       "Fresh fetch reveals a corrupted multi-assignee issue; bot must reject and list all assignees",


### PR DESCRIPTION
**Description**:
Fix duplicate `/assign` handling so a queued duplicate event does not post a spurious assignment-limit-exceeded comment after the requester has already been assigned.

* Add a fresh issue-state check before posting the assignment-limit-exceeded comment
* Return the existing already-assigned response when the requester is already assigned to the current issue
* Add a regression test for duplicate same-user `/assign` events at the assignment cap

**Related issue(s)**:

Fixes #1593
