### PR TITLE
feat: fix eip1559 recovery id#1605

### DIFF
--- a/src/sdk/main/include/EthereumTransaction.h
+++ b/src/sdk/main/include/EthereumTransaction.h
@@ -76,6 +76,14 @@ public:
   EthereumTransaction& setMaxGasAllowance(const Hbar& maxGasAllowance);
 
   /**
+   * Sign this EthereumTransaction with the specified private key.
+    *
+   * @param key The private key to use to sign this transaction.
+   * @return A reference to this EthereumTransaction object.
+   */
+  EthereumTransaction& sign(const std::shared_ptr<PrivateKey>& key);
+
+  /**
    * Get the raw Ethereum transaction.
    *
    * @return The raw Ethereum transaction.

--- a/src/sdk/main/include/EthereumTransaction.h
+++ b/src/sdk/main/include/EthereumTransaction.h
@@ -77,7 +77,7 @@ public:
 
   /**
    * Sign this EthereumTransaction with the specified private key.
-    *
+   *
    * @param key The private key to use to sign this transaction.
    * @return A reference to this EthereumTransaction object.
    */

--- a/src/sdk/main/include/EthereumTransactionDataEip1559.h
+++ b/src/sdk/main/include/EthereumTransactionDataEip1559.h
@@ -71,6 +71,13 @@ public:
   [[nodiscard]] std::string toString() const override;
 
   /**
+   * Get the RLP-encoded bytes for the required 9 fields to be signed.
+   *
+   * @return The bytes required to be hashed and signed.
+   */
+  [[nodiscard]] std::vector<std::byte> toSignBytes() const;
+
+  /**
    * The ID of the chain.
    */
   std::vector<std::byte> mChainId;

--- a/src/sdk/main/src/EthereumTransaction.cc
+++ b/src/sdk/main/src/EthereumTransaction.cc
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "EthereumTransaction.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "EthereumTransactionData.h"
+#include "EthereumTransactionDataEip1559.h"
 #include "impl/Node.h"
 #include "impl/Utilities.h"
 
 #include <services/ethereum_transaction.pb.h>
 #include <services/transaction.pb.h>
+
+#include <stdexcept>
 
 namespace Hiero
 {
@@ -45,6 +50,56 @@ EthereumTransaction& EthereumTransaction::setMaxGasAllowance(const Hbar& maxGasA
   requireNotFrozen();
   mMaxGasAllowance = maxGasAllowance;
   return *this;
+}
+
+//-----
+EthereumTransaction& EthereumTransaction::sign(const std::shared_ptr<PrivateKey>& key)
+{
+  if (!key)
+  {
+    throw std::invalid_argument("Signing key must be set.");
+  }
+
+  EthereumTransaction& signedTransaction =
+    static_cast<EthereumTransaction&>(Transaction<EthereumTransaction>::sign(key));
+
+  const auto ecdsaKey = std::dynamic_pointer_cast<ECDSAsecp256k1PrivateKey>(key);
+  if (!ecdsaKey || mEthereumData.empty())
+  {
+    return signedTransaction;
+  }
+
+  std::unique_ptr<EthereumTransactionData> ethData = EthereumTransactionData::fromBytes(mEthereumData);
+  auto* eip1559Data = dynamic_cast<EthereumTransactionDataEip1559*>(ethData.get());
+  if (!eip1559Data)
+  {
+    return signedTransaction;
+  }
+
+  const std::vector<std::byte> messageToSign = eip1559Data->toSignBytes();
+  const std::vector<std::byte> signatureBytes = ecdsaKey->sign(messageToSign);
+  if (signatureBytes.size() != ECDSAsecp256k1PrivateKey::RAW_SIGNATURE_SIZE)
+  {
+    throw std::runtime_error("Unexpected ECDSA signature size while signing Ethereum transaction");
+  }
+
+  std::vector<std::byte> r(signatureBytes.cbegin(),
+                           signatureBytes.cbegin() + ECDSAsecp256k1PrivateKey::R_SIZE);
+  std::vector<std::byte> s(signatureBytes.cbegin() + ECDSAsecp256k1PrivateKey::R_SIZE, signatureBytes.cend());
+
+  const int recId = ecdsaKey->getRecoveryId(r, s, messageToSign);
+  if (recId < 0)
+  {
+    throw std::runtime_error("Failed to compute recovery ID during Ethereum transaction signing");
+  }
+
+  eip1559Data->mR = std::move(r);
+  eip1559Data->mS = std::move(s);
+  eip1559Data->mRecoveryId = { static_cast<std::byte>(recId) };
+  mEthereumData = eip1559Data->toBytes();
+
+  regenerateSignedTransactions(nullptr);
+  return signedTransaction;
 }
 
 //-----

--- a/src/sdk/main/src/EthereumTransaction.cc
+++ b/src/sdk/main/src/EthereumTransaction.cc
@@ -83,8 +83,7 @@ EthereumTransaction& EthereumTransaction::sign(const std::shared_ptr<PrivateKey>
     throw std::runtime_error("Unexpected ECDSA signature size while signing Ethereum transaction");
   }
 
-  std::vector<std::byte> r(signatureBytes.cbegin(),
-                           signatureBytes.cbegin() + ECDSAsecp256k1PrivateKey::R_SIZE);
+  std::vector<std::byte> r(signatureBytes.cbegin(), signatureBytes.cbegin() + ECDSAsecp256k1PrivateKey::R_SIZE);
   std::vector<std::byte> s(signatureBytes.cbegin() + ECDSAsecp256k1PrivateKey::R_SIZE, signatureBytes.cend());
 
   const int recId = ecdsaKey->getRecoveryId(r, s, messageToSign);

--- a/src/sdk/main/src/EthereumTransaction.cc
+++ b/src/sdk/main/src/EthereumTransaction.cc
@@ -76,6 +76,8 @@ EthereumTransaction& EthereumTransaction::sign(const std::shared_ptr<PrivateKey>
     return signedTransaction;
   }
 
+  // messageToSign is the raw preimage (RLP list + type byte).
+  // sign() hashes this internally, and getRecoveryId() does the same.
   const std::vector<std::byte> messageToSign = eip1559Data->toSignBytes();
   const std::vector<std::byte> signatureBytes = ecdsaKey->sign(messageToSign);
   if (signatureBytes.size() != ECDSAsecp256k1PrivateKey::RAW_SIGNATURE_SIZE)

--- a/src/sdk/main/src/EthereumTransaction.cc
+++ b/src/sdk/main/src/EthereumTransaction.cc
@@ -89,7 +89,7 @@ EthereumTransaction& EthereumTransaction::sign(const std::shared_ptr<PrivateKey>
   std::vector<std::byte> s(signatureBytes.cbegin() + ECDSAsecp256k1PrivateKey::R_SIZE, signatureBytes.cend());
 
   const int recId = ecdsaKey->getRecoveryId(r, s, messageToSign);
-  if (recId < 0)
+  if (recId < 0 || recId > 1)
   {
     throw std::runtime_error("Failed to compute recovery ID during Ethereum transaction signing");
   }

--- a/src/sdk/main/src/EthereumTransactionDataEip1559.cc
+++ b/src/sdk/main/src/EthereumTransactionDataEip1559.cc
@@ -89,6 +89,23 @@ std::vector<std::byte> EthereumTransactionDataEip1559::toBytes() const
 }
 
 //-----
+std::vector<std::byte> EthereumTransactionDataEip1559::toSignBytes() const
+{
+  RLPItem list(RLPItem::RLPType::LIST_TYPE);
+  list.pushBack(mChainId);
+  list.pushBack(mNonce);
+  list.pushBack(mMaxPriorityGas);
+  list.pushBack(mMaxGas);
+  list.pushBack(mGasLimit);
+  list.pushBack(mTo);
+  list.pushBack(mValue);
+  list.pushBack(mCallData);
+  list.pushBack(RLPItem());
+
+  return internal::Utilities::concatenateVectors({ { std::byte(0x02) }, list.write() });
+}
+
+//-----
 std::string EthereumTransactionDataEip1559::toString() const
 {
   return "mChainId: " + internal::HexConverter::bytesToHex(mChainId) +

--- a/src/sdk/main/src/EthereumTransactionDataEip1559.cc
+++ b/src/sdk/main/src/EthereumTransactionDataEip1559.cc
@@ -100,7 +100,9 @@ std::vector<std::byte> EthereumTransactionDataEip1559::toSignBytes() const
   list.pushBack(mTo);
   list.pushBack(mValue);
   list.pushBack(mCallData);
-  list.pushBack(RLPItem());
+  RLPItem accessListItem(mAccessList);
+  accessListItem.setType(RLPItem::RLPType::LIST_TYPE);
+  list.pushBack(accessListItem);
 
   return internal::Utilities::concatenateVectors({ { std::byte(0x02) }, list.write() });
 }

--- a/src/sdk/tests/integration/EthereumTransactionIntegrationTests.cc
+++ b/src/sdk/tests/integration/EthereumTransactionIntegrationTests.cc
@@ -65,17 +65,20 @@ TEST_F(EthereumTransactionIntegrationTests, SignerNonceChangedOnEthereumTransact
                              .mFileId.value());
 
   const std::string memo = "[e2e::ContractCreateTransaction]";
-  ContractId contractId;
-  EXPECT_NO_THROW(contractId =
+  const uint64_t createGas = 1000000ULL;
+  TransactionReceipt contractReceipt;
+  EXPECT_NO_THROW(contractReceipt =
                     ContractCreateTransaction()
                       .setBytecodeFileId(fileId)
                       .setAdminKey(getTestClient().getOperatorPublicKey())
-                      .setGas(200000ULL)
+                      .setGas(createGas)
                       .setConstructorParameters(ContractFunctionParameters().addString("Hello from Hiero.").toBytes())
                       .setMemo(memo)
                       .execute(getTestClient())
-                      .getReceipt(getTestClient())
-                      .mContractId.value());
+                      .getReceipt(getTestClient()));
+  EXPECT_EQ(contractReceipt.mStatus, Status::SUCCESS);
+  ASSERT_TRUE(contractReceipt.mContractId.has_value());
+  const ContractId contractId = contractReceipt.mContractId.value();
 
   // Prepare byte vectors for passing to RLP serialization
   std::vector<std::byte> type = internal::HexConverter::hexToBytes("02");

--- a/src/sdk/tests/integration/EthereumTransactionIntegrationTests.cc
+++ b/src/sdk/tests/integration/EthereumTransactionIntegrationTests.cc
@@ -35,7 +35,7 @@ class EthereumTransactionIntegrationTests : public BaseIntegrationTest
 };
 
 //-----
-TEST_F(EthereumTransactionIntegrationTests, DISABLED_SignerNonceChangedOnEthereumTransaction)
+TEST_F(EthereumTransactionIntegrationTests, SignerNonceChangedOnEthereumTransaction)
 {
   // Given
   const std::shared_ptr<ECDSAsecp256k1PrivateKey> testPrivateKey = ECDSAsecp256k1PrivateKey::fromString(
@@ -104,8 +104,9 @@ TEST_F(EthereumTransactionIntegrationTests, DISABLED_SignerNonceChangedOnEthereu
   list.pushBack(accessListItem);
 
   // signed bytes in r,s form
-  std::vector<std::byte> signedBytes =
-    testPrivateKey->sign(internal::Utilities::concatenateVectors({ type, list.write() }));
+  // storing message to pass it to the getRecoveryID
+  std::vector<std::byte> message = internal::Utilities::concatenateVectors({ type, list.write() });
+  std::vector<std::byte> signedBytes = testPrivateKey->sign(message);
 
   std::vector<std::byte> r(signedBytes.begin(),
                            signedBytes.begin() + std::min(signedBytes.size(), static_cast<size_t>(32)));
@@ -113,7 +114,12 @@ TEST_F(EthereumTransactionIntegrationTests, DISABLED_SignerNonceChangedOnEthereu
   std::vector<std::byte> s(signedBytes.end() - std::min(signedBytes.size(), static_cast<size_t>(32)),
                            signedBytes.end());
 
-  std::vector<std::byte> recoveryId = internal::HexConverter::hexToBytes("01");
+  int recID = testPrivateKey->getRecoveryId(r, s, message);
+  if (recID < 0)
+  {
+    throw std::runtime_error("Failed to compute Ethereum recovery ID during integration test");
+  }
+  std::vector<std::byte> recoveryId = { static_cast<std::byte>(recID) };
 
   // recId, r, s should be added to original RLP list as Ethereum Transactions require
   list.pushBack(recoveryId);

--- a/src/sdk/tests/unit/EthereumTransactionDataEip1559UnitTests.cc
+++ b/src/sdk/tests/unit/EthereumTransactionDataEip1559UnitTests.cc
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "EthereumTransactionDataEip1559.h"
 #include "impl/HexConverter.h"
+#include "impl/RLPItem.h"
+#include "impl/Utilities.h"
 
 #include <gtest/gtest.h>
 
@@ -79,4 +81,36 @@ TEST_F(EthereumTransactionDataEip1559UnitTests, ToString)
             "mRecoveryId: 01\n"
             "mR: DF48F2EFD10421811DE2BFB125AB75B2D3C44139C4642837FB1FCCCE911FD479\n"
             "mS: 1AAF7AE92BEE896651DFC9D99AE422A296BF5D9F1CA49B2D96D82B79EB112D66");
+}
+
+//-----
+TEST_F(EthereumTransactionDataEip1559UnitTests, ToBytesPlacesRecoveryIdAndSignature)
+{
+  // Given
+  EthereumTransactionDataEip1559 data;
+  data.mChainId = internal::HexConverter::hexToBytes("01");
+  data.mNonce = internal::HexConverter::hexToBytes("00");
+  data.mMaxPriorityGas = internal::HexConverter::hexToBytes("01");
+  data.mMaxGas = internal::HexConverter::hexToBytes("02");
+  data.mGasLimit = internal::HexConverter::hexToBytes("03");
+  data.mTo = internal::HexConverter::hexToBytes("7e3a9eaf9bcc39e2ffa38eb30bf7a93feacbc181");
+  data.mValue = internal::HexConverter::hexToBytes("04");
+  data.mCallData = internal::HexConverter::hexToBytes("1234");
+  data.mAccessList = {};
+  data.mRecoveryId = { std::byte(0x01) };
+  data.mR = internal::HexConverter::hexToBytes("df48f2efd10421811de2bfb125ab75b2d3c44139c4642837fb1fccce911fd479");
+  data.mS = internal::HexConverter::hexToBytes("1aaf7ae92bee896651dfc9d99ae422a296bf5d9f1ca49b2d96d82b79eb112d66");
+
+  // When
+  const std::vector<std::byte> encoded = data.toBytes();
+
+  // Then
+  RLPItem decoded;
+  decoded.read(internal::Utilities::removePrefix(encoded, 1));
+  const std::vector<RLPItem> values = decoded.getValues();
+
+  ASSERT_EQ(values.size(), 12u);
+  EXPECT_EQ(values.at(9).getValue(), data.mRecoveryId);
+  EXPECT_EQ(values.at(10).getValue(), data.mR);
+  EXPECT_EQ(values.at(11).getValue(), data.mS);
 }


### PR DESCRIPTION


### Description

This PR wires EIP-1559 signing in the SDK so the recovery ID is computed and serialized correctly for Ethereum transactions.

**Changes**
- Add `EthereumTransaction::sign()` to compute `r`, `s`, and recovery ID, and update the encoded transaction.
- Add `EthereumTransactionDataEip1559::toSignBytes()` to build the signing preimage.
- Update the integration test to compute recovery ID dynamically (no hardcoded `01`).
- Add a unit test to validate `yParity`/`r`/`s` placement in the serialized bytes.

---

**Related issue(s)**  
Fixes #1605

---

**Notes for reviewer**
- EthereumFlow: not wired in this PR. Keeping scope limited to the `EthereumTransaction` direct path.  
  Follow-up issue: #1660 

---

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for signing Ethereum EIP-1559 transactions with private keys.
  * Signing now computes and stores signature components and the recovery identifier so signed transactions are produced end-to-end.

* **Tests**
  * Re-enabled an integration test covering signer behavior and transaction receipts.
  * Added unit tests verifying signature and recovery ID encoding in transaction data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiero-ledger/hiero-sdk-cpp/pull/1649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->