### PR TITLE
Refactor: Extract repository-specific automation policy into centralized configuration

### DIFF
--- a/.github/hiero-automation.json
+++ b/.github/hiero-automation.json
@@ -1,0 +1,83 @@
+{
+  "maintainerTeam": "@hiero-ledger/hiero-sdk-cpp-maintainers",
+  "goodFirstIssueSupportTeam": "@hiero-ledger/hiero-sdk-good-first-issue-support",
+
+  "labels": {
+    "status": {
+      "awaitingTriage": "status: awaiting triage",
+      "readyForDev": "status: ready for dev",
+      "inProgress": "status: in progress",
+      "blocked": "status: blocked",
+      "needsReview": "status: needs review",
+      "needsRevision": "status: needs revision"
+    },
+    "skill": {
+      "goodFirstIssue": "skill: good first issue",
+      "beginner": "skill: beginner",
+      "intermediate": "skill: intermediate",
+      "advanced": "skill: advanced"
+    },
+    "priority": {
+      "critical": "priority: critical",
+      "high": "priority: high",
+      "medium": "priority: medium",
+      "low": "priority: low"
+    }
+  },
+
+  "skillHierarchy": [
+    "skill: good first issue",
+    "skill: beginner",
+    "skill: intermediate",
+    "skill: advanced"
+  ],
+
+  "priorityHierarchy": [
+    "priority: critical",
+    "priority: high",
+    "priority: medium",
+    "priority: low"
+  ],
+
+  "skillPrerequisites": {
+    "skill: good first issue": {
+      "requiredLabel": null,
+      "requiredCount": 0,
+      "displayName": "Good First Issue"
+    },
+    "skill: beginner": {
+      "requiredLabel": "skill: good first issue",
+      "requiredCount": 2,
+      "displayName": "Beginner",
+      "prerequisiteDisplayName": "Good First Issues"
+    },
+    "skill: intermediate": {
+      "requiredLabel": "skill: beginner",
+      "requiredCount": 3,
+      "displayName": "Intermediate",
+      "prerequisiteDisplayName": "Beginner Issues"
+    },
+    "skill: advanced": {
+      "requiredLabel": "skill: intermediate",
+      "requiredCount": 3,
+      "displayName": "Advanced",
+      "prerequisiteDisplayName": "Intermediate Issues"
+    }
+  },
+
+  "assignmentLimits": {
+    "maxOpenAssignments": 2,
+    "maxGfiCompletions": 5
+  },
+
+  "documentation": {
+    "workflowGuide": "https://github.com/hiero-ledger/hiero-sdk-cpp/blob/main/docs/training/workflow.md",
+    "readme": "https://github.com/hiero-ledger/hiero-sdk-cpp/blob/main/README.md",
+    "signingGuide": "https://github.com/hiero-ledger/hiero-sdk-cpp/blob/main/docs/training/signing.md",
+    "mergeConflictsGuide": "https://github.com/hiero-ledger/hiero-sdk-cpp/blob/main/docs/training/merge-conflicts.md"
+  },
+
+  "community": {
+    "discordChannel": "https://discord.com/channels/905194001349627914/1337424839761465364"
+  }
+}

--- a/.github/scripts/commands/assign-comments.js
+++ b/.github/scripts/commands/assign-comments.js
@@ -7,10 +7,12 @@
 
 const {
   MAINTAINER_TEAM,
+  GFI_SUPPORT_TEAM,
   LABELS,
   ISSUE_STATE,
   SKILL_HIERARCHY,
   SKILL_PREREQUISITES,
+  AUTOMATION_CONFIG,
 } = require("../helpers");
 
 /**
@@ -18,14 +20,14 @@ const {
  * at the same time. Enforced by handleAssign in assign.js.
  * @type {number}
  */
-const MAX_OPEN_ASSIGNMENTS = 2;
+const MAX_OPEN_ASSIGNMENTS = AUTOMATION_CONFIG.assignmentLimits.maxOpenAssignments;
 
 /**
  * Maximum number of Good First Issues a contributor may complete before being
  * redirected to Beginner and higher-level issues. Enforced by handleAssign in assign.js.
  * @type {number}
  */
-const MAX_GFI_COMPLETIONS = 5;
+const MAX_GFI_COMPLETIONS = AUTOMATION_CONFIG.assignmentLimits.maxGfiCompletions;
 
 /**
  * Builds the welcome comment posted after a successful assignment. Returns a
@@ -44,7 +46,7 @@ function buildWelcomeComment(username, skillLevel) {
     return [
       `👋 Hi @${username}, welcome to the Hiero C++ SDK community! Thank you for choosing to contribute — we're thrilled to have you here! 🎉`,
       "",
-      "You've been assigned this **Good First Issue**, and the **Good First Issue Support Team** (@hiero-ledger/hiero-sdk-good-first-issue-support) is ready to help you succeed.",
+      `You've been assigned this **Good First Issue**, and the **Good First Issue Support Team** (${GFI_SUPPORT_TEAM}) is ready to help you succeed.`,
       "",
       "The issue description above has everything you need: implementation steps, contribution workflow, and links to guides. If anything is unclear, just ask — we're happy to help.",
       "",

--- a/.github/scripts/commands/finalize-comments.js
+++ b/.github/scripts/commands/finalize-comments.js
@@ -5,7 +5,7 @@
 // Comment builders and per-skill-level boilerplate for the /finalize command.
 // Pure formatting functions separated from finalize logic for readability and testability.
 
-const { MAINTAINER_TEAM, LABELS } = require('../helpers');
+const { MAINTAINER_TEAM, LABELS, DOCUMENTATION, COMMUNITY } = require('../helpers');
 
 // =============================================================================
 // TITLE PREFIX MAP
@@ -172,11 +172,11 @@ const CONTRIBUTION_GUIDE_CONTENT = [
   '- [ ] Sign each commit using `-s -S`',
   '- [ ] Push your branch and open a pull request',
   '',
-  'Read [Workflow Guide](https://github.com/hiero-ledger/hiero-sdk-cpp/blob/main/docs/training/workflow.md) for step-by-step workflow guidance.',
-  'Read [README.md](https://github.com/hiero-ledger/hiero-sdk-cpp/blob/main/README.md) for setup instructions.',
+  `Read [Workflow Guide](${DOCUMENTATION.workflowGuide}) for step-by-step workflow guidance.`,
+  `Read [README.md](${DOCUMENTATION.readme}) for setup instructions.`,
   '',
   '❗ Pull requests **cannot be merged** without `S` and `s` signed commits.',
-  'See the [Signing Guide](https://github.com/hiero-ledger/hiero-sdk-cpp/blob/main/docs/training/signing.md).',
+  `See the [Signing Guide](${DOCUMENTATION.signingGuide}).`,
 ].join('\n');
 
 // =============================================================================
@@ -192,7 +192,7 @@ const DEFAULT_ADDITIONAL_INFO_LABEL = '🤔 Additional Information';
 const DEFAULT_ADDITIONAL_INFO_CONTENT = [
   'If you have questions while working on this issue, feel free to ask!',
   '',
-  'You can reach the community and maintainers here: [Hiero-SDK-C++ Discord](https://discord.com/channels/905194001349627914/1337424839761465364)',
+  `You can reach the community and maintainers here: [Hiero-SDK-C++ Discord](${COMMUNITY.discordChannel})`,
   '',
   'Whether you need help finding the right file, understanding existing code, or confirming your approach — we\'re happy to help.',
 ].join('\n');

--- a/.github/scripts/helpers/comments.js
+++ b/.github/scripts/helpers/comments.js
@@ -6,12 +6,12 @@
 // structure so future sections (commands, instructions) can be added alongside
 // checks without changing the overall shape.
 
-const { MAINTAINER_TEAM } = require('./constants');
+const { MAINTAINER_TEAM, DOCUMENTATION } = require('./constants');
 
 const MARKER = '<!-- bot:pr-helper -->';
 
-const SIGNING_GUIDE = 'https://github.com/hiero-ledger/hiero-sdk-cpp/blob/main/docs/training/signing.md';
-const MERGE_CONFLICTS_GUIDE = 'https://github.com/hiero-ledger/hiero-sdk-cpp/blob/main/docs/training/merge-conflicts.md';
+const SIGNING_GUIDE = DOCUMENTATION.signingGuide;
+const MERGE_CONFLICTS_GUIDE = DOCUMENTATION.mergeConflictsGuide;
 
 /**
  * Determines the display state of a check result.

--- a/.github/scripts/helpers/config-loader.js
+++ b/.github/scripts/helpers/config-loader.js
@@ -90,51 +90,48 @@ function validateLabels(config, errors) {
 }
 
 /**
+ * Validates a single hierarchy array: non-empty, unique entries,
+ * and all values exist in the corresponding label group.
+ * @param {object} config - The parsed config object.
+ * @param {string[]} errors - Mutable array to push error messages into.
+ * @param {string} hierarchyKey - 'skillHierarchy' or 'priorityHierarchy'.
+ * @param {string} labelGroup - 'skill' or 'priority' (key in config.labels).
+ */
+function validateSingleHierarchy(config, errors, hierarchyKey, labelGroup) {
+  const hierarchy = config[hierarchyKey];
+
+  if (!Array.isArray(hierarchy) || hierarchy.length === 0) {
+    errors.push(`${hierarchyKey} must be a non-empty array`);
+    return;
+  }
+
+  const seen = new Set();
+  for (const entry of hierarchy) {
+    if (seen.has(entry)) {
+      errors.push(`${hierarchyKey} entry "${entry}" appears more than once`);
+    }
+    seen.add(entry);
+  }
+
+  if (config.labels && config.labels[labelGroup]) {
+    const labelValues = Object.values(config.labels[labelGroup]);
+    for (const entry of hierarchy) {
+      if (!labelValues.includes(entry)) {
+        errors.push(`${hierarchyKey} entry "${entry}" not found in labels.${labelGroup} values`);
+      }
+    }
+  }
+}
+
+/**
  * Validates that skillHierarchy and priorityHierarchy are non-empty arrays
  * whose entries are unique and exist in the corresponding label group values.
  * @param {object} config - The parsed config object.
  * @param {string[]} errors - Mutable array to push error messages into.
  */
 function validateHierarchies(config, errors) {
-  if (!Array.isArray(config.skillHierarchy) || config.skillHierarchy.length === 0) {
-    errors.push('skillHierarchy must be a non-empty array');
-  } else {
-    const seen = new Set();
-    for (const entry of config.skillHierarchy) {
-      if (seen.has(entry)) {
-        errors.push(`skillHierarchy entry "${entry}" appears more than once`);
-      }
-      seen.add(entry);
-    }
-    if (config.labels && config.labels.skill) {
-      const skillValues = Object.values(config.labels.skill);
-      for (const entry of config.skillHierarchy) {
-        if (!skillValues.includes(entry)) {
-          errors.push(`skillHierarchy entry "${entry}" not found in labels.skill values`);
-        }
-      }
-    }
-  }
-
-  if (!Array.isArray(config.priorityHierarchy) || config.priorityHierarchy.length === 0) {
-    errors.push('priorityHierarchy must be a non-empty array');
-  } else {
-    const seen = new Set();
-    for (const entry of config.priorityHierarchy) {
-      if (seen.has(entry)) {
-        errors.push(`priorityHierarchy entry "${entry}" appears more than once`);
-      }
-      seen.add(entry);
-    }
-    if (config.labels && config.labels.priority) {
-      const priorityValues = Object.values(config.labels.priority);
-      for (const entry of config.priorityHierarchy) {
-        if (!priorityValues.includes(entry)) {
-          errors.push(`priorityHierarchy entry "${entry}" not found in labels.priority values`);
-        }
-      }
-    }
-  }
+  validateSingleHierarchy(config, errors, 'skillHierarchy', 'skill');
+  validateSingleHierarchy(config, errors, 'priorityHierarchy', 'priority');
 }
 
 /**

--- a/.github/scripts/helpers/config-loader.js
+++ b/.github/scripts/helpers/config-loader.js
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// helpers/config-loader.js
+//
+// Loads and validates the repository automation configuration from
+// .github/hiero-automation.json. Provides buildConstants() to map
+// the nested config structure back into the flat constant shapes
+// consumed by the rest of the bot scripts.
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Default path to the repository automation config file.
+ * Resolves from helpers/ → scripts/ → .github/hiero-automation.json.
+ * @type {string}
+ */
+const DEFAULT_CONFIG_PATH = path.resolve(__dirname, '../../hiero-automation.json');
+
+/**
+ * Validates that a value is a non-empty string.
+ * @param {*} value
+ * @returns {boolean}
+ */
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * Validates that a value is a positive integer (> 0).
+ * @param {*} value
+ * @returns {boolean}
+ */
+function isPositiveInteger(value) {
+  return Number.isInteger(value) && value > 0;
+}
+
+/**
+ * Required keys for each label group, documentation, and community.
+ * If a key is missing from the config, buildConstants() would produce
+ * undefined — so we fail early with a clear message.
+ */
+const REQUIRED_STATUS_KEYS = ['awaitingTriage', 'readyForDev', 'inProgress', 'blocked', 'needsReview', 'needsRevision'];
+const REQUIRED_SKILL_KEYS = ['goodFirstIssue', 'beginner', 'intermediate', 'advanced'];
+const REQUIRED_PRIORITY_KEYS = ['critical', 'high', 'medium', 'low'];
+const REQUIRED_DOC_KEYS = ['workflowGuide', 'readme', 'signingGuide', 'mergeConflictsGuide'];
+const REQUIRED_COMMUNITY_KEYS = ['discordChannel'];
+
+/**
+ * Validates that team references are non-empty strings.
+ * @param {object} config - The parsed config object.
+ * @param {string[]} errors - Mutable array to push error messages into.
+ */
+function validateTeams(config, errors) {
+  if (!isNonEmptyString(config.maintainerTeam)) {
+    errors.push('maintainerTeam must be a non-empty string');
+  }
+  if (!isNonEmptyString(config.goodFirstIssueSupportTeam)) {
+    errors.push('goodFirstIssueSupportTeam must be a non-empty string');
+  }
+}
+
+/**
+ * Validates that labels.status, labels.skill, and labels.priority each exist
+ * as objects containing all required keys with non-empty string values.
+ * @param {object} config - The parsed config object.
+ * @param {string[]} errors - Mutable array to push error messages into.
+ */
+function validateLabels(config, errors) {
+  if (!config.labels || typeof config.labels !== 'object') {
+    errors.push('labels must be an object');
+    return;
+  }
+  const requiredKeysMap = {
+    status: REQUIRED_STATUS_KEYS,
+    skill: REQUIRED_SKILL_KEYS,
+    priority: REQUIRED_PRIORITY_KEYS,
+  };
+  for (const [group, requiredKeys] of Object.entries(requiredKeysMap)) {
+    if (!config.labels[group] || typeof config.labels[group] !== 'object') {
+      errors.push(`labels.${group} must be an object`);
+    } else {
+      for (const key of requiredKeys) {
+        if (!isNonEmptyString(config.labels[group][key])) {
+          errors.push(`labels.${group}.${key} is required and must be a non-empty string`);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Validates that skillHierarchy and priorityHierarchy are non-empty arrays
+ * whose entries exist in the corresponding label group values.
+ * @param {object} config - The parsed config object.
+ * @param {string[]} errors - Mutable array to push error messages into.
+ */
+function validateHierarchies(config, errors) {
+  if (!Array.isArray(config.skillHierarchy) || config.skillHierarchy.length === 0) {
+    errors.push('skillHierarchy must be a non-empty array');
+  } else if (config.labels && config.labels.skill) {
+    const skillValues = Object.values(config.labels.skill);
+    for (const entry of config.skillHierarchy) {
+      if (!skillValues.includes(entry)) {
+        errors.push(`skillHierarchy entry "${entry}" not found in labels.skill values`);
+      }
+    }
+  }
+
+  if (!Array.isArray(config.priorityHierarchy) || config.priorityHierarchy.length === 0) {
+    errors.push('priorityHierarchy must be a non-empty array');
+  } else if (config.labels && config.labels.priority) {
+    const priorityValues = Object.values(config.labels.priority);
+    for (const entry of config.priorityHierarchy) {
+      if (!priorityValues.includes(entry)) {
+        errors.push(`priorityHierarchy entry "${entry}" not found in labels.priority values`);
+      }
+    }
+  }
+}
+
+/**
+ * Validates a single prerequisite object shape: requiredLabel, requiredCount,
+ * displayName, and prerequisiteDisplayName (when requiredLabel is not null).
+ * @param {string} key - The skillPrerequisites key being validated.
+ * @param {object} prereq - The prerequisite object.
+ * @param {string[]} hierarchy - The skillHierarchy array for cross-reference.
+ * @param {string[]} errors - Mutable array to push error messages into.
+ */
+function validatePrerequisiteShape(key, prereq, hierarchy, errors) {
+  if (!prereq || typeof prereq !== 'object') {
+    errors.push(`skillPrerequisites["${key}"] must be an object`);
+    return;
+  }
+  if (!('requiredLabel' in prereq)) {
+    errors.push(`skillPrerequisites["${key}"].requiredLabel is required (use null for no prerequisite)`);
+  }
+  if (!Number.isInteger(prereq.requiredCount) || prereq.requiredCount < 0) {
+    errors.push(`skillPrerequisites["${key}"].requiredCount must be a non-negative integer`);
+  }
+  if (!isNonEmptyString(prereq.displayName)) {
+    errors.push(`skillPrerequisites["${key}"].displayName is required and must be a non-empty string`);
+  }
+  if (prereq.requiredLabel !== null && !isNonEmptyString(prereq.prerequisiteDisplayName)) {
+    errors.push(`skillPrerequisites["${key}"].prerequisiteDisplayName is required when requiredLabel is not null`);
+  }
+  if (prereq.requiredLabel !== null && prereq.requiredLabel !== undefined && !hierarchy.includes(prereq.requiredLabel)) {
+    errors.push(`skillPrerequisites["${key}"].requiredLabel "${prereq.requiredLabel}" not found in skillHierarchy`);
+  }
+}
+
+/**
+ * Validates skillPrerequisites: coverage (every hierarchy entry has a
+ * prerequisites entry), membership (every key is in the hierarchy), and
+ * individual prerequisite object shape.
+ * @param {object} config - The parsed config object.
+ * @param {string[]} errors - Mutable array to push error messages into.
+ */
+function validateSkillPrerequisites(config, errors) {
+  if (!config.skillPrerequisites || typeof config.skillPrerequisites !== 'object') {
+    errors.push('skillPrerequisites must be an object');
+    return;
+  }
+  if (!Array.isArray(config.skillHierarchy)) return;
+
+  for (const skill of config.skillHierarchy) {
+    if (!config.skillPrerequisites[skill]) {
+      errors.push(`skillPrerequisites is missing entry for skillHierarchy value "${skill}"`);
+    }
+  }
+  for (const [key, prereq] of Object.entries(config.skillPrerequisites)) {
+    if (!config.skillHierarchy.includes(key)) {
+      errors.push(`skillPrerequisites key "${key}" not found in skillHierarchy`);
+    }
+    validatePrerequisiteShape(key, prereq, config.skillHierarchy, errors);
+  }
+}
+
+/**
+ * Validates that assignmentLimits contains positive integer values for
+ * maxOpenAssignments and maxGfiCompletions.
+ * @param {object} config - The parsed config object.
+ * @param {string[]} errors - Mutable array to push error messages into.
+ */
+function validateAssignmentLimits(config, errors) {
+  if (!config.assignmentLimits || typeof config.assignmentLimits !== 'object') {
+    errors.push('assignmentLimits must be an object');
+    return;
+  }
+  if (!isPositiveInteger(config.assignmentLimits.maxOpenAssignments)) {
+    errors.push('assignmentLimits.maxOpenAssignments must be a positive integer');
+  }
+  if (!isPositiveInteger(config.assignmentLimits.maxGfiCompletions)) {
+    errors.push('assignmentLimits.maxGfiCompletions must be a positive integer');
+  }
+}
+
+/**
+ * Validates that a config section exists as an object and contains all
+ * required keys as non-empty strings.
+ * @param {object} config - The parsed config object.
+ * @param {string} section - The top-level config key (e.g. 'documentation').
+ * @param {string[]} requiredKeys - Keys that must be present with non-empty string values.
+ * @param {string[]} errors - Mutable array to push error messages into.
+ */
+function validateRequiredKeys(config, section, requiredKeys, errors) {
+  if (!config[section] || typeof config[section] !== 'object') {
+    errors.push(`${section} must be an object`);
+    return;
+  }
+  for (const key of requiredKeys) {
+    if (!isNonEmptyString(config[section][key])) {
+      errors.push(`${section}.${key} is required and must be a non-empty string`);
+    }
+  }
+}
+
+/**
+ * Validates the parsed automation config object. Collects all violations
+ * and throws a single error listing every problem found.
+ *
+ * Checks:
+ *   - teams are non-empty strings
+ *   - labels.status, labels.skill, labels.priority exist with all required keys as non-empty strings
+ *   - every skillHierarchy entry exists in labels.skill values
+ *   - every priorityHierarchy entry exists in labels.priority values
+ *   - every skillHierarchy entry has a corresponding skillPrerequisites entry
+ *   - every skillPrerequisites key exists in skillHierarchy
+ *   - every prerequisite object has requiredLabel, requiredCount, displayName
+ *   - prerequisiteDisplayName is required when requiredLabel is not null
+ *   - every non-null requiredLabel exists in skillHierarchy
+ *   - assignment limits are positive integers
+ *   - documentation has all required keys as non-empty strings
+ *   - community has all required keys as non-empty strings
+ *
+ * @param {object} config - The parsed config object.
+ * @throws {Error} If any validation rule is violated.
+ */
+function validateConfig(config) {
+  const errors = [];
+
+  validateTeams(config, errors);
+  validateLabels(config, errors);
+  validateHierarchies(config, errors);
+  validateSkillPrerequisites(config, errors);
+  validateAssignmentLimits(config, errors);
+  validateRequiredKeys(config, 'documentation', REQUIRED_DOC_KEYS, errors);
+  validateRequiredKeys(config, 'community', REQUIRED_COMMUNITY_KEYS, errors);
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Invalid hiero-automation.json:\n${errors.map((e) => `  - ${e}`).join('\n')}`,
+    );
+  }
+}
+
+/**
+ * Reads, parses, and validates the repository automation config file.
+ *
+ * @param {string} [configPath=DEFAULT_CONFIG_PATH] - Absolute path to the JSON config file.
+ * @returns {object} The validated, frozen config object.
+ * @throws {Error} If the file cannot be read, parsed, or fails validation.
+ */
+function loadAutomationConfig(configPath = DEFAULT_CONFIG_PATH) {
+  let raw;
+  try {
+    raw = fs.readFileSync(configPath, 'utf8');
+  } catch (err) {
+    throw new Error(
+      `Failed to read automation config at ${configPath}: ${err.message}`,
+    );
+  }
+
+  let config;
+  try {
+    config = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse automation config at ${configPath}: ${err.message}`,
+    );
+  }
+
+  validateConfig(config);
+  return Object.freeze(config);
+}
+
+/**
+ * Maps the nested config structure back into the flat constant shapes
+ * consumed by the rest of the bot scripts. The returned object contains
+ * every derived constant that was previously hardcoded in constants.js,
+ * assign-comments.js, finalize-comments.js, and comments.js.
+ *
+ * @param {object} config - A validated config object from loadAutomationConfig.
+ * @returns {{
+ *   MAINTAINER_TEAM: string,
+ *   GFI_SUPPORT_TEAM: string,
+ *   LABELS: object,
+ *   SKILL_HIERARCHY: string[],
+ *   PRIORITY_HIERARCHY: string[],
+ *   SKILL_PREREQUISITES: object,
+ *   DOCUMENTATION: object,
+ *   COMMUNITY: object,
+ * }}
+ */
+function buildConstants(config) {
+  const LABELS = Object.freeze({
+    // Status labels
+    AWAITING_TRIAGE: config.labels.status.awaitingTriage,
+    READY_FOR_DEV: config.labels.status.readyForDev,
+    IN_PROGRESS: config.labels.status.inProgress,
+    BLOCKED: config.labels.status.blocked,
+    NEEDS_REVIEW: config.labels.status.needsReview,
+    NEEDS_REVISION: config.labels.status.needsRevision,
+
+    // Skill level labels
+    GOOD_FIRST_ISSUE: config.labels.skill.goodFirstIssue,
+    BEGINNER: config.labels.skill.beginner,
+    INTERMEDIATE: config.labels.skill.intermediate,
+    ADVANCED: config.labels.skill.advanced,
+
+    // Priority labels
+    PRIORITY_CRITICAL: config.labels.priority.critical,
+    PRIORITY_HIGH: config.labels.priority.high,
+    PRIORITY_MEDIUM: config.labels.priority.medium,
+    PRIORITY_LOW: config.labels.priority.low,
+  });
+
+  const SKILL_HIERARCHY = Object.freeze([...config.skillHierarchy]);
+  const PRIORITY_HIERARCHY = Object.freeze([...config.priorityHierarchy]);
+
+  const SKILL_PREREQUISITES = {};
+  for (const [key, value] of Object.entries(config.skillPrerequisites)) {
+    SKILL_PREREQUISITES[key] = { ...value };
+  }
+
+  return {
+    MAINTAINER_TEAM: config.maintainerTeam,
+    GFI_SUPPORT_TEAM: config.goodFirstIssueSupportTeam,
+    LABELS,
+    SKILL_HIERARCHY,
+    PRIORITY_HIERARCHY,
+    SKILL_PREREQUISITES,
+    DOCUMENTATION: Object.freeze({ ...config.documentation }),
+    COMMUNITY: Object.freeze({ ...config.community }),
+  };
+}
+
+module.exports = {
+  DEFAULT_CONFIG_PATH,
+  loadAutomationConfig,
+  buildConstants,
+};

--- a/.github/scripts/helpers/config-loader.js
+++ b/.github/scripts/helpers/config-loader.js
@@ -91,29 +91,47 @@ function validateLabels(config, errors) {
 
 /**
  * Validates that skillHierarchy and priorityHierarchy are non-empty arrays
- * whose entries exist in the corresponding label group values.
+ * whose entries are unique and exist in the corresponding label group values.
  * @param {object} config - The parsed config object.
  * @param {string[]} errors - Mutable array to push error messages into.
  */
 function validateHierarchies(config, errors) {
   if (!Array.isArray(config.skillHierarchy) || config.skillHierarchy.length === 0) {
     errors.push('skillHierarchy must be a non-empty array');
-  } else if (config.labels && config.labels.skill) {
-    const skillValues = Object.values(config.labels.skill);
+  } else {
+    const seen = new Set();
     for (const entry of config.skillHierarchy) {
-      if (!skillValues.includes(entry)) {
-        errors.push(`skillHierarchy entry "${entry}" not found in labels.skill values`);
+      if (seen.has(entry)) {
+        errors.push(`skillHierarchy entry "${entry}" appears more than once`);
+      }
+      seen.add(entry);
+    }
+    if (config.labels && config.labels.skill) {
+      const skillValues = Object.values(config.labels.skill);
+      for (const entry of config.skillHierarchy) {
+        if (!skillValues.includes(entry)) {
+          errors.push(`skillHierarchy entry "${entry}" not found in labels.skill values`);
+        }
       }
     }
   }
 
   if (!Array.isArray(config.priorityHierarchy) || config.priorityHierarchy.length === 0) {
     errors.push('priorityHierarchy must be a non-empty array');
-  } else if (config.labels && config.labels.priority) {
-    const priorityValues = Object.values(config.labels.priority);
+  } else {
+    const seen = new Set();
     for (const entry of config.priorityHierarchy) {
-      if (!priorityValues.includes(entry)) {
-        errors.push(`priorityHierarchy entry "${entry}" not found in labels.priority values`);
+      if (seen.has(entry)) {
+        errors.push(`priorityHierarchy entry "${entry}" appears more than once`);
+      }
+      seen.add(entry);
+    }
+    if (config.labels && config.labels.priority) {
+      const priorityValues = Object.values(config.labels.priority);
+      for (const entry of config.priorityHierarchy) {
+        if (!priorityValues.includes(entry)) {
+          errors.push(`priorityHierarchy entry "${entry}" not found in labels.priority values`);
+        }
       }
     }
   }
@@ -330,8 +348,9 @@ function buildConstants(config) {
 
   const SKILL_PREREQUISITES = {};
   for (const [key, value] of Object.entries(config.skillPrerequisites)) {
-    SKILL_PREREQUISITES[key] = { ...value };
+    SKILL_PREREQUISITES[key] = Object.freeze({ ...value });
   }
+  Object.freeze(SKILL_PREREQUISITES);
 
   return {
     MAINTAINER_TEAM: config.maintainerTeam,

--- a/.github/scripts/helpers/constants.js
+++ b/.github/scripts/helpers/constants.js
@@ -4,55 +4,45 @@
 //
 // Shared constants for bot scripts: maintainer team, labels, issue state.
 
+const { loadAutomationConfig, buildConstants } = require('./config-loader');
+
+/**
+ * Parsed and validated automation config loaded from .github/hiero-automation.json.
+ * Exposed for modules that need access to nested config values (e.g. assignment limits).
+ */
+const AUTOMATION_CONFIG = loadAutomationConfig();
+
+/**
+ * Derived constants built from the automation config. Preserves the flat
+ * constant shapes (MAINTAINER_TEAM, LABELS, SKILL_HIERARCHY, etc.) that
+ * the rest of the bot scripts expect.
+ */
+const derived = buildConstants(AUTOMATION_CONFIG);
+
 /**
  * Team to tag when manual intervention is needed.
  */
-const MAINTAINER_TEAM = '@hiero-ledger/hiero-sdk-cpp-maintainers';
+const MAINTAINER_TEAM = derived.MAINTAINER_TEAM;
+
+/**
+ * Team to tag in Good First Issue welcome comments.
+ */
+const GFI_SUPPORT_TEAM = derived.GFI_SUPPORT_TEAM;
 
 /**
  * Common label constants used across bot scripts.
  */
-const LABELS = Object.freeze({
-  // Status labels
-  AWAITING_TRIAGE: 'status: awaiting triage',
-  READY_FOR_DEV: 'status: ready for dev',
-  IN_PROGRESS: 'status: in progress',
-  BLOCKED: 'status: blocked',
-  NEEDS_REVIEW: 'status: needs review',
-  NEEDS_REVISION: 'status: needs revision',
-
-  // Skill level labels
-  GOOD_FIRST_ISSUE: 'skill: good first issue',
-  BEGINNER: 'skill: beginner',
-  INTERMEDIATE: 'skill: intermediate',
-  ADVANCED: 'skill: advanced',
-
-  // Priority labels
-  PRIORITY_CRITICAL: 'priority: critical',
-  PRIORITY_HIGH: 'priority: high',
-  PRIORITY_MEDIUM: 'priority: medium',
-  PRIORITY_LOW: 'priority: low',
-});
+const LABELS = derived.LABELS;
 
 /**
  * Skill hierarchy used to determine progression for recommendations.
  */
-const SKILL_HIERARCHY = Object.freeze([
-    LABELS.GOOD_FIRST_ISSUE,
-    LABELS.BEGINNER,
-    LABELS.INTERMEDIATE,
-    LABELS.ADVANCED,
-]);
+const SKILL_HIERARCHY = derived.SKILL_HIERARCHY;
 
 /**
  * Priority hierarchy for issue recommendations.
  */
-const PRIORITY_HIERARCHY = Object.freeze([
-    LABELS.PRIORITY_CRITICAL,
-    LABELS.PRIORITY_HIGH,
-    LABELS.PRIORITY_MEDIUM,
-    LABELS.PRIORITY_LOW,
-]);
+const PRIORITY_HIERARCHY = derived.PRIORITY_HIERARCHY;
 
 /**
  * Issue state values for GitHub search queries.
@@ -72,37 +62,29 @@ const ISSUE_STATE = Object.freeze({
  * Progression: Good First Issue (no prereqs) -> Beginner (2 GFI) -> Intermediate (3 Beginner) -> Advanced (3 Intermediate).
  * @type {Object<string, { requiredLabel: string|null, requiredCount: number, displayName: string, prerequisiteDisplayName?: string }>}
  */
-const SKILL_PREREQUISITES = {
-  [LABELS.GOOD_FIRST_ISSUE]: {
-    requiredLabel: null,
-    requiredCount: 0,
-    displayName: "Good First Issue",
-  },
-  [LABELS.BEGINNER]: {
-    requiredLabel: LABELS.GOOD_FIRST_ISSUE,
-    requiredCount: 2,
-    displayName: "Beginner",
-    prerequisiteDisplayName: "Good First Issues",
-  },
-  [LABELS.INTERMEDIATE]: {
-    requiredLabel: LABELS.BEGINNER,
-    requiredCount: 3,
-    displayName: "Intermediate",
-    prerequisiteDisplayName: "Beginner Issues",
-  },
-  [LABELS.ADVANCED]: {
-    requiredLabel: LABELS.INTERMEDIATE,
-    requiredCount: 3,
-    displayName: "Advanced",
-    prerequisiteDisplayName: "Intermediate Issues",
-  },
-};
+const SKILL_PREREQUISITES = derived.SKILL_PREREQUISITES;
+
+/**
+ * Documentation links loaded from the automation config.
+ * @type {{ workflowGuide: string, readme: string, signingGuide: string, mergeConflictsGuide: string }}
+ */
+const DOCUMENTATION = derived.DOCUMENTATION;
+
+/**
+ * Community links loaded from the automation config.
+ * @type {{ discordChannel: string }}
+ */
+const COMMUNITY = derived.COMMUNITY;
 
 module.exports = {
   MAINTAINER_TEAM,
+  GFI_SUPPORT_TEAM,
   LABELS,
   ISSUE_STATE,
   SKILL_HIERARCHY,
   SKILL_PREREQUISITES,
   PRIORITY_HIERARCHY,
+  DOCUMENTATION,
+  COMMUNITY,
+  AUTOMATION_CONFIG,
 };

--- a/.github/scripts/tests/test-config-loader.js
+++ b/.github/scripts/tests/test-config-loader.js
@@ -1,0 +1,557 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// tests/test-config-loader.js
+//
+// Unit tests for helpers/config-loader.js
+// Run with: node .github/scripts/tests/test-config-loader.js
+//
+// Tests cover:
+//   - Valid config loading and constant building
+//   - Missing config file error
+//   - Malformed JSON error
+//   - Validation errors for every required field and cross-reference
+
+const fs = require('fs');
+const path = require('path');
+const { runTestSuite } = require('./test-utils');
+const { loadAutomationConfig, buildConstants, DEFAULT_CONFIG_PATH } = require('../helpers/config-loader');
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+const SCRATCH_DIR = path.resolve(__dirname, '.config-loader-scratch');
+
+/**
+ * Returns a deep clone of the production config for use as a valid baseline.
+ * Tests mutate this clone to create invalid configs without touching the real file.
+ */
+function getValidConfig() {
+  const raw = fs.readFileSync(DEFAULT_CONFIG_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+
+/**
+ * Writes a config object to a temporary file and returns the path.
+ * @param {string} name - Filename (no directory).
+ * @param {object|string} content - Object (JSON-serialized) or raw string.
+ * @returns {string} Absolute path to the temp file.
+ */
+function writeTempConfig(name, content) {
+  if (!fs.existsSync(SCRATCH_DIR)) {
+    fs.mkdirSync(SCRATCH_DIR, { recursive: true });
+  }
+  const filePath = path.join(SCRATCH_DIR, name);
+  const data = typeof content === 'string' ? content : JSON.stringify(content, null, 2);
+  fs.writeFileSync(filePath, data, 'utf8');
+  return filePath;
+}
+
+/**
+ * Removes the scratch directory and all temp files.
+ */
+function cleanupScratch() {
+  if (fs.existsSync(SCRATCH_DIR)) {
+    for (const file of fs.readdirSync(SCRATCH_DIR)) {
+      fs.unlinkSync(path.join(SCRATCH_DIR, file));
+    }
+    fs.rmdirSync(SCRATCH_DIR);
+  }
+}
+
+/**
+ * Asserts that loadAutomationConfig throws an error containing the expected substring.
+ * @param {string} configPath - Path to the temp config file.
+ * @param {string} expectedSubstring - Expected substring in the error message.
+ * @returns {boolean}
+ */
+function expectLoadError(configPath, expectedSubstring) {
+  try {
+    loadAutomationConfig(configPath);
+    return false;
+  } catch (err) {
+    if (!err.message.includes(expectedSubstring)) {
+      console.log(`    Expected error containing: "${expectedSubstring}"`);
+      console.log(`    Got: "${err.message}"`);
+      return false;
+    }
+    return true;
+  }
+}
+
+// =============================================================================
+// UNIT TESTS
+// =============================================================================
+
+const unitTests = [
+
+  // ---------------------------------------------------------------------------
+  // Valid config loading
+  // ---------------------------------------------------------------------------
+  {
+    name: 'loadAutomationConfig: loads production config without error',
+    test: () => {
+      const config = loadAutomationConfig(DEFAULT_CONFIG_PATH);
+      return config !== null && typeof config === 'object';
+    },
+  },
+  {
+    name: 'loadAutomationConfig: returns a frozen object',
+    test: () => {
+      const config = loadAutomationConfig(DEFAULT_CONFIG_PATH);
+      return Object.isFrozen(config);
+    },
+  },
+  {
+    name: 'buildConstants: produces MAINTAINER_TEAM string',
+    test: () => {
+      const config = loadAutomationConfig(DEFAULT_CONFIG_PATH);
+      const derived = buildConstants(config);
+      return derived.MAINTAINER_TEAM === '@hiero-ledger/hiero-sdk-cpp-maintainers';
+    },
+  },
+  {
+    name: 'buildConstants: produces GFI_SUPPORT_TEAM string',
+    test: () => {
+      const config = loadAutomationConfig(DEFAULT_CONFIG_PATH);
+      const derived = buildConstants(config);
+      return derived.GFI_SUPPORT_TEAM === '@hiero-ledger/hiero-sdk-good-first-issue-support';
+    },
+  },
+  {
+    name: 'buildConstants: LABELS has all expected keys',
+    test: () => {
+      const config = loadAutomationConfig(DEFAULT_CONFIG_PATH);
+      const { LABELS } = buildConstants(config);
+      const expectedKeys = [
+        'AWAITING_TRIAGE', 'READY_FOR_DEV', 'IN_PROGRESS', 'BLOCKED',
+        'NEEDS_REVIEW', 'NEEDS_REVISION',
+        'GOOD_FIRST_ISSUE', 'BEGINNER', 'INTERMEDIATE', 'ADVANCED',
+        'PRIORITY_CRITICAL', 'PRIORITY_HIGH', 'PRIORITY_MEDIUM', 'PRIORITY_LOW',
+      ];
+      return expectedKeys.every(k => typeof LABELS[k] === 'string' && LABELS[k].length > 0);
+    },
+  },
+  {
+    name: 'buildConstants: LABELS is frozen',
+    test: () => {
+      const config = loadAutomationConfig(DEFAULT_CONFIG_PATH);
+      const { LABELS } = buildConstants(config);
+      return Object.isFrozen(LABELS);
+    },
+  },
+  {
+    name: 'buildConstants: SKILL_HIERARCHY matches config order',
+    test: () => {
+      const config = loadAutomationConfig(DEFAULT_CONFIG_PATH);
+      const { SKILL_HIERARCHY, LABELS } = buildConstants(config);
+      return (
+        SKILL_HIERARCHY.length === 4 &&
+        SKILL_HIERARCHY[0] === LABELS.GOOD_FIRST_ISSUE &&
+        SKILL_HIERARCHY[3] === LABELS.ADVANCED
+      );
+    },
+  },
+  {
+    name: 'buildConstants: PRIORITY_HIERARCHY matches config order',
+    test: () => {
+      const config = loadAutomationConfig(DEFAULT_CONFIG_PATH);
+      const { PRIORITY_HIERARCHY, LABELS } = buildConstants(config);
+      return (
+        PRIORITY_HIERARCHY.length === 4 &&
+        PRIORITY_HIERARCHY[0] === LABELS.PRIORITY_CRITICAL &&
+        PRIORITY_HIERARCHY[3] === LABELS.PRIORITY_LOW
+      );
+    },
+  },
+  {
+    name: 'buildConstants: SKILL_PREREQUISITES has correct progression',
+    test: () => {
+      const config = loadAutomationConfig(DEFAULT_CONFIG_PATH);
+      const { SKILL_PREREQUISITES, LABELS } = buildConstants(config);
+      return (
+        SKILL_PREREQUISITES[LABELS.GOOD_FIRST_ISSUE].requiredLabel === null &&
+        SKILL_PREREQUISITES[LABELS.BEGINNER].requiredLabel === LABELS.GOOD_FIRST_ISSUE &&
+        SKILL_PREREQUISITES[LABELS.BEGINNER].requiredCount === 2 &&
+        SKILL_PREREQUISITES[LABELS.INTERMEDIATE].requiredLabel === LABELS.BEGINNER &&
+        SKILL_PREREQUISITES[LABELS.INTERMEDIATE].requiredCount === 3 &&
+        SKILL_PREREQUISITES[LABELS.ADVANCED].requiredLabel === LABELS.INTERMEDIATE &&
+        SKILL_PREREQUISITES[LABELS.ADVANCED].requiredCount === 3
+      );
+    },
+  },
+  {
+    name: 'buildConstants: DOCUMENTATION has all expected keys',
+    test: () => {
+      const config = loadAutomationConfig(DEFAULT_CONFIG_PATH);
+      const { DOCUMENTATION } = buildConstants(config);
+      return (
+        typeof DOCUMENTATION.workflowGuide === 'string' &&
+        typeof DOCUMENTATION.readme === 'string' &&
+        typeof DOCUMENTATION.signingGuide === 'string' &&
+        typeof DOCUMENTATION.mergeConflictsGuide === 'string'
+      );
+    },
+  },
+  {
+    name: 'buildConstants: COMMUNITY has discordChannel',
+    test: () => {
+      const config = loadAutomationConfig(DEFAULT_CONFIG_PATH);
+      const { COMMUNITY } = buildConstants(config);
+      return typeof COMMUNITY.discordChannel === 'string' && COMMUNITY.discordChannel.length > 0;
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // File-level errors
+  // ---------------------------------------------------------------------------
+  {
+    name: 'loadAutomationConfig: missing file → clear error',
+    test: () => {
+      return expectLoadError('/nonexistent/path/config.json', 'Failed to read automation config');
+    },
+  },
+  {
+    name: 'loadAutomationConfig: malformed JSON → clear error',
+    test: () => {
+      const p = writeTempConfig('malformed.json', '{ broken json!!!');
+      return expectLoadError(p, 'Failed to parse automation config');
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Validation: teams
+  // ---------------------------------------------------------------------------
+  {
+    name: 'validation: missing maintainerTeam → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.maintainerTeam;
+      const p = writeTempConfig('no-team.json', cfg);
+      return expectLoadError(p, 'maintainerTeam must be a non-empty string');
+    },
+  },
+  {
+    name: 'validation: empty goodFirstIssueSupportTeam → error',
+    test: () => {
+      const cfg = getValidConfig();
+      cfg.goodFirstIssueSupportTeam = '';
+      const p = writeTempConfig('empty-gfi-team.json', cfg);
+      return expectLoadError(p, 'goodFirstIssueSupportTeam must be a non-empty string');
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Validation: labels
+  // ---------------------------------------------------------------------------
+  {
+    name: 'validation: missing labels → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.labels;
+      const p = writeTempConfig('no-labels.json', cfg);
+      return expectLoadError(p, 'labels must be an object');
+    },
+  },
+  {
+    name: 'validation: missing labels.skill → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.labels.skill;
+      const p = writeTempConfig('no-skill-labels.json', cfg);
+      return expectLoadError(p, 'labels.skill must be an object');
+    },
+  },
+  {
+    name: 'validation: empty label value → error',
+    test: () => {
+      const cfg = getValidConfig();
+      cfg.labels.status.awaitingTriage = '';
+      const p = writeTempConfig('empty-label.json', cfg);
+      return expectLoadError(p, 'labels.status.awaitingTriage is required and must be a non-empty string');
+    },
+  },
+  {
+    name: 'validation: missing required status key (blocked) → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.labels.status.blocked;
+      const p = writeTempConfig('no-blocked.json', cfg);
+      return expectLoadError(p, 'labels.status.blocked is required and must be a non-empty string');
+    },
+  },
+  {
+    name: 'validation: missing required skill key (beginner) → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.labels.skill.beginner;
+      const p = writeTempConfig('no-beginner.json', cfg);
+      return expectLoadError(p, 'labels.skill.beginner is required and must be a non-empty string');
+    },
+  },
+  {
+    name: 'validation: missing required priority key (high) → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.labels.priority.high;
+      const p = writeTempConfig('no-high.json', cfg);
+      return expectLoadError(p, 'labels.priority.high is required and must be a non-empty string');
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Validation: hierarchies
+  // ---------------------------------------------------------------------------
+  {
+    name: 'validation: empty skillHierarchy → error',
+    test: () => {
+      const cfg = getValidConfig();
+      cfg.skillHierarchy = [];
+      const p = writeTempConfig('empty-skill-hier.json', cfg);
+      return expectLoadError(p, 'skillHierarchy must be a non-empty array');
+    },
+  },
+  {
+    name: 'validation: skillHierarchy entry not in labels.skill → error',
+    test: () => {
+      const cfg = getValidConfig();
+      cfg.skillHierarchy.push('skill: nonexistent');
+      const p = writeTempConfig('bad-skill-hier.json', cfg);
+      return expectLoadError(p, 'skillHierarchy entry "skill: nonexistent" not found in labels.skill values');
+    },
+  },
+  {
+    name: 'validation: priorityHierarchy entry not in labels.priority → error',
+    test: () => {
+      const cfg = getValidConfig();
+      cfg.priorityHierarchy.push('priority: ultra');
+      const p = writeTempConfig('bad-prio-hier.json', cfg);
+      return expectLoadError(p, 'priorityHierarchy entry "priority: ultra" not found in labels.priority values');
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Validation: skill prerequisites
+  // ---------------------------------------------------------------------------
+  {
+    name: 'validation: skillPrerequisites key not in skillHierarchy → error',
+    test: () => {
+      const cfg = getValidConfig();
+      cfg.skillPrerequisites['skill: phantom'] = { requiredLabel: null, requiredCount: 0, displayName: 'Phantom' };
+      const p = writeTempConfig('bad-prereq-key.json', cfg);
+      return expectLoadError(p, 'skillPrerequisites key "skill: phantom" not found in skillHierarchy');
+    },
+  },
+  {
+    name: 'validation: non-null requiredLabel not in skillHierarchy → error',
+    test: () => {
+      const cfg = getValidConfig();
+      cfg.skillPrerequisites['skill: beginner'].requiredLabel = 'skill: imaginary';
+      const p = writeTempConfig('bad-prereq-label.json', cfg);
+      return expectLoadError(p, 'requiredLabel "skill: imaginary" not found in skillHierarchy');
+    },
+  },
+  {
+    name: 'validation: skillHierarchy entry missing from skillPrerequisites → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.skillPrerequisites['skill: intermediate'];
+      const p = writeTempConfig('missing-prereq-entry.json', cfg);
+      return expectLoadError(p, 'skillPrerequisites is missing entry for skillHierarchy value "skill: intermediate"');
+    },
+  },
+  {
+    name: 'validation: prerequisite missing requiredLabel → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.skillPrerequisites['skill: good first issue'].requiredLabel;
+      const p = writeTempConfig('no-req-label.json', cfg);
+      return expectLoadError(p, 'requiredLabel is required');
+    },
+  },
+  {
+    name: 'validation: prerequisite missing requiredCount → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.skillPrerequisites['skill: beginner'].requiredCount;
+      const p = writeTempConfig('no-req-count.json', cfg);
+      return expectLoadError(p, 'requiredCount must be a non-negative integer');
+    },
+  },
+  {
+    name: 'validation: prerequisite missing displayName → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.skillPrerequisites['skill: advanced'].displayName;
+      const p = writeTempConfig('no-display-name.json', cfg);
+      return expectLoadError(p, 'displayName is required and must be a non-empty string');
+    },
+  },
+  {
+    name: 'validation: prerequisite missing prerequisiteDisplayName when requiredLabel is not null → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.skillPrerequisites['skill: intermediate'].prerequisiteDisplayName;
+      const p = writeTempConfig('no-prereq-display.json', cfg);
+      return expectLoadError(p, 'prerequisiteDisplayName is required when requiredLabel is not null');
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Validation: assignment limits
+  // ---------------------------------------------------------------------------
+  {
+    name: 'validation: missing assignmentLimits → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.assignmentLimits;
+      const p = writeTempConfig('no-limits.json', cfg);
+      return expectLoadError(p, 'assignmentLimits must be an object');
+    },
+  },
+  {
+    name: 'validation: maxOpenAssignments = 0 → error (must be positive)',
+    test: () => {
+      const cfg = getValidConfig();
+      cfg.assignmentLimits.maxOpenAssignments = 0;
+      const p = writeTempConfig('zero-limit.json', cfg);
+      return expectLoadError(p, 'maxOpenAssignments must be a positive integer');
+    },
+  },
+  {
+    name: 'validation: maxGfiCompletions = -1 → error (must be positive)',
+    test: () => {
+      const cfg = getValidConfig();
+      cfg.assignmentLimits.maxGfiCompletions = -1;
+      const p = writeTempConfig('neg-gfi.json', cfg);
+      return expectLoadError(p, 'maxGfiCompletions must be a positive integer');
+    },
+  },
+  {
+    name: 'validation: maxOpenAssignments = 1.5 → error (must be integer)',
+    test: () => {
+      const cfg = getValidConfig();
+      cfg.assignmentLimits.maxOpenAssignments = 1.5;
+      const p = writeTempConfig('float-limit.json', cfg);
+      return expectLoadError(p, 'maxOpenAssignments must be a positive integer');
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Validation: documentation
+  // ---------------------------------------------------------------------------
+  {
+    name: 'validation: missing documentation → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.documentation;
+      const p = writeTempConfig('no-docs.json', cfg);
+      return expectLoadError(p, 'documentation must be an object');
+    },
+  },
+  {
+    name: 'validation: empty documentation value → error',
+    test: () => {
+      const cfg = getValidConfig();
+      cfg.documentation.signingGuide = '';
+      const p = writeTempConfig('empty-doc.json', cfg);
+      return expectLoadError(p, 'documentation.signingGuide is required and must be a non-empty string');
+    },
+  },
+  {
+    name: 'validation: missing required documentation key (readme) → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.documentation.readme;
+      const p = writeTempConfig('no-readme-doc.json', cfg);
+      return expectLoadError(p, 'documentation.readme is required and must be a non-empty string');
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Validation: community
+  // ---------------------------------------------------------------------------
+  {
+    name: 'validation: missing community → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.community;
+      const p = writeTempConfig('no-community.json', cfg);
+      return expectLoadError(p, 'community must be an object');
+    },
+  },
+  {
+    name: 'validation: empty community value → error',
+    test: () => {
+      const cfg = getValidConfig();
+      cfg.community.discordChannel = '   ';
+      const p = writeTempConfig('empty-discord.json', cfg);
+      return expectLoadError(p, 'community.discordChannel is required and must be a non-empty string');
+    },
+  },
+  {
+    name: 'validation: missing required community key (discordChannel) → error',
+    test: () => {
+      const cfg = getValidConfig();
+      delete cfg.community.discordChannel;
+      const p = writeTempConfig('no-discord.json', cfg);
+      return expectLoadError(p, 'community.discordChannel is required and must be a non-empty string');
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Custom config with different values
+  // ---------------------------------------------------------------------------
+  {
+    name: 'loadAutomationConfig: loads a custom config with alternate values',
+    test: () => {
+      const cfg = getValidConfig();
+      cfg.maintainerTeam = '@my-org/my-team';
+      cfg.assignmentLimits.maxOpenAssignments = 5;
+      const p = writeTempConfig('custom.json', cfg);
+      const config = loadAutomationConfig(p);
+      const derived = buildConstants(config);
+      return (
+        derived.MAINTAINER_TEAM === '@my-org/my-team' &&
+        config.assignmentLimits.maxOpenAssignments === 5
+      );
+    },
+  },
+];
+
+// =============================================================================
+// TEST RUNNER
+// =============================================================================
+
+async function runUnitTests() {
+  console.log('🔬 UNIT TESTS (config-loader)');
+  console.log('='.repeat(70));
+  let passed = 0;
+  let failed = 0;
+  for (const test of unitTests) {
+    try {
+      const result = await Promise.resolve(test.test());
+      if (result) {
+        console.log(`✅ ${test.name}`);
+        passed++;
+      } else {
+        console.log(`❌ ${test.name}`);
+        failed++;
+      }
+    } catch (error) {
+      console.log(`❌ ${test.name} - Error: ${error.message}`);
+      failed++;
+    }
+  }
+  console.log('\n' + '-'.repeat(70));
+  console.log(`Unit Tests: ${passed} passed, ${failed} failed`);
+
+  // Cleanup scratch files
+  cleanupScratch();
+
+  return { total: unitTests.length, passed, failed };
+}
+
+runTestSuite('CONFIG LOADER TEST SUITE', [], async () => true, [
+  { label: 'Unit Tests', run: runUnitTests },
+]);

--- a/.github/scripts/tests/test-config-loader.js
+++ b/.github/scripts/tests/test-config-loader.js
@@ -329,6 +329,24 @@ const unitTests = [
       return expectLoadError(p, 'priorityHierarchy entry "priority: ultra" not found in labels.priority values');
     },
   },
+  {
+    name: 'validation: duplicate skillHierarchy entry → error',
+    test: () => {
+      const cfg = getValidConfig();
+      cfg.skillHierarchy.push(cfg.skillHierarchy[0]);
+      const p = writeTempConfig('dup-skill-hier.json', cfg);
+      return expectLoadError(p, 'appears more than once');
+    },
+  },
+  {
+    name: 'validation: duplicate priorityHierarchy entry → error',
+    test: () => {
+      const cfg = getValidConfig();
+      cfg.priorityHierarchy.push(cfg.priorityHierarchy[0]);
+      const p = writeTempConfig('dup-prio-hier.json', cfg);
+      return expectLoadError(p, 'appears more than once');
+    },
+  },
 
   // ---------------------------------------------------------------------------
   // Validation: skill prerequisites


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:
-->
Decouple repository-specific policy values from the reusable GitHub bot automation logic to enable easy migration and reuse across other SDK repositories.

* Extract maintainer team, GFI support team, labels, skill hierarchies, skill prerequisites, assignment limits, documentation URLs, and community links into a new `.github/hiero-automation.json` config file.
* Add `config-loader.js` to strictly validate the JSON config at startup.
* Update `constants.js` to map the nested config back into the flat constant shapes consumed by the rest of the bot scripts.
* Preserve zero import changes across the broader codebase.
* Add 42 unit tests covering valid loading, file errors, and validation of every required field and cross-reference.

**Related issue(s)**:

Fixes #1625

**Notes for reviewer**:
All 14 existing integration and unit test suites (319+ assertions) continue to pass entirely unchanged, guaranteeing zero functional changes to the bot's behavior or comment output.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)