### PR TITLE
build: add explicit linux-x64-gcc-{debug,release} presets

### DIFF
--- a/.github/workflows/on-schedule-builds.yaml
+++ b/.github/workflows/on-schedule-builds.yaml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   scheduled-build:
+    # Linux builds use the explicit linux-x64-gcc-* presets (via zxc-build-library.yaml)
+    # so that scheduled/nightly runs clearly advertise the GCC compiler being used.
+    # The linux-x64-* aliases remain the recommended defaults for local development.
     uses: ./.github/workflows/zxc-build-library.yaml
     with:
       run-windows-builds: true

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -1,3 +1,14 @@
+# ZXC: Build Library Workflow
+# 
+# This is the main reusable workflow for building the Hiero C++ SDK.
+# It is called by:
+#   - PR builds (via zxc-build-library.yaml in the build job)
+#   - Scheduled nightly builds (on-schedule-builds.yaml)
+#   - Manual workflow_dispatch
+#
+# Linux builds now use explicit linux-x64-gcc-* presets (see CMakePresets.json).
+# Windows and macOS builds are optional and controlled via inputs.
+
 name: "ZXC: Build Library"
 on:
   workflow_call:
@@ -86,7 +97,7 @@ jobs:
       matrix:
         include:
           - os: Linux
-            preset: linux-x64
+            preset: linux-x64-gcc
 
     steps:
       - name: Harden Runner

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -36,10 +36,21 @@
         }
       }
     },
+
     {
-      "name": "linux-x64-release",
+      "name": "linux-x64-gcc-release",
       "inherits": ["vcpkg-base"],
+      "displayName": "Linux x64 Release (GCC)",
+      "description": "Linux x64 Release build using GCC",
       "cacheVariables": {
+        "CMAKE_C_COMPILER": {
+          "type": "STRING",
+          "value": "gcc"
+        },
+        "CMAKE_CXX_COMPILER": {
+          "type": "STRING",
+          "value": "g++"
+        },
         "VCPKG_TARGET_TRIPLET": {
           "type": "STRING",
           "value": "x64-linux"
@@ -51,9 +62,19 @@
       }
     },
     {
-      "name": "linux-x64-debug",
+      "name": "linux-x64-gcc-debug",
       "inherits": ["vcpkg-base"],
+      "displayName": "Linux x64 Debug (GCC)",
+      "description": "Linux x64 Debug build using GCC",
       "cacheVariables": {
+        "CMAKE_C_COMPILER": {
+          "type": "STRING",
+          "value": "gcc"
+        },
+        "CMAKE_CXX_COMPILER": {
+          "type": "STRING",
+          "value": "g++"
+        },
         "VCPKG_TARGET_TRIPLET": {
           "type": "STRING",
           "value": "x64-linux"
@@ -64,6 +85,20 @@
         }
       }
     },
+
+    {
+      "name": "linux-x64-release",
+      "inherits": ["linux-x64-gcc-release"],
+      "displayName": "Linux x64 Release — defaults to GCC",
+      "description": "Alias of linux-x64-gcc-release (recommended for local development)"
+    },
+    {
+      "name": "linux-x64-debug",
+      "inherits": ["linux-x64-gcc-debug"],
+      "displayName": "Linux x64 Debug — defaults to GCC",
+      "description": "Alias of linux-x64-gcc-debug (recommended for local development)"
+    },
+
     {
       "name": "macos-x64-release",
       "inherits": ["vcpkg-base"],
@@ -151,6 +186,23 @@
   ],
   "buildPresets": [
     {
+      "name": "linux-x64-gcc-release",
+      "configurePreset": "linux-x64-gcc-release",
+      "displayName": "Build ninja-multi-vcpkg",
+      "description": "Build ninja-multi-vcpkg Configurations",
+      "configuration": "Release",
+      "targets": ["install"]
+    },
+    {
+      "name": "linux-x64-gcc-debug",
+      "configurePreset": "linux-x64-gcc-debug",
+      "displayName": "Build ninja-multi-vcpkg",
+      "description": "Build ninja-multi-vcpkg Configurations",
+      "configuration": "Debug",
+      "targets": ["install"]
+    },
+
+    {
       "name": "linux-x64-release",
       "configurePreset": "linux-x64-release",
       "displayName": "Build ninja-multi-vcpkg",
@@ -166,6 +218,7 @@
       "configuration": "Debug",
       "targets": ["install"]
     },
+
     {
       "name": "macos-x64-release",
       "configurePreset": "macos-x64-release",
@@ -215,7 +268,5 @@
       "targets": ["install"]
     }
   ],
-  "testPresets": [
-
-  ]
+  "testPresets": []
 }

--- a/README.md
+++ b/README.md
@@ -76,9 +76,13 @@ git submodule update --init
 cmake --preset windows-x64-release
 cmake --build --preset windows-x64-release
 
-# Linux (x64)
+# Linux (x64) — defaults to GCC
 cmake --preset linux-x64-release
 cmake --build --preset linux-x64-release
+
+# Linux (x64) — Explicit GCC (for CI or toolchain testing)
+cmake --preset linux-x64-gcc-release
+cmake --build --preset linux-x64-gcc-release
 
 # macOS (Intel x64)
 cmake --preset macos-x64-release

--- a/src/sdk/main/include/KeyList.h
+++ b/src/sdk/main/include/KeyList.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 #include <vector>
 
 namespace proto


### PR DESCRIPTION
**Description**:
<!--
Add explicit `linux-x64-gcc-debug` and `linux-x64-gcc-release` CMake presets that set `CMAKE_C_COMPILER=gcc` / `CMAKE_CXX_COMPILER=g++` directly.  

The existing `linux-x64-{debug,release}` presets are now thin aliases (via inheritance) that default to GCC. This makes compiler usage explicit in CI while keeping the short names as the recommended developer experience.

* Add canonical `linux-x64-gcc-{debug,release}` configure and build presets
* Convert `linux-x64-{debug,release}` to aliases (no deprecation)
* Update Linux matrix in `zxc-build-library.yaml` to use explicit gcc presets
* Document GCC default and new presets in `README.md`
* Bonus: Fix missing `<cstdint>` include in `KeyList.h` (exposed by GCC 15.2)
-->

**Related issue(s)**:

Fixes #1621

**Notes for reviewer**:
Both `linux-x64-release` and `linux-x64-gcc-release` (and their debug counterparts) have been tested locally and produce equivalent builds.

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the Linux (x64) Quick Start with separate GCC-specific build commands alongside the default presets.

* **Chores**
  * Updated Linux build presets to distinguish GCC-based configurations and kept user-friendly alias presets for local development.
  * Adjusted the build workflow and its messaging to reflect the new GCC preset naming.
  * Improved SDK header compatibility for threshold-related APIs by ensuring the required integer type is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->