### PR TITLE
docs: move FeeComponents operator== Doxygen comment

### DIFF
--- a/src/sdk/main/include/FeeComponents.h
+++ b/src/sdk/main/include/FeeComponents.h
@@ -268,6 +268,13 @@ public:
    * @return The price for data retrieved from disk.
    */
   [[nodiscard]] inline int64_t getResponseDiskByte() const { return mResponseDiskByte; }
+
+  /**
+   * Compare this FeeComponents to another FeeComponents and determine if they represent an equivalent set of fees.
+   *
+   * @param rhs The other FeeComponents with which to compare this FeeComponents.
+   * @return \c TRUE if this FeeComponents and \p rhs represent equivalent fee component values, otherwise \c FALSE.
+   */
   [[nodiscard]] bool operator==(const FeeComponents& rhs) const;
 
 private:
@@ -325,13 +332,6 @@ private:
    * The price of bandwidth for data retrieved from disk for a response, measured in bytes.
    */
   int64_t mResponseDiskByte = 0LL;
-
-  /**
-   * Compare two FeeComponents instances and determine if they represent an equivalent set of fees.
-   *
-   * @param rhs The right-hand side FeeComponents to compare.
-   * @return \c TRUE if this FeeComponents and \p rhs represent equivalent fee component values, otherwise \c FALSE.
-   */
 };
 
 } // namespace Hiero


### PR DESCRIPTION
Fixes #1613.

## Summary

- Move the orphaned `FeeComponents::operator==` Doxygen block to the public declaration.
- Remove the now-orphaned comment block from the end of the class.
- Keep the change comment-only; no behavior or API signature changes.

## Verification

- `git diff --check`

I could not complete the local CMake build because `cmake --preset linux-x64-debug` fails before generation: the expected repo-local vcpkg toolchain file `vcpkg/scripts/buildsystems/vcpkg.cmake` is missing in this checkout.