### PR TITLE
fix: improve windows include comments

### DIFF
--- a/src/sdk/main/include/impl/BaseNode.h
+++ b/src/sdk/main/include/impl/BaseNode.h
@@ -2,7 +2,7 @@
 #ifndef HIERO_SDK_CPP_IMPL_BASE_NODE_H_
 #define HIERO_SDK_CPP_IMPL_BASE_NODE_H_
 
-#include <services/basic_types.pb.h> // This is needed for Windows to build for some reason.
+#include <services/basic_types.pb.h> // Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers in the generated protobuf code.
 
 #include "BaseNodeAddress.h"
 #include "Defaults.h"

--- a/src/sdk/main/src/AccountId.cc
+++ b/src/sdk/main/src/AccountId.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Windows build requires this to be included first for some reason.
+// Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers in the generated protobuf code.
 #include <services/basic_types.pb.h> // NOLINT
 
 #include "AccountId.h"

--- a/src/sdk/main/src/FeeEstimateQuery.cc
+++ b/src/sdk/main/src/FeeEstimateQuery.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Windows build requires this to be included first for some reason.
+// Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers in the generated protobuf code.
 #include <services/basic_types.pb.h> // NOLINT
 
 #include "Client.h"

--- a/src/tck/src/TckServer.cc
+++ b/src/tck/src/TckServer.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Windows build requires this to be included first for some reason.
+// Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers reached transitively from this header.
 #include <Transaction.h> // NOLINT
 
 #include "TckServer.h"


### PR DESCRIPTION
**Description**:

Improve Windows-specific include-ordering comments by replacing vague explanations with clear descriptions of the underlying macro-collision issue caused by `<windows.h>`.

* Update comments in AccountId.cc
* Update comments in FeeEstimateQuery.cc
* Update comments in BaseNode.h
* Update comments in TckServer.cc
* Clarify why protobuf headers must be included before headers that may pull in `<windows.h>`

**Related issue(s)**:

Fixes #1632

**Notes for reviewer**:

This PR only updates code comments and does not introduce any functional or behavioral changes. The new comments explain the known Windows macro-collision issue (`GetMessage`, `SendMessage`, etc.) that can interfere with protobuf-generated code and justify the include-ordering workaround.

**Checklist**

* [x] Documented (Code comments, README, etc.)
* [ ] Tested (unit, integration, etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comments across multiple files to clarify Windows build include-order requirements, preventing macro collisions with generated protobuf code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->