### PR TITLE
refactor: extract inactivity comment builders

### DIFF
--- a/.github/scripts/bot-inactivity-comments.js
+++ b/.github/scripts/bot-inactivity-comments.js
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// bot-inactivity-comments.js
+//
+// Comment builders for the inactivity bot.
+// Pure formatting functions separated from inactivity execution logic for readability.
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const { LABELS } = require('./helpers/constants');
+const WARN_MARKER           = '<!-- bot:inactivity-warning -->';
+const BLOCKED_CHECKIN_MARKER = '<!-- bot:blocked-checkin -->';
+
+// ─── Comment builders ─────────────────────────────────────────────────────────
+
+/**
+ * Builds the inactivity warning comment body.
+ * @param {string[]} assigneeLogins
+ * @param {string} itemType - 'issue' or 'PR'
+ * @returns {string}
+ */
+function buildWarningComment(assigneeLogins, itemType, warnDays, remainingDays) {
+  const mentions = assigneeLogins.length > 0
+    ? assigneeLogins.map(l => `@${l}`).join(', ')
+    : 'there';
+
+  const activityHint = itemType === 'PR'
+    ? 'To stay active, leave a comment on this PR or the linked **issue**, or push a new commit.'
+    : "If you're still on it, leave a comment to let us know!";
+
+  return [
+    WARN_MARKER,
+    `👋 Hey ${mentions}! This ${itemType} has been inactive for ${warnDays} days.`,
+    '',
+    `Are you still working on this? We will close this in ${remainingDays} days if we see no further activity.`,
+    '',
+    `${activityHint} If you'd like to step down, comment \`/unassign\`.`,
+  ].join('\n');
+}
+
+/**
+ * Builds the closure comment body.
+ * @param {string} itemType - 'issue' or 'PR'
+ * @returns {string}
+ */
+function buildClosureComment(itemType, closeDays) {
+  
+  if (itemType === 'issue') {
+    return [
+      `⏱️ This issue has been unassigned and reset to \`${LABELS.READY_FOR_DEV}\` due to ${closeDays} days of inactivity.`,
+      '',
+      "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
+    ].join('\n');
+  }
+  return [
+    `⏱️ This PR has been closed due to ${closeDays} days of inactivity.`,
+    '',
+    `It has been unassigned and reset to \`${LABELS.READY_FOR_DEV}\` so another contributor can pick it up.`,
+    '',
+    "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
+  ].join('\n');
+}
+
+/**
+ * Builds the comment posted on an issue when its linked PR was closed for inactivity.
+ * @returns {string}
+ */
+function buildLinkedPRClosedComment() {
+  return [
+    '🔗 The pull request linked to this issue was closed due to inactivity.',
+    '',
+    `This issue has been unassigned and reset to \`${LABELS.READY_FOR_DEV}\`.`,
+    '',
+    "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
+  ].join('\n');
+}
+
+/**
+ * Builds the 30-day blocked check-in comment body.
+ * @param {string[]} assigneeLogins
+ * @param {string} itemType - 'issue' or 'PR'
+ * @returns {string}
+ */
+function buildBlockedCheckinComment(assigneeLogins, itemType) {
+  const mentions = assigneeLogins.length > 0
+    ? assigneeLogins.map(l => `@${l}`).join(', ')
+    : 'there';
+
+  return [
+    BLOCKED_CHECKIN_MARKER,
+    `👋 Hey ${mentions}, just checking in! Is this ${itemType} still blocked?`,
+    '',
+    `If it has been unblocked, please remove the \`${LABELS.BLOCKED}\` label so we can track progress.`,
+  ].join('\n');
+}
+
+module.exports = {
+    WARN_MARKER,
+    BLOCKED_CHECKIN_MARKER,
+    buildWarningComment,
+    buildClosureComment,
+    buildLinkedPRClosedComment,
+    buildBlockedCheckinComment,
+};

--- a/.github/scripts/bot-inactivity.js
+++ b/.github/scripts/bot-inactivity.js
@@ -41,15 +41,22 @@ const {
   closeItem,
 } = require('./helpers/api');
 const { parseIssueNumbers } = require('./helpers/checks');
+const {
+    WARN_MARKER,
+    BLOCKED_CHECKIN_MARKER,
+    buildWarningComment,
+    buildClosureComment,
+    buildLinkedPRClosedComment,
+    buildBlockedCheckinComment,
+} = require('./bot-inactivity-comments');
 
 // ─── Constants ───────────────────────────────────────────────────────────────
+
 
 const WARN_AFTER_MS           = 5 * 24 * 60 * 60 * 1000;  // 5 days
 const CLOSE_AFTER_MS          = 7 * 24 * 60 * 60 * 1000;  // 7 days
 const BLOCKED_CHECKIN_AFTER_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
-const WARN_MARKER           = '<!-- bot:inactivity-warning -->';
-const BLOCKED_CHECKIN_MARKER = '<!-- bot:blocked-checkin -->';
 
 // ─── Context builder ─────────────────────────────────────────────────────────
 
@@ -300,93 +307,6 @@ async function computeIssueLastActivity(github, owner, repo, issue, linkedOpenPR
   return latest;
 }
 
-// ─── Comment builders ─────────────────────────────────────────────────────────
-
-/**
- * Builds the inactivity warning comment body.
- * @param {string[]} assigneeLogins
- * @param {string} itemType - 'issue' or 'PR'
- * @returns {string}
- */
-function buildWarningComment(assigneeLogins, itemType) {
-  const mentions = assigneeLogins.length > 0
-    ? assigneeLogins.map(l => `@${l}`).join(', ')
-    : 'there';
-
-  const activityHint = itemType === 'PR'
-    ? 'To stay active, leave a comment on this PR or the linked **issue**, or push a new commit.'
-    : "If you're still on it, leave a comment to let us know!";
-
-  const warnDays = WARN_AFTER_MS / (24 * 60 * 60 * 1000);
-  const remainingDays = (CLOSE_AFTER_MS - WARN_AFTER_MS) / (24 * 60 * 60 * 1000);
-
-  return [
-    WARN_MARKER,
-    `👋 Hey ${mentions}! This ${itemType} has been inactive for ${warnDays} days.`,
-    '',
-    `Are you still working on this? We will close this in ${remainingDays} days if we see no further activity.`,
-    '',
-    `${activityHint} If you'd like to step down, comment \`/unassign\`.`,
-  ].join('\n');
-}
-
-/**
- * Builds the closure comment body.
- * @param {string} itemType - 'issue' or 'PR'
- * @returns {string}
- */
-function buildClosureComment(itemType) {
-  const closeDays = CLOSE_AFTER_MS / (24 * 60 * 60 * 1000);
-
-  if (itemType === 'issue') {
-    return [
-      `⏱️ This issue has been unassigned and reset to \`${LABELS.READY_FOR_DEV}\` due to ${closeDays} days of inactivity.`,
-      '',
-      "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
-    ].join('\n');
-  }
-  return [
-    `⏱️ This PR has been closed due to ${closeDays} days of inactivity.`,
-    '',
-    `It has been unassigned and reset to \`${LABELS.READY_FOR_DEV}\` so another contributor can pick it up.`,
-    '',
-    "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
-  ].join('\n');
-}
-
-/**
- * Builds the comment posted on an issue when its linked PR was closed for inactivity.
- * @returns {string}
- */
-function buildLinkedPRClosedComment() {
-  return [
-    '🔗 The pull request linked to this issue was closed due to inactivity.',
-    '',
-    `This issue has been unassigned and reset to \`${LABELS.READY_FOR_DEV}\`.`,
-    '',
-    "If you'd like to continue working on this, feel free to comment `/assign` to be reassigned.",
-  ].join('\n');
-}
-
-/**
- * Builds the 30-day blocked check-in comment body.
- * @param {string[]} assigneeLogins
- * @param {string} itemType - 'issue' or 'PR'
- * @returns {string}
- */
-function buildBlockedCheckinComment(assigneeLogins, itemType) {
-  const mentions = assigneeLogins.length > 0
-    ? assigneeLogins.map(l => `@${l}`).join(', ')
-    : 'there';
-
-  return [
-    BLOCKED_CHECKIN_MARKER,
-    `👋 Hey ${mentions}, just checking in! Is this ${itemType} still blocked?`,
-    '',
-    `If it has been unblocked, please remove the \`${LABELS.BLOCKED}\` label so we can track progress.`,
-  ].join('\n');
-}
-
 // ─── State mutation ───────────────────────────────────────────────────────────
 
 /**
@@ -463,18 +383,21 @@ async function handleStaleItem(github, owner, repo, item, lastActivityMs, itemTy
   const ctx = buildCtx(github, owner, repo, item.number);
   const elapsed = nowMs - lastActivityMs;
   const assigneeLogins = (item.assignees || []).map(a => a.login);
+  const warnDays = WARN_AFTER_MS / (24 * 60 * 60 * 1000);
+  const remainingDays = (CLOSE_AFTER_MS - WARN_AFTER_MS) / (24 * 60 * 60 * 1000);
+  const closeDays = CLOSE_AFTER_MS / (24 * 60 * 60 * 1000);
 
   if (elapsed >= CLOSE_AFTER_MS) {
     if (itemType === 'PR') {
       await closeItem(ctx);
     }
     await resetItem(github, owner, repo, item, { addReadyForDev: itemType !== 'PR' });
-    await postComment(ctx, buildClosureComment(itemType));
+    await postComment(ctx, buildClosureComment(itemType, closeDays));
     return 'closed';
   }
 
   if (elapsed >= WARN_AFTER_MS) {
-    await postOrUpdateComment(ctx, WARN_MARKER, buildWarningComment(assigneeLogins, itemType));
+    await postOrUpdateComment(ctx, WARN_MARKER, buildWarningComment(assigneeLogins, itemType, warnDays, remainingDays));
     return 'warned';
   }
 


### PR DESCRIPTION
## Linked Issue

- Fixes #1598 

## Changes

- Extracted inactivity comment builders into a new module:
  - `buildWarningComment`
  - `buildClosureComment`
  - `buildLinkedPRClosedComment`
  - `buildBlockedCheckinComment`

- Moved related HTML markers:
  - `WARN_MARKER`
  - `BLOCKED_CHECKIN_MARKER`

- Added `bot-inactivity-comments.js` to separate comment formatting from inactivity execution logic.

- Updated `bot-inactivity.js`:
  - Imported the extracted builders and markers using `require()`
  - Updated `buildWarningComment()` and `buildClosureComment()` calls to pass duration values as parameters
  - Kept `WARN_AFTER_MS`, `CLOSE_AFTER_MS`, and `BLOCKED_CHECKIN_AFTER_MS` as the single source of truth

- Added `module.exports` for the extracted builders and markers.

## Testing

- ✅ `node tests/test-inactivity-bot.js`
  - All existing inactivity bot tests pass.

- ✅ `npx eslint . --ext .js`
  - No linting issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency of automated inactivity warnings, closure notices, linked pull-request updates, and blocked check-in messages.
  - Notifications now reliably include relevant assignees, item details, and timing information.

- **Refactor**
  - Standardized automated comment formatting across inactivity-related workflows without changing existing warning, update, or closure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->