### PR TITLE
feat: add Linux Clang+libc++ build configuration

### DIFF
--- a/.github/workflows/on-schedule-builds.yaml
+++ b/.github/workflows/on-schedule-builds.yaml
@@ -14,4 +14,5 @@ jobs:
     with:
       run-windows-builds: true
       run-macos-builds: true
+      run-clang-libcxx-build: true
       upload-artifacts: false

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -12,8 +12,14 @@ on:
         description: "Select this option when you want to run the MacOS builds."
         type: boolean
         required: false
-        default: false 
-       
+        default: false
+
+      run-clang-libcxx-build:
+        description: "Run the Linux Clang+libc++ build"
+        required: false
+        type: boolean
+        default: false
+
       upload-artifacts:
         description: "Select this option when you want to upload the artifacts."
         type: boolean
@@ -32,11 +38,17 @@ on:
         description: "Select this option when you want to run the MacOS builds."
         type: boolean
         required: false
-        default: false 
-         
+        default: false
+
+      run-clang-libcxx-build:
+        description: "Run the Linux Clang+libc++ build"
+        required: false
+        type: boolean
+        default: false
+
       upload-artifacts:
         description: "Select this option when you want to upload the artifacts."
-        type: boolean 
+        type: boolean
         required: false
         default: true
 
@@ -336,3 +348,61 @@ jobs:
           name: hapi-library-${{ runner.os }}-${{ steps.sha.outputs.short }}
           path: package/
           if-no-files-found: warn
+
+  build-linux-clang-libcxx:
+    name: "Build (Linux, clang+libc++)"
+    if: ${{ (inputs.run-clang-libcxx-build) && !cancelled() }}
+    runs-on: hiero-client-sdk-linux-large
+
+    env:
+      HIERO_NETWORK: localhost
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+
+      - name: Install libc++ and libc++abi
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libc++-dev libc++abi-dev
+
+      - name: Install CMake & Ninja
+        uses: step-security/get-cmake@082f0e11945209d5c8d8476a791e39d4d041005d # v4.3.1
+        with:
+          useCloudCache: true
+
+      - name: Setup VCPkg
+        uses: step-security/run-vcpkg@48490398616947b0df92dc1b24aab5339a66f9f0 # v11.5.2
+        with:
+          binaryCachePath: ${{ github.workspace }}/b/vcpkg_cache
+
+      - name: Convert VCPkg to Full Clone
+        working-directory: vcpkg
+        run: git fetch --unshallow --prune
+
+      - name: Configure CMake (Debug)
+        run: cmake --preset linux-x64-clang-libcxx-debug -DBUILD_TESTS=ON
+
+      - name: Build (Debug)
+        run: cmake --build --preset linux-x64-clang-libcxx-debug -j 6
+
+      - name: Run Unit Tests (Debug)
+        run: ctest -j 6 -C Debug --test-dir build/linux-x64-clang-libcxx-debug -R "TestVectors|UnitTests" --output-on-failure
+        continue-on-error: false
+
+      - name: Configure CMake (Release)
+        run: cmake --preset linux-x64-clang-libcxx-release -DBUILD_TESTS=ON
+
+      - name: Build (Release)
+        run: cmake --build --preset linux-x64-clang-libcxx-release -j 6
+
+      - name: Run Unit Tests (Release)
+        run: ctest -j 6 -C Release --test-dir build/linux-x64-clang-libcxx-release -R "TestVectors|UnitTests" --output-on-failure
+        continue-on-error: false

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,7 @@
     {
       "name": "vcpkg-base",
       "hidden": true,
-      "displayName": "VCPkg Base Build",
+      "displayName": "VCPkg Base",
       "description": "Configured via the vcpkg toolchain",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "installDir": "${sourceDir}/package",
@@ -39,113 +39,115 @@
     {
       "name": "linux-x64-release",
       "inherits": ["vcpkg-base"],
+      "displayName": "Linux x64 Release",
+      "description": "Linux x64 Release build",
       "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": {
-          "type": "STRING",
-          "value": "x64-linux"
-        },
-        "CMAKE_BUILD_TYPE": {
-          "type": "STRING",
-          "value": "Release"
-        }
+        "VCPKG_TARGET_TRIPLET": "x64-linux",
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
       "name": "linux-x64-debug",
       "inherits": ["vcpkg-base"],
+      "displayName": "Linux x64 Debug",
+      "description": "Linux x64 Debug build",
       "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": {
-          "type": "STRING",
-          "value": "x64-linux"
-        },
-        "CMAKE_BUILD_TYPE": {
-          "type": "STRING",
-          "value": "Debug"
-        }
+        "VCPKG_TARGET_TRIPLET": "x64-linux",
+        "CMAKE_BUILD_TYPE": "Debug"
       }
+    },
+    {
+      "name": "linux-x64-clang-libcxx-debug",
+      "displayName": "Linux x64 Clang libc++ Debug",
+      "description": "Linux x64 build with Clang and libc++ (Debug)",
+      "inherits": "vcpkg-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_CXX_FLAGS_INIT": "-stdlib=libc++",
+        "CMAKE_EXE_LINKER_FLAGS_INIT": "-stdlib=libc++ -lc++abi",
+        "CMAKE_SHARED_LINKER_FLAGS_INIT": "-stdlib=libc++ -lc++abi",
+        "VCPKG_TARGET_TRIPLET": "x64-linux-clang-libcxx",
+        "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/vcpkg-triplets"
+      },
+      "binaryDir": "${sourceDir}/build/linux-x64-clang-libcxx-debug"
+    },
+    {
+      "name": "linux-x64-clang-libcxx-release",
+      "displayName": "Linux x64 Clang libc++ Release",
+      "description": "Linux x64 build with Clang and libc++ (Release)",
+      "inherits": "vcpkg-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_CXX_FLAGS_INIT": "-stdlib=libc++",
+        "CMAKE_EXE_LINKER_FLAGS_INIT": "-stdlib=libc++ -lc++abi",
+        "CMAKE_SHARED_LINKER_FLAGS_INIT": "-stdlib=libc++ -lc++abi",
+        "VCPKG_TARGET_TRIPLET": "x64-linux-clang-libcxx",
+        "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/vcpkg-triplets"
+      },
+      "binaryDir": "${sourceDir}/build/linux-x64-clang-libcxx-release"
     },
     {
       "name": "macos-x64-release",
       "inherits": ["vcpkg-base"],
+      "displayName": "macOS x64 Release",
+      "description": "macOS x64 Release build",
       "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": {
-          "type": "STRING",
-          "value": "x64-osx"
-        },
-        "CMAKE_BUILD_TYPE": {
-          "type": "STRING",
-          "value": "Release"
-        }
+        "VCPKG_TARGET_TRIPLET": "x64-osx",
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
       "name": "macos-x64-debug",
       "inherits": ["vcpkg-base"],
+      "displayName": "macOS x64 Debug",
+      "description": "macOS x64 Debug build",
       "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": {
-          "type": "STRING",
-          "value": "x64-osx"
-        },
-        "CMAKE_BUILD_TYPE": {
-          "type": "STRING",
-          "value": "Debug"
-        }
+        "VCPKG_TARGET_TRIPLET": "x64-osx",
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
       "name": "macos-arm64-release",
       "inherits": ["vcpkg-base"],
+      "displayName": "macOS ARM64 Release",
+      "description": "macOS ARM64 Release build",
       "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": {
-          "type": "STRING",
-          "value": "arm64-osx"
-        },
-        "CMAKE_BUILD_TYPE": {
-          "type": "STRING",
-          "value": "Release"
-        }
+        "VCPKG_TARGET_TRIPLET": "arm64-osx",
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
       "name": "macos-arm64-debug",
       "inherits": ["vcpkg-base"],
+      "displayName": "macOS ARM64 Debug",
+      "description": "macOS ARM64 Debug build",
       "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": {
-          "type": "STRING",
-          "value": "arm64-osx"
-        },
-        "CMAKE_BUILD_TYPE": {
-          "type": "STRING",
-          "value": "Debug"
-        }
+        "VCPKG_TARGET_TRIPLET": "arm64-osx",
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
       "name": "windows-x64-release",
       "inherits": ["vcpkg-msbuild-base"],
+      "displayName": "Windows x64 Release",
+      "description": "Windows x64 Release build",
       "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": {
-          "type": "STRING",
-          "value": "x64-windows"
-        },
-        "CMAKE_BUILD_TYPE": {
-          "type": "STRING",
-          "value": "Release"
-        }
+        "VCPKG_TARGET_TRIPLET": "x64-windows",
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
       "name": "windows-x64-debug",
       "inherits": ["vcpkg-msbuild-base"],
+      "displayName": "Windows x64 Debug",
+      "description": "Windows x64 Debug build",
       "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": {
-          "type": "STRING",
-          "value": "x64-windows"
-        },
-        "CMAKE_BUILD_TYPE": {
-          "type": "STRING",
-          "value": "Debug"
-        }
+        "VCPKG_TARGET_TRIPLET": "x64-windows",
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     }
   ],
@@ -153,69 +155,81 @@
     {
       "name": "linux-x64-release",
       "configurePreset": "linux-x64-release",
-      "displayName": "Build ninja-multi-vcpkg",
-      "description": "Build ninja-multi-vcpkg Configurations",
+      "displayName": "Linux x64 Release",
+      "description": "Build Linux x64 Release",
       "configuration": "Release",
       "targets": ["install"]
     },
     {
       "name": "linux-x64-debug",
       "configurePreset": "linux-x64-debug",
-      "displayName": "Build ninja-multi-vcpkg",
-      "description": "Build ninja-multi-vcpkg Configurations",
+      "displayName": "Linux x64 Debug",
+      "description": "Build Linux x64 Debug",
       "configuration": "Debug",
       "targets": ["install"]
     },
     {
+      "name": "linux-x64-clang-libcxx-debug",
+      "displayName": "Linux x64 Clang libc++ Debug",
+      "description": "Linux x64 build with Clang and libc++ (Debug)",
+      "configurePreset": "linux-x64-clang-libcxx-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "linux-x64-clang-libcxx-release",
+      "displayName": "Linux x64 Clang libc++ Release",
+      "description": "Linux x64 build with Clang and libc++ (Release)",
+      "configurePreset": "linux-x64-clang-libcxx-release",
+      "configuration": "Release"
+    },
+    {
       "name": "macos-x64-release",
       "configurePreset": "macos-x64-release",
-      "displayName": "Build ninja-multi-vcpkg",
-      "description": "Build ninja-multi-vcpkg Configurations",
+      "displayName": "macOS x64 Release",
+      "description": "Build macOS x64 Release",
       "configuration": "Release",
       "targets": ["install"]
     },
     {
       "name": "macos-x64-debug",
       "configurePreset": "macos-x64-debug",
-      "displayName": "Build ninja-multi-vcpkg",
-      "description": "Build ninja-multi-vcpkg Configurations",
+      "displayName": "macOS x64 Debug",
+      "description": "Build macOS x64 Debug",
       "configuration": "Debug",
       "targets": ["install"]
     },
     {
       "name": "macos-arm64-release",
       "configurePreset": "macos-arm64-release",
-      "displayName": "Build ninja-multi-vcpkg",
-      "description": "Build ninja-multi-vcpkg Configurations",
+      "displayName": "macOS ARM64 Release",
+      "description": "Build macOS ARM64 Release",
       "configuration": "Release",
       "targets": ["install"]
     },
     {
       "name": "macos-arm64-debug",
       "configurePreset": "macos-arm64-debug",
-      "displayName": "Build ninja-multi-vcpkg",
-      "description": "Build ninja-multi-vcpkg Configurations",
+      "displayName": "macOS ARM64 Debug",
+      "description": "Build macOS ARM64 Debug",
       "configuration": "Debug",
       "targets": ["install"]
     },
     {
       "name": "windows-x64-release",
       "configurePreset": "windows-x64-release",
-      "displayName": "MSVC Release (x64)",
-      "description": "Build MSVC Configurations",
+      "displayName": "Windows x64 Release",
+      "description": "Build Windows x64 Release",
       "configuration": "Release",
       "targets": ["install"]
     },
     {
       "name": "windows-x64-debug",
       "configurePreset": "windows-x64-debug",
-      "displayName": "MSVC Debug (x64)",
-      "description": "Build MSVC Configurations",
+      "displayName": "Windows x64 Debug",
+      "description": "Build Windows x64 Debug",
       "configuration": "Debug",
       "targets": ["install"]
     }
   ],
-  "testPresets": [
-
-  ]
+  "testPresets": []
 }

--- a/README.md
+++ b/README.md
@@ -107,6 +107,48 @@ cmake --preset linux-x64-release -DBUILD_TESTS=ON -DBUILD_TCK=ON -DBUILD_EXAMPLE
 cmake --build --preset linux-x64-release
 ```
 
+### Linux Clang + libc++ Build
+
+The project supports building with Clang and libc++ (LLVM's C++ standard library) on Linux. This configuration tests compatibility with the standard library used on macOS and catches portability issues that might not surface with libstdc++.
+
+#### Requirements
+
+In addition to the standard prerequisites, you'll need:
+
+```sh
+sudo apt-get install libc++-dev libc++abi-dev
+```
+
+#### Building with libc++
+
+```sh
+# Configure (Debug)
+cmake --preset linux-x64-clang-libcxx-debug -DBUILD_TESTS=ON
+
+# Build (Debug)
+cmake --build --preset linux-x64-clang-libcxx-debug -j 6
+
+# Run unit tests
+ctest -j 6 -C Debug --test-dir build/linux-x64-clang-libcxx-debug -R "TestVectors|UnitTests" --output-on-failure
+
+# Configure (Release)
+cmake --preset linux-x64-clang-libcxx-release -DBUILD_TESTS=ON
+
+# Build (Release)
+cmake --build --preset linux-x64-clang-libcxx-release -j 6
+
+# Run unit tests
+ctest -j 6 -C Release --test-dir build/linux-x64-clang-libcxx-release -R "TestVectors|UnitTests" --output-on-failure
+```
+
+#### Important Notes
+
+- **First build will be slow** (30-60 minutes) as vcpkg rebuilds all C++ dependencies with libc++
+- Subsequent builds are much faster once the binary cache is populated
+- This configuration uses a custom vcpkg triplet (`x64-linux-clang-libcxx`) located in `vcpkg-triplets/`
+- All dependencies (gRPC, Protobuf, abseil, log4cxx, etc.) are rebuilt against libc++ to ensure ABI compatibility
+- This build runs in nightly CI to catch libc++-specific issues
+
 ## Testing
 
 ### Running Tests

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ The C++ SDK for interacting with a [Hiero](https://hiero.org) network.
 - [Support](#support)
 - [License](#license)
 
+## Architecture Overview
+
+The SDK is built around:
+- gRPC for network communication
+- Protobuf-generated transaction models
+- CMake + vcpkg dependency management
+- Modular transaction/query APIs
+  
 ## Prerequisites
 
 ### macOS and Linux
@@ -34,6 +42,15 @@ The C++ SDK for interacting with a [Hiero](https://hiero.org) network.
   - Linux: `apt-get install cmake`
 
 > **Note**: Ensure you install all three dependencies (`ninja`, `pkg-config`, and `cmake`) to avoid errors in subsequent steps. The installations might take a few minutes.
+
+
+
+Core modules:
+- Client
+- Transactions
+- Queries
+- Cryptography
+- Mirror Node APIs
 
 ### Windows
 

--- a/vcpkg-triplets/x64-linux-clang-libcxx.cmake
+++ b/vcpkg-triplets/x64-linux-clang-libcxx.cmake
@@ -1,0 +1,16 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Use Clang as the compiler
+set(VCPKG_C_COMPILER clang)
+set(VCPKG_CXX_COMPILER clang++)
+
+# Force libc++ as the standard library
+set(VCPKG_CXX_FLAGS "-stdlib=libc++")
+set(VCPKG_C_FLAGS "")
+
+# Link against libc++ and libc++abi
+set(VCPKG_LINKER_FLAGS "-stdlib=libc++ -lc++abi")


### PR DESCRIPTION
**Description**:

Add Linux Clang+libc++ build configuration to test stdlib portability on self-hosted Linux runners, providing a faster and cheaper alternative to macOS builds for catching libc++-specific issues.

* Add custom vcpkg triplet `x64-linux-clang-libcxx` in `vcpkg-triplets/`
* Add CMake configure presets `linux-x64-clang-libcxx-debug` and `linux-x64-clang-libcxx-release`
* Add CMake build presets for both debug and release configurations
* Add `build-linux-clang-libcxx` job to `zxc-build-library.yaml` workflow
* Add `run-clang-libcxx-build` input flag to workflow (defaults to false)
* Enable libc++ build in nightly workflow via `on-schedule-builds.yaml`
* Document libc++ build requirements and usage in `README.md`

**Related issue(s)**:

Fixes #1620 

### Technical Implementation

**Custom vcpkg Triplet** (`vcpkg-triplets/x64-linux-clang-libcxx.cmake`):
- Configures vcpkg to build all C++ dependencies with Clang and libc++
- Sets compiler flags: `-stdlib=libc++`
- Sets linker flags: `-stdlib=libc++ -lc++abi`
- Ensures ABI compatibility across gRPC, Protobuf, abseil, log4cxx, and all other C++ dependencies

**CMake Presets**:
- Inherit from `vcpkg-base` for consistency
- Override compiler to Clang
- Add libc++ flags to compilation and linking
- Point to custom triplet via `VCPKG_OVERLAY_TRIPLETS`

**CI Integration**:
- New job runs only when `run-clang-libcxx-build: true` is set
- Enabled in nightly workflow, disabled for PR builds
- Installs `libc++-dev` and `libc++abi-dev` packages
- Builds and runs unit tests for both Debug and Release configurations