### PR TITLE
refactor: update EVM address handling to use std::optional for PublicKey

### DIFF
--- a/src/sdk/examples/AutoCreateAccountTransferTransactionExample.cpp
+++ b/src/sdk/examples/AutoCreateAccountTransferTransactionExample.cpp
@@ -33,9 +33,9 @@
 #include "AccountId.h"
 #include "Client.h"
 #include "ECDSAsecp256k1PrivateKey.h"
-#include "ECDSAsecp256k1PublicKey.h"
 #include "EvmAddress.h"
 #include "Hbar.h"
+#include "PublicKey.h"
 #include "TransactionReceipt.h"
 #include "TransactionReceiptQuery.h"
 #include "TransactionResponse.h"
@@ -69,13 +69,12 @@ int main(int argc, char** argv)
   /**
    * Step 2: Extract the ECDSA public key.
    */
-  const std::shared_ptr<ECDSAsecp256k1PublicKey> publicKey =
-    std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(privateKey->getPublicKey());
+  const std::shared_ptr<PublicKey> publicKey = privateKey->getPublicKey();
 
   /**
    * Step 3: Extract the Ethereum public address.
    */
-  const EvmAddress evmAddress = publicKey->toEvmAddress();
+  const EvmAddress evmAddress = publicKey->toEvmAddress().value();
 
   /**
    * Step 4: Use the `TransferTransaction` and set the EVM address field to the Ethereum public address

--- a/src/sdk/examples/TransferUsingEvmAddressExample.cpp
+++ b/src/sdk/examples/TransferUsingEvmAddressExample.cpp
@@ -5,9 +5,9 @@
 #include "AccountInfoQuery.h"
 #include "Client.h"
 #include "ECDSAsecp256k1PrivateKey.h"
-#include "ECDSAsecp256k1PublicKey.h"
 #include "EvmAddress.h"
 #include "Hbar.h"
+#include "PublicKey.h"
 #include "TransactionReceipt.h"
 #include "TransactionReceiptQuery.h"
 #include "TransactionResponse.h"
@@ -61,13 +61,12 @@ int main(int argc, char** argv)
   /*
    * Step 2: Extract the ECDSAsecp256k1PublicKey.
    */
-  const std::shared_ptr<ECDSAsecp256k1PublicKey> publicKey =
-    std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(privateKey->getPublicKey());
+  const std::shared_ptr<PublicKey> publicKey = privateKey->getPublicKey();
 
   /*
    * Step 3: Extract the Ethereum public address.
    */
-  const EvmAddress evmAddress = publicKey->toEvmAddress();
+  const EvmAddress evmAddress = publicKey->toEvmAddress().value();
   std::cout << "Corresponding EVM address: " << evmAddress.toString() << std::endl;
 
   /*

--- a/src/sdk/main/include/ECDSAsecp256k1PublicKey.h
+++ b/src/sdk/main/include/ECDSAsecp256k1PublicKey.h
@@ -5,6 +5,7 @@
 #include "PublicKey.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -183,7 +184,8 @@ public:
    * Construct an EvmAddress from this ECDSAsecp256k1PublicKey. The constructed EvmAddress will be the last 20 bytes of
    * the keccak-256 hash of this ECDSAsecp256k1PublicKey.
    *
-   * @return The constructed EvmAddress.
+   * @return The constructed EvmAddress. Unlike PublicKey::toEvmAddress(), this override always returns an engaged
+   *         optional, so callers holding an ECDSAsecp256k1PublicKey can dereference it without checking.
    */
   [[nodiscard]] std::optional<EvmAddress> toEvmAddress() const override;
 

--- a/src/sdk/main/include/ECDSAsecp256k1PublicKey.h
+++ b/src/sdk/main/include/ECDSAsecp256k1PublicKey.h
@@ -185,7 +185,7 @@ public:
    *
    * @return The constructed EvmAddress.
    */
-  [[nodiscard]] EvmAddress toEvmAddress() const;
+  [[nodiscard]] std::optional<EvmAddress> toEvmAddress() const override;
 
 private:
   /**

--- a/src/sdk/main/include/PublicKey.h
+++ b/src/sdk/main/include/PublicKey.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <string_view>
@@ -25,6 +26,7 @@ class EVP_PKEY;
 }
 
 class AccountId;
+class EvmAddress;
 }
 
 namespace Hiero
@@ -136,6 +138,14 @@ public:
    * @return The constructed AccountId.
    */
   [[nodiscard]] AccountId toAccountId(uint64_t shard = 0ULL, uint64_t realm = 0ULL) const;
+
+  /**
+   * Get the EVM address derived from this PublicKey.
+   *
+   * @return The EvmAddress derived from this PublicKey, or std::nullopt if this key is not an
+   *         ECDSAsecp256k1PublicKey.
+   */
+  [[nodiscard]] virtual std::optional<EvmAddress> toEvmAddress() const;
 
   /**
    * Write this PublicKey in DER-encoded hex to an output stream.

--- a/src/sdk/main/src/ECDSAsecp256k1PublicKey.cc
+++ b/src/sdk/main/src/ECDSAsecp256k1PublicKey.cc
@@ -401,7 +401,7 @@ std::unique_ptr<proto::SignaturePair> ECDSAsecp256k1PublicKey::toSignaturePairPr
 }
 
 //-----
-EvmAddress ECDSAsecp256k1PublicKey::toEvmAddress() const
+std::optional<EvmAddress> ECDSAsecp256k1PublicKey::toEvmAddress() const
 {
   // Generate hash without "0x04" prefix of uncompressed bytes.
   return EvmAddress::fromBytes(internal::Utilities::removePrefix(

--- a/src/sdk/main/src/PublicKey.cc
+++ b/src/sdk/main/src/PublicKey.cc
@@ -3,6 +3,7 @@
 #include "AccountId.h"
 #include "ECDSAsecp256k1PublicKey.h"
 #include "ED25519PublicKey.h"
+#include "EvmAddress.h"
 #include "exceptions/BadKeyException.h"
 #include "impl/HexConverter.h"
 #include "impl/PublicKeyImpl.h"
@@ -84,6 +85,12 @@ std::unique_ptr<PublicKey> PublicKey::fromAliasBytes(const std::vector<std::byte
 AccountId PublicKey::toAccountId(uint64_t shard, uint64_t realm) const
 {
   return AccountId(shard, realm, getShared());
+}
+
+//-----
+std::optional<EvmAddress> PublicKey::toEvmAddress() const
+{
+  return std::nullopt;
 }
 
 //-----

--- a/src/sdk/tests/integration/AccountCreateTransactionIntegrationTests.cc
+++ b/src/sdk/tests/integration/AccountCreateTransactionIntegrationTests.cc
@@ -91,7 +91,7 @@ TEST_F(AccountCreateTransactionIntegrationTests, ExecuteAccountCreateTransaction
   const std::shared_ptr<ECDSAsecp256k1PrivateKey> testPrivateKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
   const std::shared_ptr<ECDSAsecp256k1PublicKey> testPublicKey =
     std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(testPrivateKey->getPublicKey());
-  const EvmAddress testEvmAddress = testPublicKey->toEvmAddress();
+  const EvmAddress testEvmAddress = testPublicKey->toEvmAddress().value();
   const Hbar testInitialBalance(1000LL, HbarUnit::TINYBAR());
   const std::chrono::system_clock::duration testAutoRenewPeriod = std::chrono::seconds(2592000);
   const std::string testMemo = "test account memo";
@@ -238,7 +238,7 @@ TEST_F(AccountCreateTransactionIntegrationTests, AliasFromAdminKey)
   const std::shared_ptr<ECDSAsecp256k1PrivateKey> adminPrivateKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
   const std::shared_ptr<ECDSAsecp256k1PublicKey> adminPublicKey =
     std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(adminPrivateKey->getPublicKey());
-  const EvmAddress evmAddress = adminPublicKey->toEvmAddress();
+  const EvmAddress evmAddress = adminPublicKey->toEvmAddress().value();
 
   AccountId adminAccountId;
   ASSERT_NO_THROW(adminAccountId = AccountCreateTransaction()
@@ -284,7 +284,7 @@ TEST_F(AccountCreateTransactionIntegrationTests, AliasFromAdminKeyWithReceiverSi
   const std::shared_ptr<ECDSAsecp256k1PrivateKey> adminKeyPrivateKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
   const std::shared_ptr<ECDSAsecp256k1PublicKey> adminKeyPublicKey =
     std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(adminKeyPrivateKey->getPublicKey());
-  const EvmAddress evmAddress = adminKeyPublicKey->toEvmAddress();
+  const EvmAddress evmAddress = adminKeyPublicKey->toEvmAddress().value();
 
   AccountId adminAccountId;
   ASSERT_NO_THROW(adminAccountId = AccountCreateTransaction()
@@ -335,7 +335,7 @@ TEST_F(AccountCreateTransactionIntegrationTests, CannotCreateAliasFromAdminKeyWi
   const std::shared_ptr<ECDSAsecp256k1PrivateKey> adminKeyPrivateKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
   const std::shared_ptr<ECDSAsecp256k1PublicKey> adminKeyPublicKey =
     std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(adminKeyPrivateKey->getPublicKey());
-  const EvmAddress evmAddress = adminKeyPublicKey->toEvmAddress();
+  const EvmAddress evmAddress = adminKeyPublicKey->toEvmAddress().value();
 
   AccountId adminAccountId;
   ASSERT_NO_THROW(adminAccountId = AccountCreateTransaction()
@@ -375,8 +375,7 @@ TEST_F(AccountCreateTransactionIntegrationTests, AliasDifferentFromAdminKeyWithR
                                      .mAccountId.value());
 
   const std::shared_ptr<ECDSAsecp256k1PrivateKey> aliasPrivateKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
-  const EvmAddress alias =
-    std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(aliasPrivateKey->getPublicKey())->toEvmAddress();
+  const EvmAddress alias = aliasPrivateKey->getPublicKey()->toEvmAddress().value();
 
   // When
   TransactionResponse txResponse;
@@ -428,8 +427,7 @@ TEST_F(AccountCreateTransactionIntegrationTests,
                                      .mAccountId.value());
 
   const std::shared_ptr<ECDSAsecp256k1PrivateKey> aliasPrivateKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
-  const EvmAddress alias =
-    std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(aliasPrivateKey->getPublicKey())->toEvmAddress();
+  const EvmAddress alias = aliasPrivateKey->getPublicKey()->toEvmAddress().value();
 
   // When
   EXPECT_THROW(const TransactionReceipt txReceipt = AccountCreateTransaction()
@@ -559,7 +557,7 @@ TEST_F(AccountCreateTransactionIntegrationTests, FreezeSignSerializeDeserializeA
   const std::shared_ptr<ECDSAsecp256k1PrivateKey> testPrivateKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
   const std::shared_ptr<ECDSAsecp256k1PublicKey> testPublicKey =
     std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(testPrivateKey->getPublicKey());
-  const EvmAddress testEvmAddress = testPublicKey->toEvmAddress();
+  const EvmAddress testEvmAddress = testPublicKey->toEvmAddress().value();
   const Hbar testInitialBalance(1000LL, HbarUnit::TINYBAR());
   const std::chrono::system_clock::duration testAutoRenewPeriod = std::chrono::seconds(2592000);
   const std::string testMemo = "test account memo";
@@ -647,9 +645,7 @@ TEST_F(AccountCreateTransactionIntegrationTests, CreateTransactionWithAliasCanEx
   // Given
   const std::shared_ptr<PrivateKey> edPrivateKey = ED25519PrivateKey::generatePrivateKey();
   const std::shared_ptr<ECDSAsecp256k1PrivateKey> ecdsaPrivateKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
-  const std::shared_ptr<ECDSAsecp256k1PublicKey> ecdsaPublicKey =
-    std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(ecdsaPrivateKey->getPublicKey());
-  const EvmAddress expectedEvmAddress = ecdsaPublicKey->toEvmAddress();
+  const EvmAddress expectedEvmAddress = ecdsaPrivateKey->getPublicKey()->toEvmAddress().value();
   const Hbar testInitialBalance(1000LL, HbarUnit::TINYBAR());
 
   // When / Then

--- a/src/sdk/tests/integration/TransferTransactionIntegrationTests.cc
+++ b/src/sdk/tests/integration/TransferTransactionIntegrationTests.cc
@@ -9,9 +9,9 @@
 #include "AccountInfoQuery.h"
 #include "BaseIntegrationTest.h"
 #include "ECDSAsecp256k1PrivateKey.h"
-#include "ECDSAsecp256k1PublicKey.h"
 #include "ED25519PrivateKey.h"
 #include "Hbar.h"
+#include "PublicKey.h"
 #include "TokenAssociateTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TokenMintTransaction.h"
@@ -101,8 +101,7 @@ TEST_F(TransferTransactionIntegrationTests, CanTransferHbarWithAliasID)
   // Given
   const std::shared_ptr<PrivateKey> privateKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
   const Hbar amount(1LL);
-  const EvmAddress evmAddress =
-    std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(privateKey->getPublicKey())->toEvmAddress();
+  const EvmAddress evmAddress = privateKey->getPublicKey()->toEvmAddress().value();
   const AccountId aliasId(evmAddress);
 
   // When

--- a/src/sdk/tests/unit/AccountCreateTransactionUnitTests.cc
+++ b/src/sdk/tests/unit/AccountCreateTransactionUnitTests.cc
@@ -3,7 +3,6 @@
 #include "Client.h"
 #include "Defaults.h"
 #include "ECDSAsecp256k1PrivateKey.h"
-#include "ECDSAsecp256k1PublicKey.h"
 #include "ED25519PrivateKey.h"
 #include "Hbar.h"
 #include "PublicKey.h"
@@ -139,9 +138,7 @@ TEST_F(AccountCreateTransactionUnitTests, SetKeyWithAlias)
 {
   // Given
   AccountCreateTransaction transaction;
-  const std::shared_ptr<ECDSAsecp256k1PublicKey> ecdsaPublicKey =
-    std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(getTestPrivateKeyECDSA()->getPublicKey());
-  EvmAddress expectedEvmAddress = ecdsaPublicKey->toEvmAddress();
+  const EvmAddress expectedEvmAddress = getTestPrivateKeyECDSA()->getPublicKey()->toEvmAddress().value();
 
   // When
   EXPECT_NO_THROW(transaction.setKeyWithAlias(getTestPublicKey(), getTestPrivateKeyECDSA()));

--- a/src/sdk/tests/unit/ECDSAsecp256k1PublicKeyUnitTests.cc
+++ b/src/sdk/tests/unit/ECDSAsecp256k1PublicKeyUnitTests.cc
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 #include <memory>
+#include <optional>
 #include <services/basic_types.pb.h>
 #include <string>
 #include <string_view>
@@ -412,10 +413,28 @@ TEST_F(ECDSAsecp256k1PublicKeyUnitTests, ToEvmAddress)
   const auto publicKey = std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(privateKey->getPublicKey());
 
   // When
-  const EvmAddress evmAddress = publicKey->toEvmAddress();
+  const EvmAddress evmAddress = publicKey->toEvmAddress().value();
 
   // Then
   EXPECT_EQ(evmAddress.toString(), "D8EB8DB03C699FAA3F47ADCDCD2AE91773B10F8B");
+}
+
+//-----
+TEST_F(ECDSAsecp256k1PublicKeyUnitTests, ToEvmAddressThroughBaseClass)
+{
+  // Given
+  const std::shared_ptr<ECDSAsecp256k1PublicKey> ecdsaPublicKey =
+    ECDSAsecp256k1PublicKey::fromBytes(getTestUncompressedPublicKeyBytes());
+  const std::shared_ptr<PublicKey> publicKey = ecdsaPublicKey;
+
+  // When
+  const std::optional<EvmAddress> evmAddress = publicKey->toEvmAddress();
+  const std::optional<EvmAddress> expectedEvmAddress = ecdsaPublicKey->toEvmAddress();
+
+  // Then
+  ASSERT_TRUE(evmAddress.has_value());
+  ASSERT_TRUE(expectedEvmAddress.has_value());
+  EXPECT_EQ(evmAddress->toString(), expectedEvmAddress->toString());
 }
 
 //-----

--- a/src/sdk/tests/unit/ED25519PublicKeyUnitTests.cc
+++ b/src/sdk/tests/unit/ED25519PublicKeyUnitTests.cc
@@ -2,6 +2,7 @@
 #include "ECDSAsecp256k1PublicKey.h"
 #include "ED25519PrivateKey.h"
 #include "ED25519PublicKey.h"
+#include "EvmAddress.h"
 #include "exceptions/BadKeyException.h"
 #include "impl/Utilities.h"
 
@@ -215,6 +216,16 @@ TEST_F(ED25519PublicKeyUnitTests, ToBytes)
   // Then
   EXPECT_EQ(bytesDer, concatenateVectors({ ED25519PublicKey::DER_ENCODED_PREFIX_BYTES, getTestPublicKeyBytes() }));
   EXPECT_EQ(bytesRaw, getTestPublicKeyBytes());
+}
+
+//-----
+TEST_F(ED25519PublicKeyUnitTests, ToEvmAddressThroughBaseClass)
+{
+  // Given
+  const std::shared_ptr<PublicKey> publicKey = ED25519PublicKey::fromBytes(getTestPublicKeyBytes());
+
+  // When / Then
+  EXPECT_FALSE(publicKey->toEvmAddress().has_value());
 }
 
 //-----

--- a/src/tck/src/key/KeyService.cc
+++ b/src/tck/src/key/KeyService.cc
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
 #include <nlohmann/json.hpp>
 
 #include <ECDSAsecp256k1PrivateKey.h>
-#include <ECDSAsecp256k1PublicKey.h>
 #include <ED25519PrivateKey.h>
 #include <EvmAddress.h>
 #include <Key.h>
@@ -139,26 +139,24 @@ std::string generateKeyRecursively(const GenerateKeyParams& params, nlohmann::js
               std::dynamic_pointer_cast<ECDSAsecp256k1PrivateKey>(key);
             privateKey)
         {
-          return std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(privateKey->getPublicKey())
-            ->toEvmAddress()
-            .toString();
+          return privateKey->getPublicKey()->toEvmAddress()->toString();
         }
 
-        if (const std::shared_ptr<ECDSAsecp256k1PublicKey> publicKey =
-              std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(key);
-            publicKey)
+        // PublicKey::toEvmAddress() yields std::nullopt for every key type but ECDSAsecp256k1, so the "not
+        // ECDSAsecp256k1" case is the disengaged optional rather than a failed downcast.
+        if (const std::shared_ptr<PublicKey> publicKey = std::dynamic_pointer_cast<PublicKey>(key); publicKey)
         {
-          return publicKey->toEvmAddress().toString();
+          if (const std::optional<EvmAddress> evmAddress = publicKey->toEvmAddress(); evmAddress.has_value())
+          {
+            return evmAddress->toString();
+          }
         }
 
         throw JsonRpcException(JsonErrorType::INVALID_PARAMS,
                                "invalid parameters: fromKey for evmAddress is not ECDSAsecp256k1.");
       }
 
-      return std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(
-               ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey())
-        ->toEvmAddress()
-        .toString();
+      return ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey()->toEvmAddress()->toString();
     }
 
     default:


### PR DESCRIPTION
## Description
 
`toEvmAddress()` was declared only on the concrete subclass `ECDSAsecp256k1PublicKey`, so any
code holding a generic `std::shared_ptr<PublicKey>` which is what `PrivateKey::getPublicKey()`
returns  had to `std::dynamic_pointer_cast` before it could derive an EVM address.
 
This PR adds `toEvmAddress()` as a virtual method on the `PublicKey` base class returning
`std::optional<EvmAddress>`, with a default implementation returning `std::nullopt`.
`ECDSAsecp256k1PublicKey` overrides it with the existing Keccak-256 derivation, unchanged.
 
This aligns the C++ SDK with its siblings: the JS SDK returns `undefined` and the Go SDK
returns `""` for non-ECDSA keys.
 
## Changes
 
**SDK (`src/sdk/main`)**
 
- `include/PublicKey.h` added `#include <optional>`, forward-declared `class EvmAddress;`
  alongside `class AccountId;`, and declared
  `[[nodiscard]] virtual std::optional<EvmAddress> toEvmAddress() const;` next to `toAccountId`.
  `EvmAddress` stays a forward declaration here; the definition lives in the `.cc`.
- `src/PublicKey.cc` added `#include "EvmAddress.h"` and the default implementation
  (`return std::nullopt;`).
- `include/ECDSAsecp256k1PublicKey.h` / `src/ECDSAsecp256k1PublicKey.cc` return type changed to
  `std::optional<EvmAddress>` and the declaration marked `override`. The method body is untouched;
  the returned `EvmAddress` converts implicitly to `std::optional<EvmAddress>`.
- `src/AccountCreateTransaction.cc` **no change needed**. `mAlias` is already
  `std::optional<EvmAddress>`, so both assignments compile as-is.
**TCK (`src/tck`)**
 
- `src/key/KeyService.cc` the `EVM_ADDRESS_KEY_TYPE` branch no longer needs
  `std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>`. The public-key path now calls
  `PublicKey::toEvmAddress()` directly and treats `std::nullopt` as the "not ECDSAsecp256k1"
  error case, throwing the same `JsonRpcException` with the same message as before.
  Externally observable behavior is unchanged.
**Tests**
 
- Mechanical `.value()` additions at the typed call sites in
  `ECDSAsecp256k1PublicKeyUnitTests.cc`, `AccountCreateTransactionUnitTests.cc`,
  `AccountCreateTransactionIntegrationTests.cc`, and `TransferTransactionIntegrationTests.cc`.
- Dropped the now-redundant `std::dynamic_pointer_cast` at
  `AccountCreateTransactionIntegrationTests.cc` (two sites) and
  `TransferTransactionIntegrationTests.cc` (one site).
- **New:** `ED25519PublicKeyUnitTests.ToEvmAddressReturnsNulloptThroughBasePointer` calling
  `toEvmAddress()` on an ED25519 key through a `std::shared_ptr<PublicKey>` returns `std::nullopt`.
- **New:** `ECDSAsecp256k1PublicKeyUnitTests.ToEvmAddressThroughBasePointer` calling
  `toEvmAddress()` through a base-class `std::shared_ptr<PublicKey>` returns an engaged optional
  equal to the address returned by the typed subclass call.
## Compatibility note
 
Adding the base-class virtual with a default implementation is **backward compatible** for code
holding `PublicKey*` / `std::shared_ptr<PublicKey>`.
 
However, the return type of the existing `ECDSAsecp256k1PublicKey::toEvmAddress()` changes from
`EvmAddress` to `std::optional<EvmAddress>` C++ does not permit non-covariant return-type
overloading, so the subclass signature has to match the base. Downstream code calling
`toEvmAddress()` on a typed `ECDSAsecp256k1PublicKey` needs a trivial migration:
 
```cpp
// Before
const EvmAddress addr = ecdsaPublicKey->toEvmAddress();
const std::string s   = ecdsaPublicKey->toEvmAddress().toString();
 
// After
const EvmAddress addr = ecdsaPublicKey->toEvmAddress().value();
const std::string s   = ecdsaPublicKey->toEvmAddress()->toString();
```
 
All in-repo call sites are updated in this PR.
 
## Testing
 
```
cmake --preset linux-x64-debug -DBUILD_TESTS=ON
cmake --build --preset linux-x64-debug -j 6
ctest -C Debug --test-dir build/linux-x64-debug \
  -R "ECDSAsecp256k1PublicKeyUnitTests|ED25519PublicKeyUnitTests|AccountCreateTransactionUnitTests"
```
 
The integration-test edits are compile-only fixes; CI exercises them against Solo.
`clang-format-17` was run against every touched file.
 
## Checklist
 
- [x] Changes limited to the files listed in the issue
- [x] `PublicKey::toEvmAddress()` returns `std::nullopt` for ED25519, the Keccak-256-derived
      address for ECDSAsecp256k1; no other behavior changes
- [x] Subclass return-type change and its migration called out above
- [x] New unit tests cover both the `std::nullopt` and engaged paths through a base-class pointer

Fixes #1675
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Added a common EVM address conversion interface for public keys.
  * EVM address conversion now clearly indicates when an address is unavailable.
  * ECDSA public keys continue to support EVM address derivation through the shared interface.
  * Unsupported public key types no longer produce invalid EVM addresses.

* **Bug Fixes**
  * Updated account creation, transfers, and examples for consistent public-key handling and EVM address conversion.
  * Improved validation of EVM address behavior across supported and unsupported key types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->