### PR TITLE
chore: update Hiero Solo version to v0.72.0

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -198,7 +198,7 @@ jobs:
         id: solo
         uses: hiero-ledger/hiero-solo-action@328bc84c3b00a990a151418144fd682a4eb76ea6 # v0.19.0
         with:
-          soloVersion: v0.65.0
+          soloVersion: v0.72.0
           installMirrorNode: true
           mirrorNodeVersion: v0.153.0
           hieroVersion: v0.73.0


### PR DESCRIPTION
## Description

Updates the Hiero Solo version used by the reusable build workflow from v0.65.0 to v0.72.0.

Closes #1570.

## Validation

- Confirmed the workflow change is limited to .github/workflows/zxc-build-library.yaml.
- Confirmed soloVersion is set to v0.72.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to use a newer version of the build tool.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiero-ledger/hiero-sdk-cpp/pull/1666?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->