### PR TITLE
refactor: extract bot inactivity comment builders to bot-inactivity-comments.js

### DIFF
--- a/.github/scripts/bot-inactivity-comments.js
+++ b/.github/scripts/bot-inactivity-comments.js
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// bot-inactivity-comments.js
+//
+// Comment builders for the inactivity bot. Pure formatting functions
+// separated from the scheduled execution logic for readability.
+//
+// Duration values (WARN_AFTER_MS, CLOSE_AFTER_MS, BLOCKED_CHECKIN_AFTER_MS)
+// remain in bot-inactivity.js and are passed in as parameters here so this
+// file stays free of module-level constants that belong to the scheduler.
+
+const { LABELS } = require('./helpers/constants');
+
+// ─── HTML markers ────────────────────────────────────────────────────────────
+
+const WARN_MARKER           = '<!-- bot:inactivity-warning -->';
+const BLOCKED_CHECKIN_MARKER = '<!-- bot:blocked-checkin -->';
+
+// ─── Comment builders ─────────────────────────────────────────────────────────
+
+/**
+ * Builds the inactivity warning comment body.
+ * @param {string[]} assigneeLogins
+ * @param {string} itemType - 'issue' or 'PR'
+ * @param {number} warnAfterMs - Duration in ms after which a warning is issued.
+ * @param {number} closeAfterMs - Duration in ms after which the item is closed.
+ * @returns {string}
+ */
+function buildWarningComment(assigneeLogins, itemType, warnAfterMs, closeAfterMs) {
+  const mentions = assigneeLogins.length > 0
+    ? assigneeLogins.map(l => `@${l}`).join(', ')
+    : 'there';
+
+  const activityHint = itemType === 'PR'
+    ? 'To stay active, leave a comment on this PR or the linked **issue**, or push a new commit.'
+    : "If you're still on it, leave a comment to let us know!";
+
+  const warnDays = warnAfterMs / (24 * 60 * 60 * 1000);
+  const remainingDays = (closeAfterMs - warnAfterMs) / (24 * 60 * 60 * 1000);
+
+  return [
+    WARN_MARKER,
+    `👋 Hey ${mentions}! This ${itemType} has been inactive for ${warnDays} days.`,
+    '',
+    `Are you still working on this? We will close this in ${remainingDays} days if we see no further activity.`,
+    '',
+    `${activityHint} If you'd like to step down, comment \`/unassign\`.`,
+  ].join('\n');
+}
+
+/**
+ * Builds the closure comment body.
+ * @param {string} itemType - 'issue' or 'PR'
+ * @param {number} closeAfterMs - Duration in ms after which the item is closed.
+ * @returns {string}
+ */
+function buildClosureComment(itemType, closeAfterMs) {
+  const closeDays = closeAfterMs / (24 * 60 * 60 * 1000);
+
+  if (itemType === 'issue') {
+    return [
+      `⏱️ This issue has been unassigned and reset to \`${LABELS.READY_FOR_DEV}\` due to ${closeDays} days of inactivity.`,
+      '',
+      "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
+    ].join('\n');
+  }
+  return [
+    `⏱️ This PR has been closed due to ${closeDays} days of inactivity.`,
+    '',
+    `It has been unassigned and reset to \`${LABELS.READY_FOR_DEV}\` so another contributor can pick it up.`,
+    '',
+    "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
+  ].join('\n');
+}
+
+/**
+ * Builds the comment posted on an issue when its linked PR was closed for inactivity.
+ * @returns {string}
+ */
+function buildLinkedPRClosedComment() {
+  return [
+    '🔗 The pull request linked to this issue was closed due to inactivity.',
+    '',
+    `This issue has been unassigned and reset to \`${LABELS.READY_FOR_DEV}\`.`,
+    '',
+    "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
+  ].join('\n');
+}
+
+/**
+ * Builds the 30-day blocked check-in comment body.
+ * @param {string[]} assigneeLogins
+ * @param {string} itemType - 'issue' or 'PR'
+ * @returns {string}
+ */
+function buildBlockedCheckinComment(assigneeLogins, itemType) {
+  const mentions = assigneeLogins.length > 0
+    ? assigneeLogins.map(l => `@${l}`).join(', ')
+    : 'there';
+
+  return [
+    BLOCKED_CHECKIN_MARKER,
+    `👋 Hey ${mentions}, just checking in! Is this ${itemType} still blocked?`,
+    '',
+    `If it has been unblocked, please remove the \`${LABELS.BLOCKED}\` label so we can track progress.`,
+  ].join('\n');
+}
+
+module.exports = {
+  WARN_MARKER,
+  BLOCKED_CHECKIN_MARKER,
+  buildWarningComment,
+  buildClosureComment,
+  buildLinkedPRClosedComment,
+  buildBlockedCheckinComment,
+};

--- a/.github/scripts/bot-inactivity.js
+++ b/.github/scripts/bot-inactivity.js
@@ -48,8 +48,14 @@ const WARN_AFTER_MS           = 5 * 24 * 60 * 60 * 1000;  // 5 days
 const CLOSE_AFTER_MS          = 7 * 24 * 60 * 60 * 1000;  // 7 days
 const BLOCKED_CHECKIN_AFTER_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
-const WARN_MARKER           = '<!-- bot:inactivity-warning -->';
-const BLOCKED_CHECKIN_MARKER = '<!-- bot:blocked-checkin -->';
+const {
+  WARN_MARKER,
+  BLOCKED_CHECKIN_MARKER,
+  buildWarningComment,
+  buildClosureComment,
+  buildLinkedPRClosedComment,
+  buildBlockedCheckinComment,
+} = require('./bot-inactivity-comments');
 
 // ─── Context builder ─────────────────────────────────────────────────────────
 
@@ -300,92 +306,7 @@ async function computeIssueLastActivity(github, owner, repo, issue, linkedOpenPR
   return latest;
 }
 
-// ─── Comment builders ─────────────────────────────────────────────────────────
-
-/**
- * Builds the inactivity warning comment body.
- * @param {string[]} assigneeLogins
- * @param {string} itemType - 'issue' or 'PR'
- * @returns {string}
- */
-function buildWarningComment(assigneeLogins, itemType) {
-  const mentions = assigneeLogins.length > 0
-    ? assigneeLogins.map(l => `@${l}`).join(', ')
-    : 'there';
-
-  const activityHint = itemType === 'PR'
-    ? 'To stay active, leave a comment on this PR or the linked **issue**, or push a new commit.'
-    : "If you're still on it, leave a comment to let us know!";
-
-  const warnDays = WARN_AFTER_MS / (24 * 60 * 60 * 1000);
-  const remainingDays = (CLOSE_AFTER_MS - WARN_AFTER_MS) / (24 * 60 * 60 * 1000);
-
-  return [
-    WARN_MARKER,
-    `👋 Hey ${mentions}! This ${itemType} has been inactive for ${warnDays} days.`,
-    '',
-    `Are you still working on this? We will close this in ${remainingDays} days if we see no further activity.`,
-    '',
-    `${activityHint} If you'd like to step down, comment \`/unassign\`.`,
-  ].join('\n');
-}
-
-/**
- * Builds the closure comment body.
- * @param {string} itemType - 'issue' or 'PR'
- * @returns {string}
- */
-function buildClosureComment(itemType) {
-  const closeDays = CLOSE_AFTER_MS / (24 * 60 * 60 * 1000);
-
-  if (itemType === 'issue') {
-    return [
-      `⏱️ This issue has been unassigned and reset to \`${LABELS.READY_FOR_DEV}\` due to ${closeDays} days of inactivity.`,
-      '',
-      "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
-    ].join('\n');
-  }
-  return [
-    `⏱️ This PR has been closed due to ${closeDays} days of inactivity.`,
-    '',
-    `It has been unassigned and reset to \`${LABELS.READY_FOR_DEV}\` so another contributor can pick it up.`,
-    '',
-    "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
-  ].join('\n');
-}
-
-/**
- * Builds the comment posted on an issue when its linked PR was closed for inactivity.
- * @returns {string}
- */
-function buildLinkedPRClosedComment() {
-  return [
-    '🔗 The pull request linked to this issue was closed due to inactivity.',
-    '',
-    `This issue has been unassigned and reset to \`${LABELS.READY_FOR_DEV}\`.`,
-    '',
-    "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
-  ].join('\n');
-}
-
-/**
- * Builds the 30-day blocked check-in comment body.
- * @param {string[]} assigneeLogins
- * @param {string} itemType - 'issue' or 'PR'
- * @returns {string}
- */
-function buildBlockedCheckinComment(assigneeLogins, itemType) {
-  const mentions = assigneeLogins.length > 0
-    ? assigneeLogins.map(l => `@${l}`).join(', ')
-    : 'there';
-
-  return [
-    BLOCKED_CHECKIN_MARKER,
-    `👋 Hey ${mentions}, just checking in! Is this ${itemType} still blocked?`,
-    '',
-    `If it has been unblocked, please remove the \`${LABELS.BLOCKED}\` label so we can track progress.`,
-  ].join('\n');
-}
+// ─── (Comment builders moved to bot-inactivity-comments.js) ─────────────────
 
 // ─── State mutation ───────────────────────────────────────────────────────────
 
@@ -469,12 +390,12 @@ async function handleStaleItem(github, owner, repo, item, lastActivityMs, itemTy
       await closeItem(ctx);
     }
     await resetItem(github, owner, repo, item, { addReadyForDev: itemType !== 'PR' });
-    await postComment(ctx, buildClosureComment(itemType));
+    await postComment(ctx, buildClosureComment(itemType, CLOSE_AFTER_MS));
     return 'closed';
   }
 
   if (elapsed >= WARN_AFTER_MS) {
-    await postOrUpdateComment(ctx, WARN_MARKER, buildWarningComment(assigneeLogins, itemType));
+    await postOrUpdateComment(ctx, WARN_MARKER, buildWarningComment(assigneeLogins, itemType, WARN_AFTER_MS, CLOSE_AFTER_MS));
     return 'warned';
   }
 


### PR DESCRIPTION
## Summary

Resolves #1598

The four comment builder functions (, , , ) and the two HTML marker constants (, ) have been moved from `bot-inactivity.js` into a new sibling file `bot-inactivity-comments.js`.

This follows the established `*.js` ↔ `*-comments.js` pattern used by the `commands/` bots (assign, finalize, unassign), making the inactivity bot consistent with the rest of the bot system.

## Changes

- **Create** `.github/scripts/bot-inactivity-comments.js` with SPDX header, the two HTML markers, and all four builder functions exported via `module.exports`.
- **Update** `buildWarningComment` and `buildClosureComment` signatures to accept duration values (`warnAfterMs`, `closeAfterMs`) as parameters instead of reading module-level constants, keeping `WARN_AFTER_MS`, `CLOSE_AFTER_MS`, and `BLOCKED_CHECKIN_AFTER_MS` as a single source of truth in `bot-inactivity.js`.
- **Refactor** `bot-inactivity.js` to replace inline definitions with a `require('./bot-inactivity-comments')` import.
- **Update** call sites in `handleStaleItem` to pass the duration constants into the builders.

## Verification

- ✅ All 34 existing tests in `tests/test-inactivity-bot.js` pass without modification.
- ✅ ESLint is clean.
- ✅ No behavioral change — warn, close, linked-PR-closed, and blocked-checkin comments render identically.

## Checklist

- [x] `.github/scripts/bot-inactivity-comments.js` exists at the top level, colocated with `bot-inactivity.js`
- [x] The four builders and the two HTML markers live in the new file
- [x] `bot-inactivity.js` imports them and no longer defines them inline
- [x] Duration constants (`WARN_AFTER_MS`, `CLOSE_AFTER_MS`, `BLOCKED_CHECKIN_AFTER_MS`) remain in `bot-inactivity.js`
- [x] Existing tests pass without behavioral changes
- [x] ESLint is clean
- [x] No unrelated changes to bot logic or other files