### PR TITLE
docs: improve Windows include-order comments

### DIFF
--- a/src/sdk/main/include/impl/BaseNode.h
+++ b/src/sdk/main/include/impl/BaseNode.h
@@ -2,7 +2,7 @@
 #ifndef HIERO_SDK_CPP_IMPL_BASE_NODE_H_
 #define HIERO_SDK_CPP_IMPL_BASE_NODE_H_
 
-#include <services/basic_types.pb.h> // This is needed for Windows to build for some reason.
+#include <services/basic_types.pb.h> // Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers in the generated protobuf code.
 
 #include "BaseNodeAddress.h"
 #include "Defaults.h"

--- a/src/sdk/main/src/AccountId.cc
+++ b/src/sdk/main/src/AccountId.cc
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Windows build requires this to be included first for some reason.
+// Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers
+// in the generated protobuf code.
 #include <services/basic_types.pb.h> // NOLINT
 
 #include "AccountId.h"

--- a/src/sdk/main/src/FeeEstimateQuery.cc
+++ b/src/sdk/main/src/FeeEstimateQuery.cc
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Windows build requires this to be included first for some reason.
+// Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers
+// in the generated protobuf code.
 #include <services/basic_types.pb.h> // NOLINT
 
 #include "Client.h"

--- a/src/tck/src/TckServer.cc
+++ b/src/tck/src/TckServer.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Windows build requires this to be included first for some reason.
+// Must be included before any header that pulls in <windows.h>, whose macros (e.g. GetMessage) collide with identifiers reached transitively from this header.
 #include <Transaction.h> // NOLINT
 
 #include "TckServer.h"


### PR DESCRIPTION
Fixes #1632

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified build and include-order notes for Windows-related headers.
  * Improved guidance to help avoid macro collisions from system headers during compilation.
  * No functional behavior or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->