### PR TITLE
Fixes #1632

### DIFF
--- a/src/sdk/main/include/impl/BaseNode.h
+++ b/src/sdk/main/include/impl/BaseNode.h
@@ -2,7 +2,7 @@
 #ifndef HIERO_SDK_CPP_IMPL_BASE_NODE_H_
 #define HIERO_SDK_CPP_IMPL_BASE_NODE_H_
 
-#include <services/basic_types.pb.h> // This is needed for Windows to build for some reason.
+#include <services/basic_types.pb.h> // Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers in the generated protobuf code.
 
 #include "BaseNodeAddress.h"
 #include "Defaults.h"

--- a/src/sdk/main/src/AccountId.cc
+++ b/src/sdk/main/src/AccountId.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Windows build requires this to be included first for some reason.
+// Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers in the generated protobuf code.
 #include <services/basic_types.pb.h> // NOLINT
 
 #include "AccountId.h"

--- a/src/sdk/main/src/FeeEstimateQuery.cc
+++ b/src/sdk/main/src/FeeEstimateQuery.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Windows build requires this to be included first for some reason.
+// Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers in the generated protobuf code.
 #include <services/basic_types.pb.h> // NOLINT
 
 #include "Client.h"

--- a/src/tck/src/TckServer.cc
+++ b/src/tck/src/TckServer.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Windows build requires this to be included first for some reason.
+// Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers reached transitively from this header.
 #include <Transaction.h> // NOLINT
 
 #include "TckServer.h"


### PR DESCRIPTION
**Description**:
Improve documentation for Windows-specific header include ordering to prevent macro collisions.

* Update vague comments explaining the Windows build workaround with detailed explanations.
* Clarify that `<windows.h>` macros (e.g. `GetMessage`) collide with protobuf-generated identifiers if it is included before the proto headers.
* Modify comments in `AccountId.cc`, `FeeEstimateQuery.cc`, `BaseNode.h`, and `TckServer.cc`.

**Related issue(s)**:

Fixes #1632

**Notes for reviewer**:
The changes are strictly limited to updating comments for better context and clarity. No actual code behavior, `#include` directives, or logic was altered, so the builds will continue functioning on all platforms as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal code documentation and include ordering comments for improved developer clarity. No user-facing changes or functionality updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->