### PR TITLE
chore: remove redundant mutex lock around log4cxx warning

### DIFF
--- a/src/sdk/main/src/Client.cc
+++ b/src/sdk/main/src/Client.cc
@@ -1218,7 +1218,6 @@ void Client::scheduleNetworkUpdate()
     }
     catch (const std::exception& exception)
     {
-      std::unique_lock lock(mImpl->mMutex);
       mImpl->mLogger.warn(std::string("Failed to update address book via mirror node query ") + exception.what());
       break;
     }


### PR DESCRIPTION
**Description**:
Remove redundant mutex lock around log4cxx warning in the network update loop. The underlying `log4cxx::Logger` is internally thread-safe, making the outer `mMutex` lock unnecessary and a potential source of lock contention. 

* Remove `std::unique_lock` from the catch block in `Client::scheduleNetworkUpdate`
* Preserve the concurrency structure to ensure the deadlock fix from PR #1533 remains fully intact

**Related issue(s)**:

Fixes #1611 

**Notes for reviewer**:
Built locally using the `linux-x64-debug` CMake preset. 
Ran the full `ClientUnitTests` suite (24/24 passed). Specifically verified concurrency safety by running the `NetworkUpdateThreadDoesNotDeadlock*` suite; all 6 tests passed in < 1 second with 0 timeouts, confirming no regression of #1533.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)