### PR TITLE
build: add explicit gcc cmake presets for linux

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -86,7 +86,7 @@ jobs:
       matrix:
         include:
           - os: Linux
-            preset: linux-x64
+            preset: linux-x64-gcc
 
     steps:
       - name: Harden Runner

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -37,32 +37,41 @@
       }
     },
     {
-      "name": "linux-x64-release",
+      "name": "linux-x64-gcc-debug",
+      "displayName": "Linux x64 GCC Debug",
+      "description": "GCC build for Linux x64 Debug",
       "inherits": ["vcpkg-base"],
       "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": {
-          "type": "STRING",
-          "value": "x64-linux"
-        },
-        "CMAKE_BUILD_TYPE": {
-          "type": "STRING",
-          "value": "Release"
-        }
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
+        "VCPKG_TARGET_TRIPLET": "x64-linux",
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
-      "name": "linux-x64-debug",
+      "name": "linux-x64-gcc-release",
+      "displayName": "Linux x64 GCC Release",
+      "description": "GCC build for Linux x64 Release",
       "inherits": ["vcpkg-base"],
       "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": {
-          "type": "STRING",
-          "value": "x64-linux"
-        },
-        "CMAKE_BUILD_TYPE": {
-          "type": "STRING",
-          "value": "Debug"
-        }
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
+        "VCPKG_TARGET_TRIPLET": "x64-linux",
+        "CMAKE_BUILD_TYPE": "Release"
       }
+    },
+    {
+      "name": "linux-x64-release",
+      "displayName": "Linux x64 Release",
+      "description": "Linux x64 Release - defaults to GCC; alias of linux-x64-gcc-release",
+      "inherits": ["linux-x64-gcc-release"]
+    },
+    {
+      "name": "linux-x64-debug",
+      "displayName": "Linux x64 Debug",
+      "description": "Linux x64 Debug — defaults to GCC; alias of linux-x64-gcc-debug.",
+      "inherits": ["linux-x64-gcc-debug"]
+      
     },
     {
       "name": "macos-x64-release",
@@ -151,20 +160,34 @@
   ],
   "buildPresets": [
     {
-      "name": "linux-x64-release",
-      "configurePreset": "linux-x64-release",
-      "displayName": "Build ninja-multi-vcpkg",
-      "description": "Build ninja-multi-vcpkg Configurations",
+      "name": "linux-x64-gcc-release",
+      "configurePreset": "linux-x64-gcc-release",
+      "displayName": "Build ninja-multi-vcpkg (GCC)",
+      "description": "Build ninja-multi-vcpkg Configurations with GCC",
       "configuration": "Release",
       "targets": ["install"]
     },
     {
-      "name": "linux-x64-debug",
-      "configurePreset": "linux-x64-debug",
-      "displayName": "Build ninja-multi-vcpkg",
-      "description": "Build ninja-multi-vcpkg Configurations",
+      "name": "linux-x64-gcc-debug",
+      "configurePreset": "linux-x64-gcc-debug",
+      "displayName": "Build ninja-multi-vcpkg (GCC)",
+      "description": "Build ninja-multi-vcpkg Configurations with GCC",
       "configuration": "Debug",
       "targets": ["install"]
+    },
+    {
+      "name": "linux-x64-release",
+      "inherits": ["linux-x64-gcc-release"],
+      "configurePreset": "linux-x64-release",
+      "displayName": "Build ninja-multi-vcpkg",
+      "description": "Alias for linux-x64-gcc-release build preset"
+    },
+    {
+      "name": "linux-x64-debug",
+      "inherits": ["linux-x64-gcc-debug"],
+      "configurePreset": "linux-x64-debug",
+      "displayName": "Build ninja-multi-vcpkg",
+      "description": "Alias for linux-x64-gcc-debug build preset"
     },
     {
       "name": "macos-x64-release",

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ cmake --build --preset windows-x64-release
 cmake --preset linux-x64-release
 cmake --build --preset linux-x64-release
 
+# Note on Linux Presets: The standard '''linux-x64-release'''
+# and '''linux-x64-debug''' presets are the recommended
+# defaults for local development and will automatically
+# use the GCC Compiler. If you are specifically testing
+# toolchain portability or checking CI matrix
+# coverage, compiler-explicit alternatives are available:
+# '''linux-x64-gcc-release''' / '''linux-x64-gcc-debug'''
+# (with '''clang''' variants forthcoming)
+
 # macOS (Intel x64)
 cmake --preset macos-x64-release
 cmake --build --preset macos-x64-release


### PR DESCRIPTION
**Description**:
Introduces explicit CMake presets for GCC on Linux to improve CI clarity and toolchain robustness, while maintaining standard aliases for local development friction.

* Add `linux-x64-gcc-debug` and `linux-x64-gcc-release` explicit CMake configure and build presets
* Modify `linux-x64-debug` and `linux-x64-release` to act as thin aliases inheriting from the explicit GCC presets
* Update CI workflow matrix in `zxc-build-library.yaml` to use `linux-x64-gcc-*` so logs explicitly advertise the compiler
* Update `README.md` build instructions to clarify GCC defaults and document explicit alternatives

**Related issue(s)**:

Fixes #1621 

**Notes for reviewer**:
Tested locally: both the explicit `linux-x64-gcc-*` and alias `linux-x64-*` presets successfully configure and build the project via `vcpkg` and `ninja`. CI matrices will now explicitly show the GCC compiler being exercised to prepare for future toolchain additions (e.g., Clang). 

*Note regarding `CLAUDE.md`: The original issue mentioned updating `CLAUDE.md`, but I omitted that from this PR as the file does not currently exist in the repository.*

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Linux builds to use GCC-based configurations and refreshed the build action version.
  * Added dedicated GCC debug and release presets while retaining streamlined Linux preset aliases.

* **Documentation**
  * Clarified the recommended Linux presets and identified GCC as the default compiler.
  * Documented available compiler-specific preset options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->