### PR TITLE
Fix Windows build include order in FeeEstimateQuery

### DIFF
--- a/src/sdk/main/src/FeeEstimateQuery.cc
+++ b/src/sdk/main/src/FeeEstimateQuery.cc
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-#include "FeeEstimateQuery.h"
+// Windows build requires this to be included first for some reason.
+#include <services/basic_types.pb.h> // NOLINT
+
 #include "Client.h"
+#include "FeeEstimateQuery.h"
 #include "FileAppendTransaction.h"
 #include "TopicMessageSubmitTransaction.h"
 #include "exceptions/IllegalStateException.h"


### PR DESCRIPTION
**Description**:
Fix the Windows Debug build failure in `FeeEstimateQuery.cc` by correcting the include order to prevent MSVC macro collisions.

* Move `#include <services/basic_types.pb.h>` to the top of the include list in `FeeEstimateQuery.cc`
* Add an explanatory comment and `// NOLINT` to prevent clang-format from re-sorting the include

**Related issue(s)**:

Fixes #1618 

**Notes for reviewer**:
This applies the established workaround already used in `AccountId.cc`, `RegisteredNodeAddressBookQuery.cc`, and `MirrorNodeGateway.cc`. By including the proto header before `HttpClient.h` (which pulls in `<windows.h>` via `<httplib.h>`), we ensure the proto types are fully declared before Windows macros like `DELETE`, `IN`, and `OUT` are introduced. 

As noted in the issue's acceptance criteria, no new tests are required as the existing `Build (Windows)` CI job acts as the regression test.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)