### PR TITLE
docs: clarify Windows protobuf include-order comments

### DIFF
--- a/src/sdk/main/include/impl/BaseNode.h
+++ b/src/sdk/main/include/impl/BaseNode.h
@@ -2,7 +2,7 @@
 #ifndef HIERO_SDK_CPP_IMPL_BASE_NODE_H_
 #define HIERO_SDK_CPP_IMPL_BASE_NODE_H_
 
-#include <services/basic_types.pb.h> // This is needed for Windows to build for some reason.
+#include <services/basic_types.pb.h> // Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers in the generated protobuf code.
 
 #include "BaseNodeAddress.h"
 #include "Defaults.h"

--- a/src/sdk/main/src/AccountId.cc
+++ b/src/sdk/main/src/AccountId.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Windows build requires this to be included first for some reason.
+// Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers in the generated protobuf code.
 #include <services/basic_types.pb.h> // NOLINT
 
 #include "AccountId.h"

--- a/src/sdk/main/src/FeeEstimateQuery.cc
+++ b/src/sdk/main/src/FeeEstimateQuery.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Windows build requires this to be included first for some reason.
+// Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers in the generated protobuf code.
 #include <services/basic_types.pb.h> // NOLINT
 
 #include "Client.h"

--- a/src/tck/src/TckServer.cc
+++ b/src/tck/src/TckServer.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Windows build requires this to be included first for some reason.
+// Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers reached transitively from this header.
 #include <Transaction.h> // NOLINT
 
 #include "TckServer.h"


### PR DESCRIPTION
**Description**:

Clarify Windows include-order comments related to protobuf and `windows.h` macro collisions.

* Replace vague Windows include-order comments with descriptive explanations
* Preserve existing include ordering and behavior
* No functional code changes

**Related issue(s)**:

Fixes #1632 

**Notes for reviewer**:

Comment-only change. No behavior changes.

**Checklist**

* [x] Documented (Code comments, README, etc.)
* [x] Tested (unit, integration, etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal code documentation to clarify include ordering requirements, improving SDK compilation stability on Windows builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiero-ledger/hiero-sdk-cpp/pull/1659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->