### PR TITLE
CI: Automate PR feedback when CI lint/build/test checks fail

### DIFF
--- a/.github/scripts/bot-on-ci-result.js
+++ b/.github/scripts/bot-on-ci-result.js
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// bot-on-ci-result.js
+//
+// Runs when the PR Checks workflow completes. Updates the PR Helper Bot
+// dashboard with the CI result, flips failed CI back to needs-revision, and
+// pings the PR author once when CI transitions into failure.
+
+const {
+  MARKER,
+  buildCIFailureNotificationComment,
+  classifyWorkflowRunCI,
+  createLogger,
+  dashboardHasCIFailure,
+  getBotComment,
+  postComment,
+  resolveWorkflowRunPR,
+  runAllChecksAndComment,
+  swapStatusLabel,
+} = require('./helpers');
+
+const logger = createLogger('on-ci-result');
+
+function buildWorkflowRunBotContext({ github, context, pr }) {
+  return {
+    github,
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    eventType: context.eventName,
+    number: pr.number,
+    pr,
+  };
+}
+
+module.exports = async ({ github, context }) => {
+  try {
+    const workflowRun = context.payload.workflow_run;
+    if (!workflowRun) {
+      logger.log('Exit: missing workflow_run payload');
+      return;
+    }
+
+    if (workflowRun.conclusion === 'cancelled') {
+      logger.log('Exit: workflow run was cancelled');
+      return;
+    }
+
+    const baseContext = {
+      github,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+    };
+    const pr = await resolveWorkflowRunPR(baseContext, workflowRun);
+    if (!pr) {
+      logger.log('Exit: no pull request resolved for workflow_run');
+      return;
+    }
+
+    if (pr.draft) {
+      logger.log('Exit: draft PR');
+      return;
+    }
+
+    const botContext = buildWorkflowRunBotContext({ github, context, pr });
+    const existingDashboard = await getBotComment(botContext, MARKER);
+    const hadCIFailure = dashboardHasCIFailure(existingDashboard?.body);
+    const ci = await classifyWorkflowRunCI(botContext, workflowRun);
+
+    await runAllChecksAndComment(botContext, { ci });
+
+    if (!ci.failed) {
+      logger.log('CI did not fail; leaving status label unchanged');
+      return;
+    }
+
+    const labelResult = await swapStatusLabel(botContext, false, { force: true });
+    if (!labelResult.success) {
+      logger.error(`Failed to force-swap status label after CI failure: ${labelResult.errorDetails}`);
+    }
+
+    if (!hadCIFailure) {
+      const prAuthor = pr.user?.login;
+      const body = buildCIFailureNotificationComment(prAuthor, ci.runUrl);
+      await postComment(botContext, body);
+      logger.log('Posted CI failure notification comment');
+    }
+
+    logger.log('On-CI-result bot completed');
+  } catch (error) {
+    logger.error('Error:', {
+      message: error.message,
+      runId: context?.payload?.workflow_run?.id,
+    });
+    throw error;
+  }
+};

--- a/.github/scripts/helpers/api.js
+++ b/.github/scripts/helpers/api.js
@@ -540,6 +540,31 @@ function classifyFailedJob(job) {
   return { check: 'build', checkName: 'Build' };
 }
 
+async function fetchWorkflowRunJobs(botContext, workflowRunId) {
+  const jobs = [];
+  let page = 1;
+  const perPage = 100;
+
+  while (true) {
+    const { data } = await botContext.github.rest.actions.listJobsForWorkflowRun({
+      owner: botContext.owner,
+      repo: botContext.repo,
+      run_id: workflowRunId,
+      filter: 'latest',
+      per_page: perPage,
+      page,
+    });
+
+    const pageJobs = data.jobs || [];
+    jobs.push(...pageJobs);
+
+    if (pageJobs.length < perPage) break;
+    page++;
+  }
+
+  return jobs;
+}
+
 /**
  * Classifies the PR Checks workflow result into lint, build, or test failure.
  *
@@ -555,26 +580,7 @@ async function classifyWorkflowRunCI(botContext, workflowRun) {
   }
 
   try {
-    const jobs = [];
-    let page = 1;
-    const perPage = 100;
-
-    while (true) {
-      const { data } = await botContext.github.rest.actions.listJobsForWorkflowRun({
-        owner: botContext.owner,
-        repo: botContext.repo,
-        run_id: workflowRun.id,
-        filter: 'latest',
-        per_page: perPage,
-        page,
-      });
-
-      jobs.push(...(data.jobs || []));
-
-      if (!data.jobs || data.jobs.length < perPage) break;
-      page++;
-    }
-
+    const jobs = await fetchWorkflowRunJobs(botContext, workflowRun.id);
     const failedJob = jobs.find(job => job.conclusion === 'failure');
     const classification = failedJob ? classifyFailedJob(failedJob) : { check: 'build', checkName: 'Build' };
     return {

--- a/.github/scripts/helpers/api.js
+++ b/.github/scripts/helpers/api.js
@@ -478,6 +478,126 @@ async function fetchClosingIssueNumbers(botContext) {
 }
 
 /**
+ * Resolves the pull request associated with a completed workflow_run event.
+ * Same-repository PRs usually include workflow_run.pull_requests. Fork PRs can
+ * leave that array empty, so fall back to the head owner and branch.
+ *
+ * @param {object} botContext
+ * @param {object} workflowRun
+ * @returns {Promise<object|null>}
+ */
+async function resolveWorkflowRunPR(botContext, workflowRun) {
+  const pullRequest = workflowRun.pull_requests?.[0];
+  if (pullRequest?.number) {
+    const { data } = await botContext.github.rest.pulls.get({
+      owner: botContext.owner,
+      repo: botContext.repo,
+      pull_number: pullRequest.number,
+    });
+    return data;
+  }
+
+  const headBranch = workflowRun.head_branch;
+  const headOwner = workflowRun.head_repository?.owner?.login || workflowRun.repository?.owner?.login;
+  if (!headBranch || !headOwner || !isSafeSearchToken(headOwner) || !isSafeSearchToken(headBranch)) {
+    getLogger().log('Could not resolve workflow_run PR: missing or unsafe head owner/branch');
+    return null;
+  }
+
+  const { data } = await botContext.github.rest.pulls.list({
+    owner: botContext.owner,
+    repo: botContext.repo,
+    state: 'open',
+    head: `${headOwner}:${headBranch}`,
+    per_page: 100,
+  });
+
+  const match = data.find(pr => pr.head?.sha === workflowRun.head_sha) || data[0];
+  if (!match) {
+    getLogger().log('Could not resolve workflow_run PR from head branch', {
+      head: `${headOwner}:${headBranch}`,
+      headSha: workflowRun.head_sha,
+    });
+    return null;
+  }
+
+  return match;
+}
+
+function classifyFailedJob(job) {
+  const jobName = (job.name || '').toLowerCase();
+  const failedSteps = (job.steps || []).filter(step => step.conclusion === 'failure');
+  const failedText = [jobName, ...failedSteps.map(step => (step.name || '').toLowerCase())].join(' ');
+
+  if (failedText.includes('lint') || failedText.includes('clang-format')) {
+    return { check: 'lint', checkName: 'Lint' };
+  }
+
+  if (failedText.includes('ctest') || failedText.includes('test')) {
+    return { check: 'tests', checkName: 'Tests' };
+  }
+
+  return { check: 'build', checkName: 'Build' };
+}
+
+/**
+ * Classifies the PR Checks workflow result into lint, build, or test failure.
+ *
+ * @param {object} botContext
+ * @param {object} workflowRun
+ * @returns {Promise<{passed: boolean, failed: boolean, check: string|null, checkName: string|null, runUrl: string, error?: boolean, errorMessage?: string}>}
+ */
+async function classifyWorkflowRunCI(botContext, workflowRun) {
+  const runUrl = workflowRun.html_url || '';
+
+  if (workflowRun.conclusion === 'success') {
+    return { passed: true, failed: false, check: null, checkName: null, runUrl };
+  }
+
+  try {
+    const jobs = [];
+    let page = 1;
+    const perPage = 100;
+
+    while (true) {
+      const { data } = await botContext.github.rest.actions.listJobsForWorkflowRun({
+        owner: botContext.owner,
+        repo: botContext.repo,
+        run_id: workflowRun.id,
+        filter: 'latest',
+        per_page: perPage,
+        page,
+      });
+
+      jobs.push(...(data.jobs || []));
+
+      if (!data.jobs || data.jobs.length < perPage) break;
+      page++;
+    }
+
+    const failedJob = jobs.find(job => job.conclusion === 'failure');
+    const classification = failedJob ? classifyFailedJob(failedJob) : { check: 'build', checkName: 'Build' };
+    return {
+      passed: false,
+      failed: true,
+      ...classification,
+      runUrl,
+    };
+  } catch (error) {
+    getLogger().error(`Could not classify workflow_run CI result: ${error.message}`);
+    return {
+      passed: false,
+      failed: false,
+      check: null,
+      checkName: null,
+      runUrl,
+      error: true,
+      errorMessage: error.message,
+    };
+  }
+}
+
+/**
  * Fetches the latest open milestone for the repository.
  * Milestones with due dates are sorted by latest due_on. If none have due
  * dates, falls back to the highest milestone number.
@@ -622,7 +742,7 @@ async function acknowledgeComment(botContext, commentId) {
  * @returns {Promise<{ allPassed: boolean }>}
  */
 async function runAllChecksAndComment(botContext, precomputed = {}) {
-  let { dco, gpg, merge, issueLink } = precomputed;
+  let { dco, gpg, merge, issueLink, ci } = precomputed;
   let commits = [];
 
   try {
@@ -654,7 +774,7 @@ async function runAllChecksAndComment(botContext, precomputed = {}) {
   }
 
   const prAuthor = botContext.pr?.user?.login;
-  const { marker, body, allPassed } = buildBotComment({ prAuthor, dco, gpg, merge, issueLink });
+  const { marker, body, allPassed } = buildBotComment({ prAuthor, dco, gpg, merge, issueLink, ci });
   await postOrUpdateComment(botContext, marker, body);
 
   return { allPassed };
@@ -1115,6 +1235,8 @@ module.exports = {
   fetchOpenPRs,
   fetchIssue,
   fetchClosingIssueNumbers,
+  resolveWorkflowRunPR,
+  classifyWorkflowRunCI,
   fetchLatestMilestone,
   setMilestone,
   swapStatusLabel,

--- a/.github/scripts/helpers/comments.js
+++ b/.github/scripts/helpers/comments.js
@@ -111,6 +111,22 @@ function buildMergeConflictNotificationComment(prAuthor, mergedPRNumber) {
 }
 
 /**
+ * Builds a standalone notification comment to alert a PR author that CI failed.
+ * This is posted once when the dashboard transitions into a CI failure state.
+ *
+ * @param {string} prAuthor - GitHub username of the PR author.
+ * @param {string} runUrl - URL for the failing workflow run.
+ * @returns {string}
+ */
+function buildCIFailureNotificationComment(prAuthor, runUrl) {
+  return [
+    `Hi @${prAuthor} :wave: — the check just failed on this PR.`,
+    `Take a look at the [failing run](${runUrl}) and push a fix when you're ready.`,
+    'Feel free to ping the maintainers if you need a hand.',
+  ].join(' ');
+}
+
+/**
  * @param {{ passed: boolean, reason?: string, issues?: Array<{ number: number, title: string, isAssigned: boolean }>, error?: boolean, errorMessage?: string }} issueLink
  * @returns {string}
  */
@@ -138,11 +154,47 @@ function buildIssueLinkSection(issueLink) {
 }
 
 /**
- * Builds the ### PR Checks section of the dashboard comment.
- * @param {{ dco: object, gpg: object, merge: object, issueLink: object }} results
+ * @param {{ passed?: boolean, failed?: boolean, checkName?: string, runUrl?: string, error?: boolean, errorMessage?: string }} [ci]
  * @returns {string}
  */
-function buildChecksSection({ dco, gpg, merge, issueLink }) {
+function buildCISection(ci) {
+  if (!ci) {
+    return [
+      ':hourglass_flowing_sand: **CI Checks** -- Waiting for the PR Checks workflow to report.',
+      '',
+      'A maintainer will run CI after the PR helper checks pass.',
+    ].join('\n');
+  }
+
+  const common = buildSection({ title: 'CI Checks', result: ci, passMessage: 'All CI checks passed.' });
+  if (common) return common;
+
+  const checkName = ci.checkName || 'CI';
+  const runLink = ci.runUrl ? `[failing run](${ci.runUrl})` : 'failing run';
+  return [
+    `:x: **CI Checks** -- ${checkName} failed in the PR Checks workflow.`,
+    '',
+    `Please review the ${runLink}, push a fix, and rerun CI when you're ready.`,
+  ].join('\n');
+}
+
+/**
+ * Checks whether a dashboard body currently contains a CI failure section.
+ *
+ * @param {string} body
+ * @returns {boolean}
+ */
+function dashboardHasCIFailure(body) {
+  if (typeof body !== 'string') return false;
+  return body.includes(':x: **CI Checks**');
+}
+
+/**
+ * Builds the ### PR Checks section of the dashboard comment.
+ * @param {{ dco: object, gpg: object, merge: object, issueLink: object, ci?: object }} results
+ * @returns {string}
+ */
+function buildChecksSection({ dco, gpg, merge, issueLink, ci }) {
   return [
     '### PR Checks',
     '',
@@ -159,39 +211,45 @@ function buildChecksSection({ dco, gpg, merge, issueLink }) {
     '---',
     '',
     buildIssueLinkSection(issueLink),
+    '',
+    '---',
+    '',
+    buildCISection(ci),
   ].join('\n');
 }
 
 /**
  * Determines whether all checks passed (errors count as not passed).
- * @param {{ dco: object, gpg: object, merge: object, issueLink: object }} results
+ * @param {{ dco: object, gpg: object, merge: object, issueLink: object, ci?: object }} results
  * @returns {boolean}
  */
-function allChecksPassed({ dco, gpg, merge, issueLink }) {
+function allChecksPassed({ dco, gpg, merge, issueLink, ci }) {
   return (
     !dco.error && dco.passed &&
     !gpg.error && gpg.passed &&
     !merge.error && merge.passed &&
-    !issueLink.error && issueLink.passed
+    !issueLink.error && issueLink.passed &&
+    (!ci || (!ci.error && ci.passed))
   );
 }
 
 /**
  * Builds the full unified bot comment.
- * @param {{ prAuthor: string, dco: object, gpg: object, merge: object, issueLink: object }} params
+ * @param {{ prAuthor: string, dco: object, gpg: object, merge: object, issueLink: object, ci?: object }} params
  * @returns {{ marker: string, body: string, allPassed: boolean }}
  */
-function buildBotComment({ prAuthor, dco, gpg, merge, issueLink }) {
+function buildBotComment({ prAuthor, dco, gpg, merge, issueLink, ci }) {
   const greeting = [
     `Hey @${prAuthor} :wave: thanks for the PR!`,
     "I'm your friendly **PR Helper Bot** :robot: and I'll be riding shotgun on this one, keeping track of your PR's status to help you get it approved and merged.",
     '',
     "This comment updates automatically as you push changes -- think of it as your PR's live scoreboard!",
+    '`status: needs review` means the checks are clear for maintainer review; `status: needs revision` means something below needs your attention.',
     "Here's the latest:",
   ].join('\n');
 
-  const checksSection = buildChecksSection({ dco, gpg, merge, issueLink });
-  const passed = allChecksPassed({ dco, gpg, merge, issueLink });
+  const checksSection = buildChecksSection({ dco, gpg, merge, issueLink, ci });
+  const passed = allChecksPassed({ dco, gpg, merge, issueLink, ci });
 
   const footer = passed
     ? ':tada: *All checks passed! Your PR is ready for review. Great job!*'
@@ -206,5 +264,8 @@ module.exports = {
   buildBotComment,
   buildChecksSection,
   allChecksPassed,
+  buildCISection,
+  dashboardHasCIFailure,
   buildMergeConflictNotificationComment,
+  buildCIFailureNotificationComment,
 };

--- a/.github/scripts/helpers/comments.js
+++ b/.github/scripts/helpers/comments.js
@@ -224,13 +224,9 @@ function buildChecksSection({ dco, gpg, merge, issueLink, ci }) {
  * @returns {boolean}
  */
 function allChecksPassed({ dco, gpg, merge, issueLink, ci }) {
-  return (
-    !dco.error && dco.passed &&
-    !gpg.error && gpg.passed &&
-    !merge.error && merge.passed &&
-    !issueLink.error && issueLink.passed &&
-    (!ci || (!ci.error && ci.passed))
-  );
+  const requiredChecks = [dco, gpg, merge, issueLink];
+  const checks = ci ? [...requiredChecks, ci] : requiredChecks;
+  return checks.every(check => !check.error && check.passed);
 }
 
 /**

--- a/.github/scripts/tests/test-api.js
+++ b/.github/scripts/tests/test-api.js
@@ -13,6 +13,8 @@ const {
   fetchOpenPRs,
   fetchIssue,
   fetchClosingIssueNumbers,
+  resolveWorkflowRunPR,
+  classifyWorkflowRunCI,
   fetchLatestMilestone,
   setMilestone,
   swapStatusLabel,
@@ -75,17 +77,30 @@ function createMockBotContext(overrides = {}) {
             },
           },
           pulls: {
-            list: async ({ page, per_page }) => {
+            list: async ({ page = 1, per_page = 100 }) => {
               const allPRs = overrides.openPRs || [];
               const start = (page - 1) * per_page;
               const slice = allPRs.slice(start, start + per_page);
               return { data: slice };
+            },
+            get: async ({ pull_number }) => {
+              const pr = (overrides.pullRequests || {})[pull_number];
+              if (!pr) throw new Error('PR Not Found');
+              return { data: pr };
             },
             listCommits: async ({ page, per_page }) => {
               const allCommits = overrides.commits || [];
               const start = (page - 1) * per_page;
               const slice = allCommits.slice(start, start + per_page);
               return { data: slice };
+            },
+          },
+          actions: {
+            listJobsForWorkflowRun: async ({ page, per_page }) => {
+              const allJobs = overrides.workflowJobs || [];
+              const start = (page - 1) * per_page;
+              const slice = allJobs.slice(start, start + per_page);
+              return { data: { jobs: slice } };
             },
           },
         },
@@ -487,6 +502,107 @@ const unitTests = [
       });
       const result = await fetchClosingIssueNumbers(botContext);
       return Array.isArray(result) && result.length === 0;
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // resolveWorkflowRunPR
+  // ---------------------------------------------------------------------------
+  {
+    name: 'resolveWorkflowRunPR: uses pull_requests array when present',
+    test: async () => {
+      const pr = { number: 12, title: 'Same repo PR' };
+      const { botContext } = createMockBotContext({
+        pullRequests: { 12: pr },
+      });
+      const result = await resolveWorkflowRunPR(botContext, {
+        pull_requests: [{ number: 12 }],
+      });
+      return result === pr;
+    },
+  },
+  {
+    name: 'resolveWorkflowRunPR: falls back to fork head branch and SHA',
+    test: async () => {
+      const pr = {
+        number: 34,
+        title: 'Fork PR',
+        head: { sha: 'abc123' },
+      };
+      const { botContext } = createMockBotContext({
+        openPRs: [pr],
+      });
+      const result = await resolveWorkflowRunPR(botContext, {
+        pull_requests: [],
+        head_branch: 'feature/ci',
+        head_sha: 'abc123',
+        head_repository: { owner: { login: 'contributor' } },
+      });
+      return result === pr;
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // classifyWorkflowRunCI
+  // ---------------------------------------------------------------------------
+  {
+    name: 'classifyWorkflowRunCI: successful workflow passes',
+    test: async () => {
+      const { botContext } = createMockBotContext();
+      const result = await classifyWorkflowRunCI(botContext, {
+        id: 1,
+        conclusion: 'success',
+        html_url: 'https://github.com/run',
+      });
+      return result.passed === true && result.failed === false && result.check === null;
+    },
+  },
+  {
+    name: 'classifyWorkflowRunCI: lint job failure returns lint',
+    test: async () => {
+      const { botContext } = createMockBotContext({
+        workflowJobs: [
+          { name: 'Code / Lint', conclusion: 'failure', steps: [{ name: 'Run Clang-Format', conclusion: 'failure' }] },
+        ],
+      });
+      const result = await classifyWorkflowRunCI(botContext, {
+        id: 1,
+        conclusion: 'failure',
+        html_url: 'https://github.com/run',
+      });
+      return result.failed === true && result.check === 'lint' && result.checkName === 'Lint';
+    },
+  },
+  {
+    name: 'classifyWorkflowRunCI: CTest step failure returns tests',
+    test: async () => {
+      const { botContext } = createMockBotContext({
+        workflowJobs: [
+          { name: 'Code / Build', conclusion: 'failure', steps: [{ name: 'Start CTest suite (Debug)', conclusion: 'failure' }] },
+        ],
+      });
+      const result = await classifyWorkflowRunCI(botContext, {
+        id: 1,
+        conclusion: 'failure',
+        html_url: 'https://github.com/run',
+      });
+      return result.failed === true && result.check === 'tests' && result.checkName === 'Tests';
+    },
+  },
+  {
+    name: 'classifyWorkflowRunCI: CMake build step failure returns build',
+    test: async () => {
+      const { botContext } = createMockBotContext({
+        workflowJobs: [
+          { name: 'Code / Build', conclusion: 'failure', steps: [{ name: 'CMake Build (Debug)', conclusion: 'failure' }] },
+        ],
+      });
+      const result = await classifyWorkflowRunCI(botContext, {
+        id: 1,
+        conclusion: 'failure',
+        html_url: 'https://github.com/run',
+      });
+      return result.failed === true && result.check === 'build' && result.checkName === 'Build';
     },
   },
 

--- a/.github/scripts/tests/test-comments.js
+++ b/.github/scripts/tests/test-comments.js
@@ -6,7 +6,16 @@
 // Run with: node .github/scripts/tests/test-comments.js
 
 const { runTestSuite } = require('./test-utils');
-const { MARKER, buildBotComment, buildChecksSection, allChecksPassed, buildMergeConflictNotificationComment } = require('../helpers/comments');
+const {
+  MARKER,
+  buildBotComment,
+  buildChecksSection,
+  allChecksPassed,
+  buildCISection,
+  dashboardHasCIFailure,
+  buildMergeConflictNotificationComment,
+  buildCIFailureNotificationComment,
+} = require('../helpers/comments');
 
 // =============================================================================
 // TEST DATA HELPERS
@@ -400,6 +409,64 @@ const unitTests = [
   },
 
   // ---------------------------------------------------------------------------
+  // CI section
+  // ---------------------------------------------------------------------------
+  {
+    name: 'CI pending: dashboard contains waiting message',
+    test: () => {
+      const { body } = buildBotComment({ prAuthor: 'ci-pending', ...allPassing() });
+      return body.includes('**CI Checks**') && body.includes('Waiting for the PR Checks workflow');
+    },
+  },
+  {
+    name: 'CI pass: dashboard contains CI success',
+    test: () => {
+      const { body, allPassed } = buildBotComment({
+        prAuthor: 'ci-pass',
+        ...allPassing(),
+        ci: { passed: true, failed: false },
+      });
+      return allPassed === true && body.includes(':white_check_mark: **CI Checks**');
+    },
+  },
+  {
+    name: 'CI failure: dashboard contains failing run link and fails allPassed',
+    test: () => {
+      const { body, allPassed } = buildBotComment({
+        prAuthor: 'ci-fail',
+        ...allPassing(),
+        ci: {
+          passed: false,
+          failed: true,
+          checkName: 'Tests',
+          runUrl: 'https://github.com/hiero-ledger/hiero-sdk-cpp/actions/runs/1',
+        },
+      });
+      return (
+        allPassed === false &&
+        body.includes(':x: **CI Checks**') &&
+        body.includes('Tests failed') &&
+        body.includes('actions/runs/1')
+      );
+    },
+  },
+  {
+    name: 'CI error: dashboard tags maintainers',
+    test: () => {
+      const section = buildCISection({ passed: false, error: true, errorMessage: 'API error' });
+      return section.includes(':warning: **CI Checks**') && section.includes('@hiero-ledger/hiero-sdk-cpp-maintainers');
+    },
+  },
+  {
+    name: 'dashboardHasCIFailure: detects CI failure section',
+    test: () => dashboardHasCIFailure(':x: **CI Checks** -- Tests failed') === true,
+  },
+  {
+    name: 'dashboardHasCIFailure: ignores non-CI failure sections',
+    test: () => dashboardHasCIFailure(':x: **DCO Sign-off** -- Missing sign-off') === false,
+  },
+
+  // ---------------------------------------------------------------------------
   // buildMergeConflictNotificationComment
   // ---------------------------------------------------------------------------
   {
@@ -428,6 +495,13 @@ const unitTests = [
     test: () => {
       const comment = buildMergeConflictNotificationComment('dave', 99);
       return comment.includes('resolve the merge conflict');
+    },
+  },
+  {
+    name: 'CI failure notification contains @prAuthor and run link',
+    test: () => {
+      const comment = buildCIFailureNotificationComment('erin', 'https://github.com/run');
+      return comment.includes('@erin') && comment.includes('https://github.com/run');
     },
   },
 ];

--- a/.github/scripts/tests/test-on-ci-result-bot.js
+++ b/.github/scripts/tests/test-on-ci-result-bot.js
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// tests/test-on-ci-result-bot.js
+//
+// Integration tests for bot-on-ci-result.js.
+// Run with: node .github/scripts/tests/test-on-ci-result-bot.js
+
+const { runTestSuite, commitDCOAndGPG } = require('./test-utils');
+const script = require('../bot-on-ci-result.js');
+const { LABELS } = require('../helpers/constants');
+const { MARKER } = require('../helpers/comments');
+
+function createMockGithub({
+  pr = defaultPR(),
+  existingComments = [],
+  workflowJobs = [],
+  closingIssueNumbers = [42],
+} = {}) {
+  const calls = {
+    commentsCreated: [],
+    commentsUpdated: [],
+    labelsAdded: [],
+    labelsRemoved: [],
+  };
+
+  return {
+    calls,
+    rest: {
+      actions: {
+        listJobsForWorkflowRun: async () => ({ data: { jobs: workflowJobs } }),
+      },
+      pulls: {
+        get: async () => ({
+          data: {
+            ...pr,
+            mergeable: true,
+            mergeable_state: 'clean',
+          },
+        }),
+        list: async () => ({ data: [pr] }),
+        listCommits: async () => ({
+          data: [commitDCOAndGPG('abc123', 'feat: test')],
+        }),
+      },
+      issues: {
+        listComments: async () => ({ data: existingComments }),
+        createComment: async ({ body }) => {
+          calls.commentsCreated.push(body);
+          return {};
+        },
+        updateComment: async ({ body }) => {
+          calls.commentsUpdated.push(body);
+          return {};
+        },
+        addLabels: async ({ labels }) => {
+          calls.labelsAdded.push(...labels);
+          return {};
+        },
+        removeLabel: async ({ name }) => {
+          calls.labelsRemoved.push(name);
+          return {};
+        },
+        get: async () => ({
+          data: {
+            number: 42,
+            assignees: [{ login: pr.user.login }],
+          },
+        }),
+      },
+    },
+    graphql: async () => ({
+      repository: {
+        pullRequest: {
+          closingIssuesReferences: {
+            nodes: closingIssueNumbers.map(number => ({ number })),
+          },
+        },
+      },
+    }),
+  };
+}
+
+function defaultPR(overrides = {}) {
+  return {
+    number: 100,
+    draft: false,
+    user: { login: 'contributor', type: 'User' },
+    labels: [{ name: LABELS.NEEDS_REVIEW }],
+    head: { sha: 'abc123' },
+    ...overrides,
+  };
+}
+
+function defaultContext(overrides = {}) {
+  return {
+    eventName: 'workflow_run',
+    repo: { owner: 'test-owner', repo: 'test-repo' },
+    payload: {
+      workflow_run: {
+        id: 123,
+        conclusion: 'failure',
+        html_url: 'https://github.com/test-owner/test-repo/actions/runs/123',
+        pull_requests: [{ number: 100 }],
+        head_branch: 'feature/ci',
+        head_sha: 'abc123',
+        head_repository: { owner: { login: 'contributor' } },
+      },
+    },
+    ...overrides,
+  };
+}
+
+function dashboardBody(ciLine) {
+  return [MARKER, 'Existing dashboard', ciLine].join('\n');
+}
+
+const scenarios = [
+  {
+    name: 'CI failure updates dashboard, flips label, and pings on transition',
+    run: async () => {
+      const github = createMockGithub({
+        existingComments: [{ id: 1, body: dashboardBody(':white_check_mark: **CI Checks** -- All CI checks passed.') }],
+        workflowJobs: [
+          { name: 'Code / Lint', conclusion: 'failure', steps: [{ name: 'Run Clang-Format', conclusion: 'failure' }] },
+        ],
+      });
+
+      await script({ github, context: defaultContext() });
+
+      return (
+        github.calls.commentsUpdated.length === 1 &&
+        github.calls.commentsUpdated[0].includes(':x: **CI Checks**') &&
+        github.calls.labelsRemoved.includes(LABELS.NEEDS_REVIEW) &&
+        github.calls.labelsAdded.includes(LABELS.NEEDS_REVISION) &&
+        github.calls.commentsCreated.length === 1 &&
+        github.calls.commentsCreated[0].includes('@contributor')
+      );
+    },
+  },
+  {
+    name: 'Repeated CI failure does not post another ping',
+    run: async () => {
+      const github = createMockGithub({
+        existingComments: [{ id: 1, body: dashboardBody(':x: **CI Checks** -- Tests failed.') }],
+        workflowJobs: [
+          { name: 'Code / Build', conclusion: 'failure', steps: [{ name: 'Start CTest suite (Debug)', conclusion: 'failure' }] },
+        ],
+      });
+
+      await script({ github, context: defaultContext() });
+
+      return (
+        github.calls.commentsUpdated.length === 1 &&
+        github.calls.commentsUpdated[0].includes('Tests failed') &&
+        github.calls.commentsCreated.length === 0
+      );
+    },
+  },
+  {
+    name: 'CI success updates dashboard but leaves status label alone',
+    run: async () => {
+      const github = createMockGithub({
+        existingComments: [{ id: 1, body: dashboardBody(':x: **CI Checks** -- Build failed.') }],
+      });
+      const context = defaultContext({
+        payload: {
+          workflow_run: {
+            id: 124,
+            conclusion: 'success',
+            html_url: 'https://github.com/test-owner/test-repo/actions/runs/124',
+            pull_requests: [{ number: 100 }],
+            head_branch: 'feature/ci',
+            head_sha: 'abc123',
+            head_repository: { owner: { login: 'contributor' } },
+          },
+        },
+      });
+
+      await script({ github, context });
+
+      return (
+        github.calls.commentsUpdated.length === 1 &&
+        github.calls.commentsUpdated[0].includes(':white_check_mark: **CI Checks**') &&
+        github.calls.labelsAdded.length === 0 &&
+        github.calls.labelsRemoved.length === 0 &&
+        github.calls.commentsCreated.length === 0
+      );
+    },
+  },
+  {
+    name: 'Fork PR resolves through head branch fallback',
+    run: async () => {
+      const github = createMockGithub({
+        pr: defaultPR({ number: 101 }),
+        workflowJobs: [
+          { name: 'Code / Build', conclusion: 'failure', steps: [{ name: 'CMake Build (Debug)', conclusion: 'failure' }] },
+        ],
+      });
+      const context = defaultContext({
+        payload: {
+          workflow_run: {
+            id: 125,
+            conclusion: 'failure',
+            html_url: 'https://github.com/test-owner/test-repo/actions/runs/125',
+            pull_requests: [],
+            head_branch: 'feature/fork-ci',
+            head_sha: 'abc123',
+            head_repository: { owner: { login: 'fork-user' } },
+          },
+        },
+      });
+
+      await script({ github, context });
+
+      return (
+        github.calls.commentsUpdated.length === 0 &&
+        github.calls.commentsCreated.length === 2 &&
+        github.calls.commentsCreated[0].includes(':x: **CI Checks**') &&
+        github.calls.commentsCreated[1].includes('@contributor') &&
+        github.calls.labelsAdded.includes(LABELS.NEEDS_REVISION)
+      );
+    },
+  },
+];
+
+async function runScenario(scenario, index) {
+  console.log(`\nScenario ${index}: ${scenario.name}`);
+  try {
+    const passed = await scenario.run();
+    console.log(passed ? 'Passed' : 'Failed');
+    return passed;
+  } catch (error) {
+    console.log(`Failed with error: ${error.message}`);
+    console.log(error.stack);
+    return false;
+  }
+}
+
+runTestSuite('ON-CI-RESULT BOT TEST SUITE', scenarios, runScenario);

--- a/.github/workflows/on-ci-result.yaml
+++ b/.github/workflows/on-ci-result.yaml
@@ -1,0 +1,41 @@
+name: Bot - On CI Result
+
+# Runs after the top-level PR Checks workflow completes and updates the PR
+# Helper Bot dashboard with the latest CI result.
+on:
+  workflow_run:
+    workflows:
+      - PR Checks
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  actions: read
+
+jobs:
+  on-ci-result:
+    runs-on: hiero-client-sdk-linux-large
+    if: github.event.workflow_run.conclusion != 'cancelled'
+
+    concurrency:
+      group: pr-ci-result-${{ github.event.workflow_run.id }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Bot
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const script = require('./.github/scripts/bot-on-ci-result.js');
+            await script({ github, context });

--- a/.github/workflows/zxc-test-bot-scripts.yaml
+++ b/.github/workflows/zxc-test-bot-scripts.yaml
@@ -78,6 +78,9 @@ jobs:
 
       - name: Run On-PR-Close Bot Tests
         run: node .github/scripts/tests/test-on-pr-close-bot.js
+
+      - name: Run On-CI-Result Bot Tests
+        run: node .github/scripts/tests/test-on-ci-result-bot.js
          
       - name: Run On-Comment Bot Tests
         run: node .github/scripts/tests/test-on-comment-bot.js


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
Automate PR Helper Bot handling for completed PR Checks runs so contributors get dashboard feedback, status label updates, and a notification when CI fails.

- Added a CI-result workflow triggered by completed `PR Checks `runs
- Added bot logic to resolve the related PR, including fork PR fallback handling
- Added CI status rendering to the PR Helper Bot dashboard
- Classify failed CI runs as lint, build, or tests based on failed jobs/steps
- Force-swap failed PRs to `status: needs revision`
- Post a one-time contributor notification when CI transitions into failure
- Add unit and integration coverage for the new CI result behavior

**Related issue(s)**:

Fixes #1631 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Verified Locally.
**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
