### PR TITLE
ci: remove PR status labels when converted to draft

### DIFF
--- a/.github/scripts/bot-on-pr-converted-to-draft.js
+++ b/.github/scripts/bot-on-pr-converted-to-draft.js
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// bot-on-pr-converted-to-draft.js
+//
+// Runs when a PR is converted to draft.
+// Removes review-related status labels.
+
+const {
+  createLogger,
+  buildBotContext,
+} = require('./helpers');
+
+const { LABELS } = require('./helpers/constants');
+
+const logger = createLogger('on-pr-converted-to-draft');
+
+module.exports = async ({ github, context }) => {
+  try {
+    const botContext = buildBotContext({ github, context });
+
+    if (botContext.pr?.user?.type === 'Bot') {
+      logger.log('Skipping bot-authored PR');
+      return;
+    }
+
+    const labelsToRemove = [
+      LABELS.NEEDS_REVIEW,
+      LABELS.NEEDS_REVISION,
+    ];
+
+    const existingLabels = botContext.pr.labels.map((label) => label.name);
+
+    for (const label of labelsToRemove) {
+      if (existingLabels.includes(label)) {
+        await github.rest.issues.removeLabel({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          issue_number: botContext.pr.number,
+          name: label,
+        });
+
+        logger.log(`Removed label: ${label}`);
+      }
+    }
+
+    logger.log('On-PR-converted-to-draft bot completed');
+  } catch (error) {
+    logger.error('Error:', {
+      message: error.message,
+      number: context?.payload?.pull_request?.number,
+    });
+
+    throw error;
+  }
+};

--- a/.github/scripts/bot-on-pr-converted-to-draft.js
+++ b/.github/scripts/bot-on-pr-converted-to-draft.js
@@ -8,9 +8,10 @@
 const {
   createLogger,
   buildBotContext,
+  hasLabel,
+  removeLabel,
+  LABELS,
 } = require('./helpers');
-
-const { LABELS } = require('./helpers/constants');
 
 const logger = createLogger('on-pr-converted-to-draft');
 
@@ -28,18 +29,17 @@ module.exports = async ({ github, context }) => {
       LABELS.NEEDS_REVISION,
     ];
 
-    const existingLabels = botContext.pr.labels.map((label) => label.name);
-
     for (const label of labelsToRemove) {
-      if (existingLabels.includes(label)) {
-        await github.rest.issues.removeLabel({
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          issue_number: botContext.pr.number,
-          name: label,
-        });
+      if (!hasLabel(botContext.pr, label)) {
+        continue;
+      }
 
-        logger.log(`Removed label: ${label}`);
+      const result = await removeLabel(botContext, label);
+
+      if (!result.success) {
+        logger.error(
+          `Failed to remove '${label}' from #${botContext.number}: ${result.error}`
+        );
       }
     }
 
@@ -52,4 +52,4 @@ module.exports = async ({ github, context }) => {
 
     throw error;
   }
-};
+}; 

--- a/.github/scripts/tests/test-on-pr-converted-to-draft-bot.js
+++ b/.github/scripts/tests/test-on-pr-converted-to-draft-bot.js
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// tests/test-on-pr-converted-to-draft-bot.js
+//
+// Integration tests for bot-on-pr-converted-to-draft.js
+
+const { runTestSuite } = require('./test-utils');
+const script = require('../bot-on-pr-converted-to-draft.js');
+const { LABELS } = require('../helpers/constants');
+
+function defaultContext(overrides = {}) {
+  return {
+    eventName: 'pull_request_target',
+    payload: {
+      action: 'converted_to_draft',
+      pull_request: {
+        number: 1,
+        user: { login: 'contributor', type: 'User' },
+        labels: [],
+      },
+    },
+    repo: { owner: 'test', repo: 'repo' },
+    ...overrides,
+  };
+}
+
+function createMockGithub() {
+  const calls = {
+    labelsRemoved: [],
+  };
+
+  return {
+    rest: {
+      issues: {
+        removeLabel: async ({ name }) => {
+          calls.labelsRemoved.push(name);
+          return {};
+        },
+      },
+    },
+
+    calls,
+  };
+}
+
+const scenarios = [
+  {
+    name: 'Remove needs-review label',
+    context: defaultContext({
+      payload: {
+        action: 'converted_to_draft',
+        pull_request: {
+          number: 1,
+          user: { login: 'alice', type: 'User' },
+          labels: [{ name: LABELS.NEEDS_REVIEW }],
+        },
+      },
+    }),
+
+    expect: {
+      labelsRemoved: [LABELS.NEEDS_REVIEW],
+    },
+  },
+
+  {
+    name: 'Remove needs-revision label',
+    context: defaultContext({
+      payload: {
+        action: 'converted_to_draft',
+        pull_request: {
+          number: 1,
+          user: { login: 'bob', type: 'User' },
+          labels: [{ name: LABELS.NEEDS_REVISION }],
+        },
+      },
+    }),
+
+    expect: {
+      labelsRemoved: [LABELS.NEEDS_REVISION],
+    },
+  },
+
+  {
+    name: 'Remove both labels',
+    context: defaultContext({
+      payload: {
+        action: 'converted_to_draft',
+        pull_request: {
+          number: 1,
+          user: { login: 'carol', type: 'User' },
+          labels: [
+            { name: LABELS.NEEDS_REVIEW },
+            { name: LABELS.NEEDS_REVISION },
+          ],
+        },
+      },
+    }),
+
+    expect: {
+      labelsRemoved: [
+        LABELS.NEEDS_REVIEW,
+        LABELS.NEEDS_REVISION,
+      ],
+    },
+  },
+
+  {
+    name: 'No labels present',
+    context: defaultContext(),
+
+    expect: {
+      labelsRemoved: [],
+    },
+  },
+
+  {
+    name: 'Bot-authored PR skipped',
+    context: defaultContext({
+      payload: {
+        action: 'converted_to_draft',
+        pull_request: {
+          number: 1,
+          user: { login: 'dependabot', type: 'Bot' },
+          labels: [
+            { name: LABELS.NEEDS_REVIEW },
+          ],
+        },
+      },
+    }),
+
+    expect: {
+      labelsRemoved: [],
+    },
+  },
+];
+
+async function runTest(scenario, index) {
+  console.log('\\n' + '='.repeat(70));
+  console.log(`TEST ${index + 1}: ${scenario.name}`);
+  console.log('='.repeat(70));
+
+  const github = createMockGithub();
+
+  try {
+    await script({
+      github,
+      context: scenario.context,
+    });
+  } catch (error) {
+    console.log(`\\n❌ SCRIPT THREW ERROR: ${error.message}`);
+
+    if (error.stack) {
+      console.log(error.stack);
+    }
+
+    return false;
+  }
+
+  let passed = true;
+
+  const expected = scenario.expect.labelsRemoved || [];
+  const actual = github.calls.labelsRemoved;
+
+  if (
+    expected.length !== actual.length ||
+    expected.some((label, i) => label !== actual[i])
+  ) {
+    console.log(
+      `\\n❌ labelsRemoved: expected [${expected.join(', ')}], got [${actual.join(', ')}]`
+    );
+
+    passed = false;
+  } else {
+    console.log(`\\n✅ labelsRemoved: [${actual.join(', ')}]`);
+  }
+
+  if (passed) {
+    console.log('\\n✅ PASSED');
+  }
+
+  return passed;
+}
+
+runTestSuite(
+  'ON-PR-CONVERTED-TO-DRAFT BOT TEST SUITE',
+  scenarios,
+  runTest
+);

--- a/.github/scripts/tests/test-on-pr-converted-to-draft-bot.js
+++ b/.github/scripts/tests/test-on-pr-converted-to-draft-bot.js
@@ -135,7 +135,7 @@ const scenarios = [
 ];
 
 async function runTest(scenario, index) {
-  console.log('\\n' + '='.repeat(70));
+  console.log('\n' + '='.repeat(70));
   console.log(`TEST ${index + 1}: ${scenario.name}`);
   console.log('='.repeat(70));
 
@@ -147,7 +147,7 @@ async function runTest(scenario, index) {
       context: scenario.context,
     });
   } catch (error) {
-    console.log(`\\n❌ SCRIPT THREW ERROR: ${error.message}`);
+    console.log(`\n❌ SCRIPT THREW ERROR: ${error.message}`);
 
     if (error.stack) {
       console.log(error.stack);
@@ -166,16 +166,16 @@ async function runTest(scenario, index) {
     expected.some((label, i) => label !== actual[i])
   ) {
     console.log(
-      `\\n❌ labelsRemoved: expected [${expected.join(', ')}], got [${actual.join(', ')}]`
+      `\n❌ labelsRemoved: expected [${expected.join(', ')}], got [${actual.join(', ')}]`
     );
 
     passed = false;
   } else {
-    console.log(`\\n✅ labelsRemoved: [${actual.join(', ')}]`);
+    console.log(`\n✅ labelsRemoved: [${actual.join(', ')}]`);
   }
 
   if (passed) {
-    console.log('\\n✅ PASSED');
+    console.log('\n✅ PASSED');
   }
 
   return passed;
@@ -185,4 +185,4 @@ runTestSuite(
   'ON-PR-CONVERTED-TO-DRAFT BOT TEST SUITE',
   scenarios,
   runTest
-);
+); 

--- a/.github/workflows/on-pr-converted-to-draft.yaml
+++ b/.github/workflows/on-pr-converted-to-draft.yaml
@@ -1,0 +1,36 @@
+name: Bot - On PR Converted To Draft
+
+on:
+  pull_request_target:
+    types:
+      - converted_to_draft
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  on-pr-converted-to-draft:
+    runs-on: hiero-client-sdk-linux-large
+
+    concurrency:
+      group: pr-bot-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450
+
+        with:
+          egress-policy: audit
+
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Run Bot
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+
+        with:
+          script: |
+            const script = require('./.github/scripts/bot-on-pr-converted-to-draft.js');
+            await script({ github, context });

--- a/.github/workflows/on-pr-converted-to-draft.yaml
+++ b/.github/workflows/on-pr-converted-to-draft.yaml
@@ -1,5 +1,9 @@
-name: Bot - On PR Converted To Draft
-
+name: Bot - On PR Converted To Draft 
+ 
+# Runs when a PR is converted to draft.
+# Removes status: needs review and status: needs revision
+# labels via bot-on-pr-converted-to-draft.js.
+# Skips bot-authored PRs. 
 on:
   pull_request_target:
     types:
@@ -19,18 +23,16 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450
-
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: audit
 
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Bot
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
-
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const script = require('./.github/scripts/bot-on-pr-converted-to-draft.js');
-            await script({ github, context });
+            await script({ github, context }); 

--- a/.github/workflows/zxc-test-bot-scripts.yaml
+++ b/.github/workflows/zxc-test-bot-scripts.yaml
@@ -74,7 +74,10 @@ jobs:
         run: node .github/scripts/tests/test-on-pr-review-bot.js
 
       - name: Run On-PR-Merged Bot Tests
-        run: node .github/scripts/tests/test-on-pr-merged-bot.js 
+        run: node .github/scripts/tests/test-on-pr-merged-bot.js  
+         
+      - name: Run On-PR-Converted-To-Draft Bot Tests
+        run: node .github/scripts/tests/test-on-pr-converted-to-draft-bot.js
 
       - name: Run On-PR-Close Bot Tests
         run: node .github/scripts/tests/test-on-pr-close-bot.js


### PR DESCRIPTION
**Description**:

Remove stale PR status labels when a pull request is converted to draft.

* Add new `on-pr-converted-to-draft.yaml` workflow for the `converted_to_draft` event
* Add `bot-on-pr-converted-to-draft.js` bot script
* Remove `status: needs review` label when present
* Remove `status: needs revision` label when present
* Skip bot-authored PRs
* Add integration tests for all draft conversion scenarios
* Register new bot tests in `zxc-test-bot-scripts.yaml`

**Related issue(s)**:

Fixes #1466

**Notes for reviewer**:

* Added dedicated workflow following the existing one-workflow-per-event pattern
* Added tests for:
  * needs-review removal
  * needs-revision removal
  * both labels removed
  * no labels present
  * bot-authored PR skip

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automation to automatically remove review-related labels when pull requests are converted to draft.
  * Added comprehensive tests for the draft PR label management automation.
  * Added GitHub Actions workflow to trigger the draft PR label management automation.
  * Fixed formatting in existing test workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiero-ledger/hiero-sdk-cpp/pull/1630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->