### PR TITLE
fix: Remove redundant CODEOWNERS rule for `.github/workflows/`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,6 @@
 # Protection Rules for Github Configuration Files and Actions Workflows
 /.github/                                       @hiero-ledger/github-maintainers
 /.github/scripts/                               @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
-/.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
 
 # Cmake project files and inline plugins
 **/.clang*                                      @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers


### PR DESCRIPTION
## Summary

Removes the explicit `/.github/workflows/` entry from [.github/CODEOWNERS](.github/CODEOWNERS) so that workflow files inherit ownership from the broader `/.github/` rule, which is owned by `@hiero-ledger/github-maintainers`. This consolidates workflow ownership into a single, dedicated maintainer group and removes the SDK-cpp maintainer/committer co-ownership on workflow files.

**Key Changes:**

- Drop the `/.github/workflows/` rule from `.github/CODEOWNERS`
- Workflow files now fall under the existing `/.github/` rule (`@hiero-ledger/github-maintainers`)

## Motivation

The previous configuration assigned three teams to `/.github/workflows/` (`@hiero-ledger/github-maintainers`, `@hiero-ledger/hiero-sdk-cpp-maintainers`, `@hiero-ledger/hiero-sdk-cpp-committers`), which duplicated responsibilities already covered by the broader `/.github/` rule and required workflow PRs to collect reviews from teams that aren't the canonical owners of CI/workflow configuration. Funneling workflow ownership through `@hiero-ledger/github-maintainers` keeps the review responsibility with the team that maintains GitHub Actions for the org.

## Changes

### CODEOWNERS

Removed the dedicated workflows rule:

```diff
 /.github/                                       @hiero-ledger/github-maintainers
 /.github/scripts/                               @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
-/.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-cpp-maintainers @hiero-ledger/hiero-sdk-cpp-committers
```

After this change, ownership resolution for the `.github/` tree:

| Path | Owner(s) |
|------|----------|
| `/.github/scripts/` | `@hiero-ledger/hiero-sdk-cpp-maintainers`, `@hiero-ledger/hiero-sdk-cpp-committers` |
| `/.github/workflows/` | `@hiero-ledger/github-maintainers` (inherited from `/.github/`) |
| `/.github/` (everything else) | `@hiero-ledger/github-maintainers` |

## Testing

- [x] Verified the resulting CODEOWNERS file parses with no GitHub warnings
- [x] Confirmed the `/.github/scripts/` rule still takes precedence over the broader `/.github/` rule (CODEOWNERS last-match wins)
- [x] Confirmed `/.github/workflows/*` resolves to `@hiero-ledger/github-maintainers` under the broader `/.github/` rule

## Files Changed Summary

| Category | Files |
|----------|-------|
| Repo config | `.github/CODEOWNERS` |

## Breaking Changes

**None for code consumers.** This change only affects PR review routing:

- Workflow PRs no longer auto-request review from `@hiero-ledger/hiero-sdk-cpp-maintainers` or `@hiero-ledger/hiero-sdk-cpp-committers`. They will still require approval from `@hiero-ledger/github-maintainers`.
