### PR TITLE
chore: Moved orphaned doxygen block back to declaration

### DIFF
--- a/src/sdk/main/include/FeeComponents.h
+++ b/src/sdk/main/include/FeeComponents.h
@@ -268,6 +268,13 @@ public:
    * @return The price for data retrieved from disk.
    */
   [[nodiscard]] inline int64_t getResponseDiskByte() const { return mResponseDiskByte; }
+
+  /**
+   * Compare two FeeComponents instances and determine if they represent an equivalent set of fees.
+   *
+   * @param rhs The right-hand side FeeComponents to compare.
+   * @return \c TRUE if this FeeComponents and \p rhs represent equivalent fee component values, otherwise \c FALSE.
+   */
   [[nodiscard]] bool operator==(const FeeComponents& rhs) const;
 
 private:
@@ -325,13 +332,6 @@ private:
    * The price of bandwidth for data retrieved from disk for a response, measured in bytes.
    */
   int64_t mResponseDiskByte = 0LL;
-
-  /**
-   * Compare two FeeComponents instances and determine if they represent an equivalent set of fees.
-   *
-   * @param rhs The right-hand side FeeComponents to compare.
-   * @return \c TRUE if this FeeComponents and \p rhs represent equivalent fee component values, otherwise \c FALSE.
-   */
 };
 
 } // namespace Hiero


### PR DESCRIPTION
**Description**:
Moved orphaned doxygen block above ==operator declaration and removed the hanging doxygen block.

**Related issue(s)**:

Fixes #1613 

**Notes for reviewer**:
Image shows doxygen block now above the operator declaration
<img width="1188" height="190" alt="image" src="https://github.com/user-attachments/assets/62b2c696-f981-4201-bddf-26d2e22cc2da" />

Image shows deleted hanging doxygen block
<img width="1032" height="169" alt="image" src="https://github.com/user-attachments/assets/cd55900d-21d6-4ff3-bb24-78488628478b" />


<!-- Provide logs, performance numbers or screenshots of the new functionality -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the placement of comparison-operator documentation for clearer API reference navigation.
  * No functional behavior or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->