### PR TITLE
chore: update solo version to 0.65.1

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -198,7 +198,7 @@ jobs:
         id: solo
         uses: hiero-ledger/hiero-solo-action@328bc84c3b00a990a151418144fd682a4eb76ea6 # v0.19.0
         with:
-          soloVersion: v0.65.0
+          soloVersion: v0.65.1
           installMirrorNode: true
           mirrorNodeVersion: v0.153.0
           hieroVersion: v0.73.0


### PR DESCRIPTION
## Summary
- Bumps the pinned Solo CLI version used in CI (`hiero-solo-action` `soloVersion` input) from `v0.65.0` to `v0.65.1` in `zxc-build-library.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Linux build environment to a newer Solo version, improving build reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->